### PR TITLE
Add the generated family footer

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -195,3 +195,13 @@ Caty Agent Harness は、Caty AI プロジェクト **Family OS** — 複数の 
 **ただのテキストファイル** ｜ **5つの AI ツールで動く** ｜ **コマンド1つで一時停止・再開**
 
 </div>
+
+<!-- family:generated:family-footer:start -->
+
+---
+
+このリポジトリは **Caty AI ファミリー** の一員です — AI エージェントの家族を運用するためのオープンなツール群。公開準備中のモジュールを含む全体の地図は [Family OS](https://github.com/caty-ai/family-os) にあります。
+
+兄弟モジュール: [Persona Engine](https://github.com/caty-ai/persona-engine) · [Sitter](https://github.com/caty-ai/sitter) · [X Collector](https://github.com/caty-ai/x-collector) · [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook)
+
+<!-- family:generated:family-footer:end -->

--- a/README.md
+++ b/README.md
@@ -195,3 +195,13 @@ Caty Agent Harness is one tool inside **Family OS** — the Caty AI project's la
 **plain text files** ｜ **works with 5 AI tools** ｜ **paused in one command**
 
 </div>
+
+<!-- family:generated:family-footer:start -->
+
+---
+
+Part of the **Caty AI family** — open tools for running a family of AI agents. The full map, including modules still being prepared for release, lives in [Family OS](https://github.com/caty-ai/family-os).
+
+Siblings: [Persona Engine](https://github.com/caty-ai/persona-engine) · [Sitter](https://github.com/caty-ai/sitter) · [X Collector](https://github.com/caty-ai/x-collector) · [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook)
+
+<!-- family:generated:family-footer:end -->

--- a/README.th.md
+++ b/README.th.md
@@ -195,3 +195,13 @@ Caty Agent Harness เป็นเครื่องมือหนึ่งใ�
 **ไฟล์ข้อความธรรมดา** ｜ **ใช้ได้กับเครื่องมือ AI 5 ตัว** ｜ **คำสั่งเดียวหยุด/ทำต่อได้**
 
 </div>
+
+<!-- family:generated:family-footer:start -->
+
+---
+
+รีโพนี้เป็นส่วนหนึ่งของ **ครอบครัว Caty AI** — ชุดเครื่องมือโอเพนซอร์สสำหรับดูแลครอบครัวเอเจนต์ AI แผนที่ฉบับเต็ม (รวมโมดูลที่กำลังเตรียมเปิด) อยู่ที่ [Family OS](https://github.com/caty-ai/family-os)
+
+โมดูลพี่น้อง: [Persona Engine](https://github.com/caty-ai/persona-engine) · [Sitter](https://github.com/caty-ai/sitter) · [X Collector](https://github.com/caty-ai/x-collector) · [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook)
+
+<!-- family:generated:family-footer:end -->

--- a/README.zh.md
+++ b/README.zh.md
@@ -194,3 +194,13 @@ Caty Agent Harness 是 Caty AI 项目 **Family OS**——把多个 AI agent 当�
 **纯文本文件** ｜ **支持 5 种 AI 工具** ｜ **一条命令即可暂停与恢复**
 
 </div>
+
+<!-- family:generated:family-footer:start -->
+
+---
+
+本仓库属于 **Caty AI 家族** — 用于运营 AI 智能体家族的开源工具集。完整地图（包括仍在准备公开的模块）见 [Family OS](https://github.com/caty-ai/family-os)。
+
+同家族模块: [Persona Engine](https://github.com/caty-ai/persona-engine) · [Sitter](https://github.com/caty-ai/sitter) · [X Collector](https://github.com/caty-ai/x-collector) · [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook)
+
+<!-- family:generated:family-footer:end -->


### PR DESCRIPTION
Mechanical rollout child of caty-ai/family-os#5 (design frozen after three independent review rounds; generator and checks landed in caty-ai/family-os#6).

Adds the generated family footer to all four README language files: one line saying this repository is part of the Caty AI family with a link to the map, plus links to the published sibling modules. Preparing modules are deliberately not linked here — the map owns that list, so this footer never ships an intentional 404.

The region between the markers is machine-maintained and verified byte-exact by family-os's weekly check once the registry flag flips (the epic's final child). To change the footer, edit `registry/modules.json` in family-os and re-render — not this file.

Generated output; no hand-written content beyond this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
