### PR TITLE
docs: purge private-era statements and unreachable references (#15)

### DIFF
--- a/DESIGN-task-runner.md
+++ b/DESIGN-task-runner.md
@@ -1,5 +1,7 @@
 # task-runner v0.2 — Completion Driver for Weak-Model Agents (Issue #8)
 
+> Historical design record. Issue numbers cited in this document (e.g. #43, #49) refer to the pre-publication private tracker, not to issues in this repository.
+
 Status: v0.2 — cross-review resolutions TR-R1…TR-R15 (SYNTHESIS-task-runner.md) applied.
 Amended 2026-07-18: §8 cross-cutting contracts (grok-build study, #43 → #49).
 Author: Alpha (Claude Fable 5), 2026-07-04.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,5 +1,7 @@
 # fable-loop v0.2 — Minimal Self-Improving Loop Harness for OpenClaw & Hermes Agent
 
+> Historical design record. Issue numbers cited in this document (e.g. #43, #49) refer to the pre-publication private tracker, not to issues in this repository.
+
 Status: v0.2 — cross-review resolutions R1–R15 (SYNTHESIS.md) applied.
 Amended 2026-07-18: §10 cross-cutting contracts (grok-build study, #43 → #49).
 Amended 2026-07-24: P1 implementation roll-up (#74–#84) and related CHECKPOINT

--- a/adapters/claude-code/INSTALL.md
+++ b/adapters/claude-code/INSTALL.md
@@ -108,7 +108,8 @@ both `manual` and `auto` compaction):
 
 On macOS, crontab sessions cannot reach the user Keychain, so `claude -p` exits 1
 with `Not logged in · Please run /login` under cron while the same command succeeds
-interactively and under launchd (observed in the Phase-1 pilot, #43, 2026-07-19).
+interactively and under launchd. The Phase-1 pilot on 2026-07-19 therefore adopted
+LaunchAgent scheduling for Claude CLI jobs on macOS.
 This is specific to the claude CLI's credential lookup; other targets may run fine
 under cron. The rule: any tick wrapper or spawn adapter that shells out to the
 claude CLI MUST be scheduled as a LaunchAgent in the `gui/<uid>` domain with
@@ -130,10 +131,10 @@ launchctl bootout gui/501/<label>    # to stop/remove
 ## Host hook isolation for headless spawn sessions
 
 Headless `claude -p` sessions inherit the user-level hooks in
-`~/.claude/settings.json`. In the Phase-1 pilot (#43, 2026-07-19), a host
-PreToolUse hook on the operator's machine blocked the weak agent's writes under
-`loop/artifacts/`; the weak model burned a full 381 s attempt negotiating with the
-hook before failing. This is a silent, host-specific failure mode: the harness
+`~/.claude/settings.json`. The Phase-1 pilot on 2026-07-19 established the need to
+isolate operator-level hooks after a host PreToolUse hook blocked the weak agent's
+writes under `loop/artifacts/`; the weak model burned a full 381 s attempt
+negotiating with the hook before failing. This is a silent, host-specific failure mode: the harness
 looks broken while the actual cause lives in the operator's personal settings.
 
 Contract for claude-code spawn adapters:

--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -6,10 +6,13 @@ Run them from a shell where the profile can write its own workspace and bootstra
 The [shared adapter runtime contract](../CONTRACT.md) is normative for this adapter.
 The rules there apply in addition to the Hermes-specific wiring below.
 
-1. Clone this private repository into a stable local path.
+1. Clone the public repository into a stable local path.
 
-   Access is by repo invite or deploy key. Do not copy adapter files by hand if the
-   profile can clone; keeping a clone makes updates auditable.
+   ```sh
+   git clone https://github.com/caty-ai/caty-agent-harness.git
+   ```
+
+   Keep the clone so updates remain auditable; do not copy adapter files by hand.
 
 2. Initialize the profile workspace.
 

--- a/adapters/openclaw/INSTALL.md
+++ b/adapters/openclaw/INSTALL.md
@@ -7,10 +7,13 @@ AGENTS.md, and cron entry.
 The [shared adapter runtime contract](../CONTRACT.md) is normative for this adapter.
 The rules there apply in addition to the OpenClaw-specific wiring below.
 
-1. Clone this private repository into a stable local path.
+1. Clone the public repository into a stable local path.
 
-   Access is by repo invite or deploy key. Do not copy adapter files by hand if the
-   profile can clone; keeping a clone makes updates auditable.
+   ```sh
+   git clone https://github.com/caty-ai/caty-agent-harness.git
+   ```
+
+   Keep the clone so updates remain auditable; do not copy adapter files by hand.
 
 2. Initialize the profile workspace.
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -26,7 +26,7 @@ bash --version          # 3.2+ is fine (macOS default works)
 command -v python3      # needed for hooks and automated paths
 ```
 
-If `python3` is missing, you can still complete steps 1–4; say so in your report and point the human at their platform's Python 3 install. If the repository URL is not reachable, the most likely causes are missing access to this private repo or a network problem — stop and tell the human which error you saw.
+If `python3` is missing, you can still complete steps 1–4; say so in your report and point the human at their platform's Python 3 install. This repository is public at <https://github.com/caty-ai/caty-agent-harness>, so no invitation is needed. If the repository URL is not reachable, stop and tell the human which error you saw.
 
 <a id="step-1--identify-your-runtime"></a>
 
@@ -53,8 +53,6 @@ cd ..    # only if you are currently inside the workspace
 git clone https://github.com/caty-ai/caty-agent-harness.git
 cd caty-agent-harness
 ```
-
-> The public home will be `caty-ai/caty-agent-harness`; until that exists, the URL above is correct.
 
 ## Step 3 — install into the workspace
 
@@ -123,7 +121,6 @@ I'll remember where we were.
 | --- | --- | --- |
 | `append target must be an absolute path with an existing real parent: …` (exit 2) | The instruction-file path wasn't absolute, or the target/its parent is a symlink, or the parent folder doesn't exist | Re-run Step 3 with an absolute `$WORKSPACE` path |
 | `skip: bootstrap already present` | The block is already installed (idempotency marker `# caty-agent-harness bootstrap v2`) | Nothing — this is success |
-| Clone fails with auth error | Repo is private and this account isn't invited | Tell the human; they need access before you can proceed |
 | `--check` exit 1 | Required layout or safety invariant broken | Read the message; usually re-running Step 3 repairs missing scaffold |
 | Want to stop the harness | — | `./install.sh --disable --workspace "$WORKSPACE"` (reversible; `--enable` resumes; state is preserved) |
 

--- a/docs/governance-rules.md
+++ b/docs/governance-rules.md
@@ -1,5 +1,7 @@
 # Family Adoption Governance Rules (R1–R14)
 
+> Historical design record. Issue numbers and commit references cited in this document refer to the pre-publication private trackers and working repositories, not to issues or commits in this repository.
+
 > **Canonical file** for the family adoption governance R-series (R1–R14).
 > Initial version transcribed from the binding text of
 > fable-loop-harness#26 (private tracker)

--- a/docs/updater-rollout.md
+++ b/docs/updater-rollout.md
@@ -1,6 +1,6 @@
 # Task Packet — family-updater rollout
 
-> Historical design record. Issue numbers cited in this document refer to the pre-publication private tracker, not to issues in this repository.
+> Historical design record. Issue numbers cited in this document refer to the pre-publication private trackers, not to issues in this repository.
 
 From: Alpha · SoT: fable-loop-harness Issue #36
 For: Claude Code, OpenClaw, and Hermes family agents

--- a/docs/updater-rollout.md
+++ b/docs/updater-rollout.md
@@ -1,5 +1,7 @@
 # Task Packet — family-updater rollout
 
+> Historical design record. Issue numbers cited in this document refer to the pre-publication private tracker, not to issues in this repository.
+
 From: Alpha · SoT: fable-loop-harness Issue #36
 For: Claude Code, OpenClaw, and Hermes family agents
 
@@ -106,32 +108,11 @@ the same harness fixes without being first to absorb release risk.
 - [ ] The local ledger records real updates and failures; no-op
       already-current runs do not add a line.
 
-## Verified deployments — actual paths (as of 2026-07-14, fable-loop #40)
+## Deployment inventory example
 
-The packet templates above use illustrative paths. These are the paths that were
-actually verified working at install time — trust this table over the templates,
-and always confirm the live workspace path on the host before installing.
+The live deployment inventory is maintained privately by the operator. Use this
+minimal placeholder pattern and confirm every value on the target host before installing.
 
 | Agent | Host | Trigger | Deploy clone | Credential |
 | --- | --- | --- | --- | --- |
-| Claire (canary) | VPS | cron `:17` | `/path/to/clones/caty-agent-harness` | read-only deploy key |
-| Alpha | MBP | launchd `com.alpha.fable-loop.updater` `:12` | `~/claude-workspace/systems/caty-agent-harness-stable` | `alpha-mbp-updater-ro` |
-| Cero | VPS | cron `:22` | `/path/to/hermes-home/.hermes/profiles/cero/systems/caty-agent-harness-stable` | `cero-vps-updater-ro` |
-| Mine | VPS | cron `:27` | `/path/to/openclaw-home/.openclaw/workspace/systems/caty-agent-harness-stable` | `mine-vps-updater-ro` |
-| Caty | mac-mini | launchd `com.caty.fable-loop.updater` `:22` | `~/systems/caty-agent-harness-stable` | mini's existing read ssh key |
-
-Install learnings folded back from the rollout:
-
-- Claire's real workspace is `/path/to/openclaw-home/.openclaw/workspace-claire`, not the
-  packet's `/path/to/claire-home/.openclaw-claire/workspace` (see the correction note in
-  the Claire section).
-- On macOS hosts (Alpha MBP, Caty mini) launchd is the source of truth, not
-  crontab — register a `com.<agent>.fable-loop.updater` plist instead of a cron
-  line.
-- VPS agents share one heartbeat dir (`/path/to/hermes-home/.hermes/profiles/cero/state/heartbeats`);
-  the fma watchdog reads a single dir per host and resolves entries by filename,
-  so per-agent heartbeat dirs are not required.
-- Caty on the mini needed `FMA_SCRIPTS_DIR=~/.openclaw/bin/fma`; an existing
-  host key with read access makes a dedicated deploy key unnecessary.
-- Register the fma `jobs.yaml` entry only after the real heartbeat file exists
-  (fma #77 lesson): alpha=#85, caty=#103, cero/mine=#105.
+| `<agent>` | `<host>` | `<cron-or-launchd schedule>` | `/path/to/caty-agent-harness` | `<host>-updater-ro` |


### PR DESCRIPTION
Closes #15 (child of epic #14 — serial slice 1 of 4; order #15 → #16 → #18 → #17 per the [design-review record](https://github.com/caty-ai/caty-agent-harness/issues/14#issuecomment-5231258463)).

The repository is public, but several docs still told readers it is private, cited private-tracker issues they cannot open, or published internal deployment inventory. This PR:

- **docs/agent-guide.md** — states the repo is public (no invitation needed); deletes the obsolete "public home will be…" note (it contradicted the URL right above it) and the unverifiable private-repo troubleshooting row (deleted, not re-guessed — per the evidence gate). The first-run line at :114 is untouched (#17 territory).
- **adapters/hermes/INSTALL.md, adapters/openclaw/INSTALL.md** — "Clone this private repository / invite or deploy key" → normal public HTTPS clone.
- **adapters/claude-code/INSTALL.md** — both private-tracker `#43` citations replaced with self-contained explanations (LaunchAgent scheduling decision; host-hook isolation rationale).
- **DESIGN.md, DESIGN-task-runner.md, docs/governance-rules.md, docs/updater-rollout.md** — historical-record notice under the H1; inline issue history preserved as labeled history (not silently rewritten).
- **docs/updater-rollout.md** — ⚠️ owner attention: the real deployment inventory (deploy-key names `alpha-mbp-updater-ro` etc., launchd labels, personal paths, host-specific rollout notes) is replaced with one generic example row + "live inventory is maintained privately by the operator". Deliberate redaction per the design-review adopted scope.

Allow-listed (true statements kept, per design review): `docs/engineering.md:173,230,231,238` + `.ja` twins (private *sibling systems* and the true private-working-repo release model — not claims that this repo is private); `docs/updater-rollout.md:19,61,91` (generic read-only-credential guidance).

Declared-but-unchanged files (from the WIP declaration): `docs/plugin-convention.md` (old-name token only — #16 territory), `docs/engineering.md/.ja`, `docs/reference.md/.ja` (allow-listed or #18 territory). Declared-file set ⊇ diff set; nothing in the diff is undeclared (L0-6).

## 完了記録 (Completion record)

candidate SHA: 00f9be67d2a48e38a2086494df88975657efc405
implementer: Codex (gpt-5.6-sol, profile sol) — brief: 3-layer, session scratchpad `lane-15/brief.md`
orchestrator / final inspector: Alpha (claude-fable-5) — not counted as a review seat
reviewers: Kimi K3 + GLM 5.2 (loom-seats, size M — records will follow as PR comments)
identity check: 別モデル (writer GPT-5.6 Sol ≠ reviewers Kimi K3 / GLM 5.2 ≠ orchestrator Fable 5)

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| No public doc claims the repo is private or forthcoming | PASS | orchestrator sweep 2026-08-09: `grep -rniE "private (repo\|repository)\|invitation\|invite\|deploy key" docs/ adapters/ DESIGN*.md` → 6 hits, all allow-listed true statements or historical-labeled records (list above) |
| Troubleshooting matches the public flow | PASS | unverifiable private-invite row deleted; public statement cites the live repo URL (agent-guide.md:29) |
| Private-issue citations replaced with self-contained explanations | PASS | `grep -rn "#43" adapters/claude-code/INSTALL.md` → 0 hits (2026-08-09); design records carry the historical notice instead |
| テスト / lint green | PASS | orchestrator run 2026-08-09: `for t in tests/*.test.sh; do bash "$t" \|\| echo "FAIL $t"; done` → 0 FAIL lines across all 20 suites (implementer's own run: final suite tail `Summary: 41 PASS, 0 FAIL`) |
| Frozen identifiers untouched | PASS | `git diff \| grep -cE "^\-.*(fable-loop (bootstrap\|cron wrapper template\|sentinel notice) v1\|fable-wrapper-conformance/v1\|FABLE_)"` → 0 removals (2026-08-09) |

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...00f9be6: 8 files changed, 31 insertions(+), 40 deletions(-) — DESIGN-task-runner.md, DESIGN.md, adapters/{claude-code,hermes,openclaw}/INSTALL.md, docs/{agent-guide,governance-rules,updater-rollout}.md
宣言ファイル集合との差分: なし（宣言13ファイル中8変更・5は宣言済み未変更）

Merge: local merge + push by the owner (no API merge — public-repo identity policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
