### PR TITLE
example: generalize the bundled task and remove host-specific paths (#18)

### DIFF
--- a/adapters/codex/INSTALL.md
+++ b/adapters/codex/INSTALL.md
@@ -5,7 +5,8 @@ Harness CHECKPOINT enforcement reuses the reference Stop-hook logic
 (DESIGN §4.1) with no cron watchdog — the `Stop` event fires the reminder
 mechanically. This adapter targets a "relief Alpha" running on Codex while the
 Claude Code Alpha is down (see the relief operating charter at
-`~/claude-workspace/AGENTS.md`).
+`~/path/to/your/AGENTS.md`). Replace this placeholder with the operator's own
+agent charter file path during setup.
 
 ## checkpoint-stop-hook.sh (Stop hook)
 

--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -159,7 +159,7 @@ WATCHDOG_STALE_SECS=3600 adapters/hermes/stale-claim-watchdog.sh --workspace ~/.
 
 ## Cron wrapper pattern
 
-For cron-driven verifier, watchdog, or Luca task-runner jobs, copy
+For cron-driven verifier, watchdog, or task-runner jobs, copy
 `templates/cron-wrapper.tmpl.sh` into the profile workspace, for example
 `<workspace>/scripts/cron-wrapper.sh`, and make the copy executable. Set `TARGET` to
 the absolute adapter/script path and pass the target arguments after the wrapper.

--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -165,7 +165,7 @@ For cron-driven verifier, watchdog, or Luca task-runner jobs, copy
 the absolute adapter/script path and pass the target arguments after the wrapper.
 
 ```cron
-*/5 * * * * CATY_HARNESS_ROOT=/opt/caty-agent-harness TARGET=/opt/caty-agent-harness/scripts/task-runner.sh SECRETS_ENV=/home/luca/.config/fable-loop/cron.env /home/luca/.hermes/profiles/luca/workspace/scripts/cron-wrapper.sh /home/luca/.hermes/profiles/luca/workspace >>/home/luca/.hermes/profiles/luca/workspace/loop/task-runner-cron.log 2>&1
+*/5 * * * * CATY_HARNESS_ROOT=/opt/caty-agent-harness TARGET=/opt/caty-agent-harness/scripts/task-runner.sh SECRETS_ENV=/path/to/secrets/cron.env /path/to/hermes-home/profiles/example/workspace/scripts/cron-wrapper.sh /path/to/hermes-home/profiles/example/workspace >>/path/to/hermes-home/profiles/example/workspace/loop/task-runner-cron.log 2>&1
 ```
 
 Adapter stdout is now captured per attempt in `attempts/NNN/model.stdout` and no longer appears in the tick log.

--- a/adapters/kimi/INSTALL.md
+++ b/adapters/kimi/INSTALL.md
@@ -4,7 +4,8 @@ Kimi Code CLI exposes lifecycle hooks including a blockable `Stop` event, so
 Caty Agent Harness CHECKPOINT enforcement reuses the reference Stop-hook logic
 (DESIGN §4.1) with no cron watchdog. This adapter targets a "relief Alpha"
 running on Kimi while the Claude Code Alpha is down (see the relief operating
-charter at `~/claude-workspace/AGENTS.md`).
+charter at `~/path/to/your/AGENTS.md`). Replace this placeholder with the
+operator's own agent charter file path during setup.
 
 ## checkpoint-stop-hook.sh (Stop hook)
 

