### PR TITLE
rename: fable-loop -> Caty Agent Harness in user-facing surfaces (#16)

### DIFF
--- a/adapters/claude-code/INSTALL.md
+++ b/adapters/claude-code/INSTALL.md
@@ -36,13 +36,14 @@ instruction-driven and therefore softer than the shell guards.
 
 ## checkpoint-stop-hook.sh (Stop hook)
 
-What it does: when the assistant ends a turn in a cwd that contains a fable-loop
-`STATE.md` and workspace files changed after `STATE.md` was last written, it blocks
-ONCE per session (exit 2) with a reminder to update `## Last session`. Silent in
-every other case: no STATE.md, nothing changed, already nagged this session,
-stop-hook-forced continuation, or any environment problem (a guard hook must never
-crash the hook chain). Its reminder also demands a delta-only, unverified flush
-append when there are genuinely new durable observations.
+What it does: when the assistant ends a turn in a cwd for a Caty Agent Harness
+workspace that contains `STATE.md` and workspace files changed after `STATE.md`
+was last written, it blocks ONCE per session (exit 2) with a reminder to update
+`## Last session`. Silent in every other case: no STATE.md, nothing changed,
+already nagged this session, stop-hook-forced continuation, or any environment
+problem (a guard hook must never crash the hook chain). Its reminder also
+demands a delta-only, unverified flush append when there are genuinely new
+durable observations.
 
 Known accepted false positive: `git checkout`/`rebase` rewrites tree mtimes and can
 trigger one spurious nag; the message allows the assistant to decline explicitly.
@@ -68,13 +69,14 @@ Point at your repo clone — `git pull` then updates the hook with no re-registr
 ## precompact-flush-hook.sh (PreCompact hook)
 
 What it does: before Claude Code compacts a context window, this hook makes one
-governed, headless capture attempt per session. It supplies the current `## Lessons
-learned`, `## Open failures`, and today's flush file as already captured context, so
-the model extracts delta-only candidates into `loop/pending/`. Every attempted write
-has a synthetic-origin stamp and is classified as `ok`, `no_reply`, `degenerate`,
-`timeout`, or `error`; bullets are appended only for `ok`. It never self-promotes
-these unverified candidates into `STATE.md`, and its outside-workspace guard prevents
-more than one attempt per session.
+governed, headless capture attempt per session. It supplies the current
+`## Lessons learned`, `## Open failures`, and today's flush file as already
+captured context, so the model extracts delta-only candidates into
+`loop/pending/`. Every attempted write has a synthetic-origin stamp and is
+classified as `ok`, `no_reply`, `degenerate`, `timeout`, or `error`; bullets
+are appended only for `ok`. It never self-promotes these unverified candidates
+into `STATE.md`, and its outside-workspace guard prevents more than one attempt
+per session.
 
 Known accepted bounded re-arm: the per-session guard file is cleaned up after
 about two days, so a session that runs longer can flush once more after the guard

--- a/adapters/claude-code/checkpoint-stop-hook.sh
+++ b/adapters/claude-code/checkpoint-stop-hook.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# fable-loop CHECKPOINT enforcement — Claude Code Stop hook (DESIGN §4.1, Issue #7).
-# Fires when the assistant ends a turn in a workspace that has a fable-loop STATE.md
+# Caty Agent Harness CHECKPOINT enforcement — Claude Code Stop hook (DESIGN §4.1, Issue #7).
+# Fires when the assistant ends a turn in a Caty Agent Harness workspace that has STATE.md
 # and files changed after STATE.md was last written: blocks once per session with a
 # reminder to CHECKPOINT. Exits 0 (silent) in every other case.
 # Known accepted false positive (GLM review 2026-07-04): git checkout/rebase rewrites
@@ -49,7 +49,7 @@ state_file="$cwd/STATE.md"
 
 # Nudge at most once per session (state kept outside the workspace). If we cannot
 # record the guard we must not block at all — a nag on every turn is worse than none.
-guard_dir="${TMPDIR:-/tmp}/fable-loop-hook"
+guard_dir="${TMPDIR:-/tmp}/caty-agent-harness-hook"
 mkdir -p "$guard_dir" 2>/dev/null || exit 0
 find "$guard_dir" -name 'nagged-*' -mtime +2 -delete 2>/dev/null || true
 [[ -n "$session_id" ]] || session_id="cwd-$(printf '%s' "$cwd" | cksum | cut -d' ' -f1)"
@@ -71,7 +71,7 @@ flush_stamp_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 stamp_sid=$(printf '%s' "$session_id" | tr -cd 'A-Za-z0-9._-')
 [[ -n "$stamp_sid" ]] || stamp_sid="cwd-$(printf '%s' "$cwd" | cksum | cut -d' ' -f1)"
 cat >&2 <<EOF
-fable-loop CHECKPOINT: workspace files changed after STATE.md was last written (e.g. ${newer#"$cwd"/}).
+caty-agent-harness CHECKPOINT: workspace files changed after STATE.md was last written (e.g. ${newer#"$cwd"/}).
 Before ending the session, update '## Last session' in STATE.md (task id / next action / blockers / last verified artifact path) and fold any new observations into the right sections. If this turn genuinely produced nothing checkpoint-worthy, state that explicitly and continue — this reminder fires at most once per session.
 
 Also append only genuinely NEW, delta-only observations to '$flush_file': first read '## Lessons learned' and '## Open failures' in STATE.md and today's flush file (if any) as already captured. If appending, prefix the block with '<!-- flush origin=stop-hook-demand session=$stamp_sid ts=$flush_stamp_ts outcome=ok unverified=true -->'. NO_REPLY is legal: if nothing new exists, say so explicitly instead of writing. Flush entries are unverified candidates; never fold them directly into '## Lessons learned' or '## Open failures' — normal distill gates apply later at intake. Do not capture transient environment failures or negative absolute tool claims; if a retry fixed it, capture the fix. Violation-shaped items go only to dated Open failures entries.

--- a/adapters/claude-code/precompact-flush-hook.sh
+++ b/adapters/claude-code/precompact-flush-hook.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# fable-loop pre-destruction memory flush — Claude Code PreCompact hook (Issue #47).
+# Caty Agent Harness pre-destruction memory flush — Claude Code PreCompact hook (Issue #47).
 # Captures only new, unverified candidates before compaction; it never blocks compaction.
 set -euo pipefail
 trap 'exit 0' ERR
@@ -94,7 +94,7 @@ cwd=$(caty_pause_canonical_workspace "$cwd" 2>/dev/null) || exit 0
 state_file="$cwd/STATE.md"
 [[ -f "$state_file" ]] || exit 0
 
-guard_dir="${TMPDIR:-/tmp}/fable-loop-hook"
+guard_dir="${TMPDIR:-/tmp}/caty-agent-harness-hook"
 mkdir -p "$guard_dir" 2>/dev/null || exit 0
 find "$guard_dir" -name 'flushed-*' -mtime +2 -delete 2>/dev/null || true
 [[ -n "$session_id" ]] || session_id="cwd-$(printf '%s' "$cwd" | cksum | cut -d' ' -f1)"
@@ -141,7 +141,7 @@ cleanup() {
 trap cleanup EXIT
 
 cat >"$prompt_tmp" <<EOF
-You are a memory-flush extractor for a fable-loop workspace about to lose its context window. Below is (1) what is ALREADY captured — do not restate any of it — and (2) the recent session transcript. Extract only NEW durable observations (lessons, open failures, decisions with reasons, verified facts). Output either exactly NO_REPLY (if nothing new) or markdown bullets (- ...), one observation per bullet, each self-contained with concrete referents (paths/ids), no headers, no prose around them.
+You are a memory-flush extractor for a Caty Agent Harness workspace about to lose its context window. Below is (1) what is ALREADY captured — do not restate any of it — and (2) the recent session transcript. Extract only NEW durable observations (lessons, open failures, decisions with reasons, verified facts). Output either exactly NO_REPLY (if nothing new) or markdown bullets (- ...), one observation per bullet, each self-contained with concrete referents (paths/ids), no headers, no prose around them.
 Current UTC date: $today
 Do not save transient environment failures or negative absolute tool claims; if a retry fixed it, save the fix. Such items go only to dated Open failures entries.
 

--- a/adapters/codex/INSTALL.md
+++ b/adapters/codex/INSTALL.md
@@ -1,20 +1,21 @@
 # Codex CLI Adapter Install
 
-Codex CLI supports the same lifecycle hooks as Claude Code, so fable-loop CHECKPOINT
-enforcement reuses the reference Stop-hook logic (DESIGN §4.1) with no cron watchdog —
-the `Stop` event fires the reminder mechanically. This adapter targets a "relief
-Alpha" running on Codex while the Claude Code Alpha is down (see the relief operating
-charter at `~/claude-workspace/AGENTS.md`).
+Codex CLI supports the same lifecycle hooks as Claude Code, so Caty Agent
+Harness CHECKPOINT enforcement reuses the reference Stop-hook logic
+(DESIGN §4.1) with no cron watchdog — the `Stop` event fires the reminder
+mechanically. This adapter targets a "relief Alpha" running on Codex while the
+Claude Code Alpha is down (see the relief operating charter at
+`~/claude-workspace/AGENTS.md`).
 
 ## checkpoint-stop-hook.sh (Stop hook)
 
-What it does: when the agent ends a turn in a cwd that contains a fable-loop
-`STATE.md` and workspace files changed after `STATE.md` was last written, it asks ONCE
-per session to update `## Last session`, and demands a delta-only, unverified flush
-append when there are genuinely new observations. Silent in every other case: no
-STATE.md, nothing changed, already asked this session, a Stop-forced continuation
-(`stop_hook_active`), or any environment problem (a guard hook must never crash the
-hook chain).
+What it does: when the agent ends a turn in a cwd for a Caty Agent Harness
+workspace that contains `STATE.md` and workspace files changed after `STATE.md`
+was last written, it asks ONCE per session to update `## Last session`, and
+demands a delta-only, unverified flush append when there are genuinely new
+observations. Silent in every other case: no STATE.md, nothing changed,
+already asked this session, a Stop-forced continuation (`stop_hook_active`),
+or any environment problem (a guard hook must never crash the hook chain).
 
 Codex block contract: the hook prints `{"decision":"block","reason":"..."}` on stdout
 and exits 0. Codex turns the `reason` into an automatic continuation prompt, so the

--- a/adapters/codex/checkpoint-stop-hook.sh
+++ b/adapters/codex/checkpoint-stop-hook.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# fable-loop CHECKPOINT enforcement — Codex CLI Stop hook (DESIGN §4.1, Issue #93).
-# Fires when the agent ends a turn in a workspace that has a fable-loop STATE.md
+# Caty Agent Harness CHECKPOINT enforcement — Codex CLI Stop hook (DESIGN §4.1, Issue #93).
+# Fires when the agent ends a turn in a Caty Agent Harness workspace that has STATE.md
 # and files changed after STATE.md was last written: asks once per session to
 # CHECKPOINT. Exits 0 silently in every other case.
 #
@@ -65,7 +65,7 @@ state_file="$cwd/STATE.md"
 
 # Ask at most once per session (state kept outside the workspace). If we cannot
 # record the guard we must not block at all — an ask on every turn is worse than none.
-guard_dir="${TMPDIR:-/tmp}/fable-loop-hook"
+guard_dir="${TMPDIR:-/tmp}/caty-agent-harness-hook"
 mkdir -p "$guard_dir" 2>/dev/null || exit 0
 find "$guard_dir" -name 'nagged-*' -mtime +2 -delete 2>/dev/null || true
 [[ -n "$session_id" ]] || session_id="cwd-$(printf '%s' "$cwd" | cksum | cut -d' ' -f1)"
@@ -87,7 +87,7 @@ stamp_sid=$session_id
 
 reason_tmp=$(mktemp "$guard_dir/flh-codex-reason.XXXXXX") || exit 0
 cat >"$reason_tmp" <<EOF || { rm -f "$reason_tmp"; exit 0; }
-fable-loop CHECKPOINT: workspace files changed after STATE.md was last written (e.g. ${newer#"$cwd"/}).
+caty-agent-harness CHECKPOINT: workspace files changed after STATE.md was last written (e.g. ${newer#"$cwd"/}).
 Before ending the session, update '## Last session' in STATE.md (task id / next action / blockers / last verified artifact path) and fold any new observations into the right sections. If this turn genuinely produced nothing checkpoint-worthy, state that explicitly and continue — this reminder fires at most once per session.
 
 Also append only genuinely NEW, delta-only observations to '$flush_file': first read '## Lessons learned' and '## Open failures' in STATE.md and today's flush file (if any) as already captured. If appending, prefix the block with '<!-- flush origin=stop-hook-demand session=$stamp_sid ts=$flush_stamp_ts outcome=ok unverified=true -->'. NO_REPLY is legal: if nothing new exists, say so explicitly instead of writing. Flush entries are unverified candidates; never fold them directly into '## Lessons learned' or '## Open failures' — normal distill gates apply later at intake. Do not capture transient environment failures or negative absolute tool claims; if a retry fixed it, capture the fix. Violation-shaped items go only to dated Open failures entries.

--- a/adapters/kimi/INSTALL.md
+++ b/adapters/kimi/INSTALL.md
@@ -1,16 +1,18 @@
 # Kimi Code CLI Adapter Install
 
-Kimi Code CLI exposes lifecycle hooks including a blockable `Stop` event, so fable-loop
-CHECKPOINT enforcement reuses the reference Stop-hook logic (DESIGN §4.1) with no cron
-watchdog. This adapter targets a "relief Alpha" running on Kimi while the Claude Code
-Alpha is down (see the relief operating charter at `~/claude-workspace/AGENTS.md`).
+Kimi Code CLI exposes lifecycle hooks including a blockable `Stop` event, so
+Caty Agent Harness CHECKPOINT enforcement reuses the reference Stop-hook logic
+(DESIGN §4.1) with no cron watchdog. This adapter targets a "relief Alpha"
+running on Kimi while the Claude Code Alpha is down (see the relief operating
+charter at `~/claude-workspace/AGENTS.md`).
 
 ## checkpoint-stop-hook.sh (Stop hook)
 
-What it does: identical policy to the Claude Code reference — when the model is about to
-end a turn in a cwd with a fable-loop `STATE.md` and workspace files changed after
-`STATE.md` was last written, it asks ONCE per session to update `## Last session` and
-demands a delta-only, unverified flush append for genuinely new observations. Silent in
+What it does: identical policy to the Claude Code reference — when the model
+is about to end a turn in a cwd for a Caty Agent Harness workspace that
+contains `STATE.md` and workspace files changed after `STATE.md` was last
+written, it asks ONCE per session to update `## Last session` and demands a
+delta-only, unverified flush append for genuinely new observations. Silent in
 every other case, and it never crashes the hook chain.
 
 Kimi block contract: the `Stop` event is blockable, so the hook exits 2 with the

--- a/adapters/kimi/checkpoint-stop-hook.sh
+++ b/adapters/kimi/checkpoint-stop-hook.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# fable-loop CHECKPOINT enforcement — Kimi Code CLI Stop hook (DESIGN §4.1, Issue #93).
-# Fires when the model is about to end a turn in a workspace that has a fable-loop
+# Caty Agent Harness CHECKPOINT enforcement — Kimi Code CLI Stop hook (DESIGN §4.1, Issue #93).
+# Fires when the model is about to end a turn in a Caty Agent Harness workspace that has
 # STATE.md and files changed after STATE.md was last written: asks once per session
 # to CHECKPOINT. Exits 0 silently in every other case.
 #
@@ -67,7 +67,7 @@ state_file="$cwd/STATE.md"
 
 # Ask at most once per session (state kept outside the workspace). If we cannot
 # record the guard we must not block at all — an ask on every turn is worse than none.
-guard_dir="${TMPDIR:-/tmp}/fable-loop-hook"
+guard_dir="${TMPDIR:-/tmp}/caty-agent-harness-hook"
 mkdir -p "$guard_dir" 2>/dev/null || exit 0
 find "$guard_dir" -name 'nagged-*' -mtime +2 -delete 2>/dev/null || true
 [[ -n "$session_id" ]] || session_id="cwd-$(printf '%s' "$cwd" | cksum | cut -d' ' -f1)"
@@ -88,7 +88,7 @@ flush_stamp_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 stamp_sid=$session_id
 touch "$guard" 2>/dev/null || exit 0
 cat >&2 <<EOF
-fable-loop CHECKPOINT: workspace files changed after STATE.md was last written (e.g. ${newer#"$cwd"/}).
+caty-agent-harness CHECKPOINT: workspace files changed after STATE.md was last written (e.g. ${newer#"$cwd"/}).
 Before ending the session, update '## Last session' in STATE.md (task id / next action / blockers / last verified artifact path) and fold any new observations into the right sections. If this turn genuinely produced nothing checkpoint-worthy, state that explicitly and continue — this reminder fires at most once per session.
 
 Also append only genuinely NEW, delta-only observations to '$flush_file': first read '## Lessons learned' and '## Open failures' in STATE.md and today's flush file (if any) as already captured. If appending, prefix the block with '<!-- flush origin=stop-hook-demand session=$stamp_sid ts=$flush_stamp_ts outcome=ok unverified=true -->'. NO_REPLY is legal: if nothing new exists, say so explicitly instead of writing. Flush entries are unverified candidates; never fold them directly into '## Lessons learned' or '## Open failures' — normal distill gates apply later at intake. Do not capture transient environment failures or negative absolute tool claims; if a retry fixed it, capture the fix. Violation-shaped items go only to dated Open failures entries.

--- a/docs/plugin-convention.md
+++ b/docs/plugin-convention.md
@@ -1,6 +1,6 @@
 # Plugin Convention v0 (2026-07-20)
 
-fable-loop-harness is a **generic completion engine**: cron tick → one fresh-context
+Caty Agent Harness is a **generic completion engine**: cron tick → one fresh-context
 step per tick → executable donecheck gate → budget/DLQ/escalation. Everything
 domain-specific (what the tasks *do*) lives outside the engine.
 

--- a/templates/cron-wrapper.tmpl.sh
+++ b/templates/cron-wrapper.tmpl.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 export PATH
 
-TARGET=${TARGET:-/absolute/path/to/fable-loop-target}
+TARGET=${TARGET:-/absolute/path/to/caty-agent-harness-target}
 CATY_HARNESS_ROOT=${CATY_HARNESS_ROOT:-}
 CATY_WORKSPACE=${CATY_WORKSPACE:-}
 SECRETS_ENV=${SECRETS_ENV:-}

--- a/templates/launchd.tmpl.plist
+++ b/templates/launchd.tmpl.plist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
-  fable-loop LaunchAgent template v1
+  Caty Agent Harness LaunchAgent template v1
 
   macOS scheduling for any tick that shells out to the claude CLI. crontab
   sessions cannot reach the user Keychain, so `claude -p` fails there with
@@ -30,7 +30,7 @@
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>com.example.fable-loop-tick</string>
+  <string>com.example.caty-agent-harness-tick</string>
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
@@ -39,7 +39,7 @@
   <key>EnvironmentVariables</key>
   <dict>
     <key>TARGET</key>
-    <string>/absolute/path/to/fable-loop-target</string>
+    <string>/absolute/path/to/caty-agent-harness-target</string>
     <key>DEADMAN_MARKER</key>
     <string>/absolute/path/to/workspace/loop/.deadman/tick-marker</string>
   </dict>

--- a/templates/updater-cron.tmpl.sh
+++ b/templates/updater-cron.tmpl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# fable-loop updater cron wrapper template v1
+# Caty Agent Harness updater cron wrapper template v1
 #
 # Copy this file next to a checked-out harness clone, set REPO_DIR to the
 # absolute clone path, and run it from cron. It validates wrapper-level
@@ -15,7 +15,7 @@ fail() {
   exit 3
 }
 
-REPO_DIR=${REPO_DIR:-/absolute/path/to/fable-loop-harness}
+REPO_DIR=${REPO_DIR:-/absolute/path/to/caty-agent-harness}
 WORKSPACE=${WORKSPACE:-$PWD}
 AGENT=${AGENT:-${USER:-unknown}}
 RING=${RING:-stable}

--- a/tests/pause-contract.test.sh
+++ b/tests/pause-contract.test.sh
@@ -483,7 +483,7 @@ for runtime in claude-code kimi; do
   set -e
   assert_eq "enabled $runtime hook retains blocking exit" "2" "$hook_rc"
   assert_eq "enabled $runtime hook stdout remains empty" "" "$(cat "$TMP/enabled-hook.stdout")"
-  grep -Fq 'fable-loop CHECKPOINT' "$TMP/enabled-hook.stderr" \
+  grep -Fq 'caty-agent-harness CHECKPOINT' "$TMP/enabled-hook.stderr" \
     && pass "enabled $runtime hook keeps checkpoint reason on stderr" \
     || fail_case "enabled $runtime hook keeps checkpoint reason on stderr" "$(cat "$TMP/enabled-hook.stderr")"
 done
@@ -502,7 +502,7 @@ import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
     value = json.load(f)
 assert value["decision"] == "block"
-assert "fable-loop CHECKPOINT" in value["reason"]
+assert "caty-agent-harness CHECKPOINT" in value["reason"]
 PY
 
 # Missing or syntactically broken pause helpers must fail open for every hook.
@@ -705,7 +705,7 @@ multiworkspace_hook_rc=$?
 set -e
 assert_eq "other enabled workspace entrypoint remains active while selected workspace is paused" "2" "$multiworkspace_hook_rc"
 assert_eq "other enabled hook stdout remains empty" "" "$(cat "$TMP/multiworkspace-hook.stdout")"
-grep -Fq 'fable-loop CHECKPOINT' "$TMP/multiworkspace-hook.stderr" \
+grep -Fq 'caty-agent-harness CHECKPOINT' "$TMP/multiworkspace-hook.stderr" \
   && pass "other enabled workspace produces its normal checkpoint behavior" \
   || fail_case "other enabled workspace produces its normal checkpoint behavior" "$(cat "$TMP/multiworkspace-hook.stderr")"
 


### PR DESCRIPTION
Closes #16 (child of epic #14 — serial slice 2 of 4; #15 MERGED → **#16** → #18 → #17 per the [design-review record](https://github.com/caty-ai/caty-agent-harness/issues/14#issuecomment-5231258463)).

Finishes the user-facing rename to the public product name, per the CP1 wording [approved by the owner 2026-08-09](https://github.com/caty-ai/caty-agent-harness/issues/14#issuecomment-5231477011): product name **Caty Agent Harness**, hook message prefix **`caty-agent-harness CHECKPOINT:`**.

- **Hooks (claude-code / codex / kimi checkpoint + claude-code precompact-flush)** — stderr/JSON-reason prefix, header comments, workspace prose, and the per-session guard dir (`/tmp/fable-loop-hook` → `/tmp/caty-agent-harness-hook`; per-session temp state, upgrade-safe — documented exception: the once-per-session reminder can fire one extra time if an upgrade lands mid-session).
- **tests/pause-contract.test.sh** — the three checkpoint-prefix assertions move in the same commit (hook and test cannot drift); the four legacy `# fable-loop bootstrap v1` fixtures stay verbatim (they test the upgrade path).
- **Adapter INSTALL prose, docs/plugin-convention.md, template example values** (launchd label/path, cron/updater target paths) — renamed; new-install-only surfaces.
- **Frozen identifiers kept verbatim** (design-review binding list): `# fable-loop bootstrap v1`, `# fable-loop cron wrapper template v1` (install.sh:607/782 greps it — verified), `# fable-loop sentinel notice v1`, `fable-wrapper-conformance/v1`, `FABLE_*` env vars. Marker-detector verification for the two template markers that WERE renamed (LaunchAgent / updater-cron prose): grep over `*.sh`/`*.test.sh` → no detector references them (evidence in-lane).
- Not touched (by design): DESIGN*/SYNTHESIS*/governance-rules/updater-rollout (labeled historical records), hermes/openclaw adapters (hermes crontab example = #18), bootstrap-block.md files (already carry the new name).

## 完了記録 (Completion record)

candidate SHA: f5bd51cc63eae4738dec876b04829ddd511b5b14
implementer: Codex (gpt-5.6-sol, profile sol) — 3-layer brief, session scratchpad `lane-16/brief.md`
orchestrator / final inspector: Alpha (claude-fable-5) — not a review seat
reviewers: Kimi K3 + GLM 5.2 (loom-seats, size M — records follow as PR comments)
identity check: 別モデル (writer GPT-5.6 Sol ≠ reviewers ≠ orchestrator)

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| User-facing strings and install docs use the public name consistently | PASS | orchestrator sweep 2026-08-09: `grep -rn "fable-loop CHECKPOINT" .` → 0 hits; scoped grep over adapters/{claude-code,codex,kimi}, plugin-convention, templates → remaining "fable" = frozen markers only |
| Internal identifiers keep the old name only where renaming would break installs, exception documented | PASS | frozen list kept verbatim (0 removals in diff, orchestrator grep); guard-dir rename assessed upgrade-safe with the bounded exception documented above |
| テスト / lint green | PASS | orchestrator run 2026-08-09: 20 suites, 0 FAIL lines (implementer run: `Summary: 41 PASS, 0 FAIL`; renamed assertions passed for all three runtimes) |

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...f5bd51c: 12 files changed, 64 insertions(+), 59 deletions(-) — exactly the 12 files declared in the WIP comment on #16.
宣言ファイル集合との差分: なし

Merge: local merge + push by owner identity (owner authorized Alpha to execute, 2026-08-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