--- a/install.sh
+++ b/install.sh
@@ -794,9 +794,10 @@ probe_adapter_conformance() {
 check_learning_paths() {
   local adapter
 
-  # Capability probes are read-only and diagnostic: they inspect the adapter
-  # implementation shipped beside this installer, never execute a model or
-  # mutate the checked workspace. FAIL does not change --check exit semantics.
+  # Capability probes are read-only and diagnostic: they inspect configured
+  # adapter paths. Conformance probes read and hash configured wrapper, provider,
+  # and probe paths, including env-supplied external ones. They never execute a
+  # model or mutate the checked workspace. FAIL does not change --check semantics.
   for adapter in claude-code codex hermes kimi openclaw; do
     if [[ "$adapter" == "claude-code" ]]; then
       print_learning_path_result "$adapter" "CONSULT injection" probe_claude_consult
@@ -1064,7 +1065,7 @@ EOF
   # RELATIVE path that does not exist in this workspace but does exist in a sibling
   # directory usually means the checkpoint was written into the wrong STATE.md.
   # Absolute paths, ~ paths, and URLs are legitimate host references and are skipped
-  # (Claire's STATE.md points at that agent's own VPS home by design).
+  # (Some agents' STATE.md legitimately points at that agent's own remote home directory).
   if [[ -f "$state_file" ]]; then
     local token
     local ws_base

--- a/scripts/family-updater
+++ b/scripts/family-updater
@@ -7,7 +7,7 @@ agent=${USER:-unknown}
 ring=stable
 soak_hours=24
 dry_run=0
-fma_scripts_dir=${FMA_SCRIPTS_DIR:-"$HOME/claude-workspace/family-memory-architecture/scripts"}
+fma_scripts_dir=${FMA_SCRIPTS_DIR:-}
 lock_acquired=0
 lock_dir=
 
@@ -19,13 +19,14 @@ Usage:
                          [--fma-scripts-dir <dir>]
 
 Flags:
-  --repo-dir <path>       Local fable-loop-harness clone to update. Required.
+  --repo-dir <path>       Local caty-agent-harness clone to update. Required.
   --workspace <dir>       Workspace passed to install.sh --check.
   --agent <name>          Reporting agent name. Defaults to $USER.
   --ring canary|stable    Canary takes the newest semver tag. Stable waits for soak.
   --soak-hours N          Stable tag minimum age in hours. Defaults to 24.
   --dry-run               Print the planned update without fetching or changing files.
   --fma-scripts-dir <dir> Directory containing job-heartbeat and hot-inbox-post.
+                           When omitted, reporting is disabled with a warning.
   -h, --help              Show this help.
 USAGE
 }
@@ -164,12 +165,14 @@ append_ledger() {
 }
 
 warn_missing_reporter() {
-  printf 'warning: reporter script missing or not executable: %s\n' "$1" >&2
+  printf 'warning: reporter script missing or not executable: %s; set FMA_SCRIPTS_DIR or pass --fma-scripts-dir with the reporter directory\n' "$1" >&2
 }
 
 send_heartbeat() {
   local status=$1
   local reason=$2
+
+  [[ -n "$fma_scripts_dir" ]] || return 0
   local reporter="$fma_scripts_dir/job-heartbeat"
 
   if [[ ! -x "$reporter" ]]; then
@@ -185,6 +188,8 @@ post_failure_report() {
   local tag=$1
   local rollback=$2
   local summary=$3
+
+  [[ -n "$fma_scripts_dir" ]] || return 0
   local reporter="$fma_scripts_dir/hot-inbox-post"
   local repo_name
   local report_summary=$summary
@@ -299,6 +304,10 @@ while (($# > 0)); do
       ;;
   esac
 done
+
+if [[ -z "$fma_scripts_dir" ]]; then
+  printf '%s\n' 'warning: FMA_SCRIPTS_DIR is not set; heartbeat and failure reporting are disabled. Set FMA_SCRIPTS_DIR or pass --fma-scripts-dir <dir>.' >&2
+fi
 
 [[ -n "$repo_dir" ]] || die_usage
 [[ "$ring" == "canary" || "$ring" == "stable" ]] || die "invalid ring: $ring"

--- a/templates/TASK.tmpl.md
+++ b/templates/TASK.tmpl.md
@@ -1,11 +1,11 @@
 ---
 id: {{TASK_ID}}
 title: {{TITLE}}
-issued_by: sho-alpha
+issued_by: example-operator
 created: {{CREATED_UTC}}
 attempts_budget: 8
 time_budget_min: 30
-escalate_to: sho
+escalate_to: example-operator
 verify: mechanical
 parent_id: null
 ---

--- a/templates/examples/img-pilot.task.md
+++ b/templates/examples/img-pilot.task.md
@@ -1,42 +1,55 @@
 ---
 id: img-pilot-20260706-001
-title: Generate and deliver pilot PNG image
-issued_by: sho-alpha
+title: Generate and deliver a local SVG image card
+issued_by: example-operator
 created: 2026-07-06T00:00:00Z
 attempts_budget: 8
 time_budget_min: 60
-escalate_to: sho
+escalate_to: example-operator
 verify: mechanical
 parent_id: null
 ---
 
 ## Goal
 
-Generate one pilot PNG image through the Luca image-generation workflow and deliver it with a captured receipt.
+Generate a self-contained SVG image card using only local tools, then deliver it with a JSON receipt.
 
 ## Done-when
 
 ```donecheck
-test -s "$ARTIFACT_DIR/out/image.png" || { echo "FAIL: image exists"; exit 1; }
-head -c8 "$ARTIFACT_DIR/out/image.png" | grep -q $'\x89PNG' || { echo "FAIL: PNG magic bytes"; exit 1; }
+test -s "$ARTIFACT_DIR/out/image.svg" || { echo "FAIL: SVG image exists"; exit 1; }
+grep -Fq '<svg xmlns="http://www.w3.org/2000/svg"' "$ARTIFACT_DIR/out/image.svg" || { echo "FAIL: SVG root element"; exit 1; }
+grep -Fq 'Caty Agent Harness image pilot' "$ARTIFACT_DIR/out/image.svg" || { echo "FAIL: image pilot label"; exit 1; }
 test -s "$ARTIFACT_DIR/out/delivery-receipt.json" || { echo "FAIL: delivery receipt exists"; exit 1; }
+python3 - "$ARTIFACT_DIR/out/delivery-receipt.json" "$TASK_ID" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    receipt = json.load(handle)
+expected = {
+    "artifact": "out/image.svg",
+    "status": "delivered",
+    "task_id": sys.argv[2],
+}
+if receipt != expected:
+    raise SystemExit("FAIL: delivery receipt content")
+PY
 ```
 
 ## Step plan
 
-1. Create the image request sidecar at "$ARTIFACT_DIR/out/image-request.json" before calling the backend.
-2. Generate the image and save it to "$ARTIFACT_DIR/out/image.png".
-3. Inspect "$ARTIFACT_DIR/out/image.png" with the PNG magic-byte check from Done-when.
-4. deliver + capture receipt in "$ARTIFACT_DIR/out/delivery-receipt.json".
+1. Use bash or Python 3's standard library to create a self-contained image card at "$ARTIFACT_DIR/out/image.svg"; include an SVG root element and the visible text `Caty Agent Harness image pilot`.
+2. Validate the SVG with the Done-when checks, then deliver + capture a JSON receipt at "$ARTIFACT_DIR/out/delivery-receipt.json" with exactly the keys and values checked above.
 
 ## Resources
 
 - ARTIFACT_DIR
-- FAMILY_PUSH_CHANNEL
-- LUCA_IMAGE_BACKEND
+- bash
+- python3 standard library
 
 ## Non-goals
 
+- Do not call network services or image-generation backends.
 - Do not create alternate image formats.
-- Do not perform vision-rubric scoring.
 - Do not modify workspace state outside the named artifact paths.

--- a/templates/updater-cron.tmpl.sh
+++ b/templates/updater-cron.tmpl.sh
@@ -21,10 +21,9 @@ AGENT=${AGENT:-${USER:-unknown}}
 RING=${RING:-stable}
 SOAK_HOURS=${SOAK_HOURS:-24}
 
-if [[ -z "${FMA_SCRIPTS_DIR:-}" && -z "${HOME:-}" ]]; then
-  fail "HOME is not set; cannot derive default FMA_SCRIPTS_DIR"
+if [[ -z "${FMA_SCRIPTS_DIR:-}" ]]; then
+  fail "FMA_SCRIPTS_DIR is not set; set it to the reporter directory (for example, /path/to/family-memory-architecture/scripts)"
 fi
-FMA_SCRIPTS_DIR=${FMA_SCRIPTS_DIR:-"$HOME/claude-workspace/family-memory-architecture/scripts"}
 
 if [[ "$REPO_DIR" != /* ]]; then
   fail "REPO_DIR must be an absolute path: $REPO_DIR"


### PR DESCRIPTION
Closes #18 (child of epic #14 — serial slice 3 of 4; #15, #16 MERGED → **#18** → #17 per the [design-review record](https://github.com/caty-ai/caty-agent-harness/issues/14#issuecomment-5231258463)).

Makes the bundled example runnable by any public user and removes maintainer-specific residue:

- **templates/examples/img-pilot.task.md** — the task now builds a self-contained SVG image card and an exact-match JSON receipt using only bash/python3 stdlib; the private `LUCA_IMAGE_BACKEND` / `FAMILY_PUSH_CHANNEL` requirements are gone. Pinned path and id `img-pilot-20260706-001` kept, so `tests/tr-enqueue.test.sh` needed no change.
- **templates/TASK.tmpl.md + example frontmatter** — `issued_by: sho-alpha` / `escalate_to: sho` → `example-operator`.
- **codex/kimi INSTALL** — personal `~/claude-workspace/AGENTS.md` → placeholder charter path + setup note; **hermes INSTALL** — `/home/luca/...` crontab → placeholder paths.
- **install.sh (comment-only)** — the `--check` note now says probes read and hash *configured* wrapper/provider/probe paths **including env-supplied external ones** (matches `install.sh:788`/`:814–817` wiring); the read-only guarantee wording stays (it is true). Internal persona comment generalized.
- **scripts/family-updater + templates/updater-cron.tmpl.sh** — ⚠️ owner attention: the maintainer-layout `FMA_SCRIPTS_DIR` default is removed. Unset ⇒ heartbeat/failure reporting disabled **with a visible instruction**; explicit-but-broken reporter keeps the existing warning-and-continue semantics (locked by `tests/family-updater.test.sh`). **Deployed family hosts that relied on the old default need `FMA_SCRIPTS_DIR` set explicitly, else their cron logs will show the warning and heartbeats stop.** Help text now says caty-agent-harness.

Evidence gate (design review): the implementer ran the generalized example end to end in a clean temp workspace — `loop-init` → `tr-enqueue` (exit 0) → tick 1 (SVG produced) → tick 2 (receipt, `status=delivered`) → extracted donecheck run → **exit 0** — full transcript in the lane record (posted as a PR comment with the review record).

## 完了記録 (Completion record)

candidate SHA: e36075664b059d0fefc4353da2cbd688884fa143
implementer: Codex (gpt-5.6-sol, profile sol) — 3-layer brief, session scratchpad `lane-18/brief.md`
orchestrator / final inspector: Alpha (claude-fable-5) — not a review seat
reviewers: Kimi K3 + GLM 5.2 (loom-seats, size M — records follow as PR comments)
identity check: 別モデル (writer GPT-5.6 Sol ≠ reviewers ≠ orchestrator)

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| A generic example task runs with no private resources | PASS | implementer clean-workspace transcript: enqueue exit 0 → 2 ticks → `status=delivered` → donecheck exit 0; only bash/python3 stdlib/plain files |
| Host-specific paths become placeholders with setup notes | PASS | orchestrator sweep 2026-08-09: `grep -rn "sho-alpha\|escalate_to: sho\|/home/luca\|LUCA_IMAGE_BACKEND\|FAMILY_PUSH_CHANNEL\|claude-workspace" templates/ adapters/ scripts/ install.sh` → 0 hits |
| The check note matches probe behaviour | PASS | comment now describes env-supplied external path inspection (matches wiring at install.sh:788/:814–817); fence: `git diff -- scripts/lib-wrapper-conformance.sh tests/wrapper-conformance.test.sh` → empty (orchestrator-verified, 0 lines) |
| テスト / lint green | PASS | orchestrator run 2026-08-09: 20 suites, 0 FAIL lines (implementer: tr-enqueue 19 PASS / family-updater 34 PASS / full-suite FAIL scan empty) |

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...e360756: 8 files changed, 52 insertions(+), 28 deletions(-).
宣言10ファイル中8変更・2は宣言済み未変更（adapters/CONTRACT.md=既に正確・tests/tr-enqueue.test.sh=pin 維持で不要）。diff にあって宣言にないファイル: なし

Merge: local merge + push under owner identity (owner authorized, 2026-08-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
