### PR TITLE
#23: skill lint enforces the six-field contract, status-conditionally (warning level)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -158,6 +158,8 @@ degraded no-template fallback does not render this block.
   Skill frontmatter: `name, description, trigger (deterministic: keyword list or glob),
   status (draft | verified | deprecated | needs_reverify), verified_at (UTC),
   verifier_id`. Drafts live in `skills/_staging/` and are never loaded at CONSULT.
+  Drafts there carry `name, description, trigger, status, source`; `verified_at` and
+  `verifier_id` are added at promotion, so the six-field schema binds verified skills.
   If two promoted skills match one task, the more specific trigger wins; tie → most
   recent `verified_at`; the collision is logged to Open failures for human review.
 - OpenClaw distillation skill drafts may declare `source_task_id`, `target_skill`, and

--- a/install.sh
+++ b/install.sh
@@ -1015,7 +1015,7 @@ EOF
   # Skill lint warnings do not affect --check exit semantics. The loader budget is
   # adapter-specific, so callers may tune it with SKILL_DESC_MAX (default: 200).
   local skill_desc_max=${SKILL_DESC_MAX:-200}
-  local skill_file rel_path description description_bytes key key_value
+  local skill_file rel_path description description_bytes key key_value status_value
   while IFS= read -r skill_file; do
     [[ -n "$skill_file" ]] || continue
     rel_path=$(print_relative "$workspace" "$skill_file")
@@ -1039,7 +1039,8 @@ EOF
     if ! grep -q '^## Verification[[:space:]]*$' "$skill_file"; then
       printf 'warning: skill lint: missing ## Verification section: %s\n' "$rel_path" >&2
     fi
-    for key in name trigger status; do
+    status_value=
+    for key in name trigger status verified_at verifier_id; do
       key_value=$(awk -v key="$key" '
         $0 == "---" {markers++; next}
         markers == 1 && $0 ~ ("^" key ":[[:space:]]*") {
@@ -1049,7 +1050,14 @@ EOF
         }
         markers >= 2 {exit}
       ' "$skill_file")
-      if [[ -z "$key_value" ]]; then
+      if [[ "$key" == status ]]; then
+        status_value=$key_value
+      fi
+      if [[ "$key" == verified_at || "$key" == verifier_id ]]; then
+        if [[ "$status_value" == verified && -z "$key_value" ]]; then
+          printf 'warning: skill lint: missing %s for status verified: %s\n' "$key" "$rel_path" >&2
+        fi
+      elif [[ -z "$key_value" ]]; then
         printf 'warning: skill lint: missing %s: %s\n' "$key" "$rel_path" >&2
       fi
     done

--- a/install.sh
+++ b/install.sh
@@ -1052,6 +1052,7 @@ EOF
       ' "$skill_file")
       if [[ "$key" == status ]]; then
         status_value=$key_value
+        status_value=$(printf '%s' "$status_value" | sed -e 's/[[:space:]]*$//' -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/")
       fi
       if [[ "$key" == verified_at || "$key" == verifier_id ]]; then
         if [[ "$status_value" == verified && -z "$key_value" ]]; then

--- a/skills/_staging/SKILL.tmpl.md
+++ b/skills/_staging/SKILL.tmpl.md
@@ -4,6 +4,9 @@ description: <one-line description within the measured CONSULT loader budget; de
 trigger: <trigger>
 status: draft
 source: <source material>
+# Add these fields when promoting the skill:
+# verified_at: <UTC timestamp>
+# verifier_id: <verifier identifier>
 ---
 
 # <name>

--- a/tests/skill-lint.test.sh
+++ b/tests/skill-lint.test.sh
@@ -93,8 +93,41 @@ trigger: worse
 Check.
 EOF
 
+mkdir -p "$ws/skills/verified-complete" "$ws/skills/draft-without-verification"
+cat >"$ws/skills/verified-complete/SKILL.md" <<'EOF'
+---
+name: verified-complete
+description: verified skill with complete verification metadata
+trigger: verified-complete
+status: verified
+verified_at: 2026-08-10T00:00:00Z
+verifier_id: test-verifier
+---
+
+# verified-complete
+
+## Verification
+
+Check.
+EOF
+cat >"$ws/skills/draft-without-verification/SKILL.md" <<'EOF'
+---
+name: draft-without-verification
+description: draft skill without verification metadata
+trigger: draft-without-verification
+status: draft
+---
+
+# draft-without-verification
+
+## Verification
+
+Check.
+EOF
+
 output=$("$ROOT/install.sh" --check --workspace "$ws" 2>&1)
 rc=$?
+baseline_rc=$rc
 if [ "$rc" -eq 0 ] \
   && printf '%s\n' "$output" | grep -q 'warning: skill lint: description exceeds 200 bytes: skills/_staging/bad-skill/SKILL.md' \
   && printf '%s\n' "$output" | grep -q 'warning: skill lint: missing ## Verification section: skills/_staging/bad-skill/SKILL.md' \
@@ -117,6 +150,46 @@ if printf '%s\n' "$output" | grep -q 'warning: skill lint: missing description: 
   pass "empty description and missing name/status are each warned"
 else
   fail_case "empty description and missing name/status are each warned" "output=$output"
+fi
+
+if ! printf '%s\n' "$output" | grep -q 'skill lint: missing verified_at.*skills/verified-complete/SKILL.md' \
+  && ! printf '%s\n' "$output" | grep -q 'skill lint: missing verifier_id.*skills/verified-complete/SKILL.md'; then
+  pass "verified skill with verification metadata has no verification-field warnings"
+else
+  fail_case "verified skill with verification metadata has no verification-field warnings" "output=$output"
+fi
+
+if ! printf '%s\n' "$output" | grep -q 'skill lint: missing verified_at.*skills/draft-without-verification/SKILL.md' \
+  && ! printf '%s\n' "$output" | grep -q 'skill lint: missing verifier_id.*skills/draft-without-verification/SKILL.md'; then
+  pass "draft skill without verification metadata has no verification-field warnings"
+else
+  fail_case "draft skill without verification metadata has no verification-field warnings" "output=$output"
+fi
+
+mkdir -p "$ws/skills/verified-missing"
+cat >"$ws/skills/verified-missing/SKILL.md" <<'EOF'
+---
+name: verified-missing
+description: verified skill without verification metadata
+trigger: verified-missing
+status: verified
+---
+
+# verified-missing
+
+## Verification
+
+Check.
+EOF
+
+output=$("$ROOT/install.sh" --check --workspace "$ws" 2>&1)
+rc=$?
+if [ "$rc" -eq "$baseline_rc" ] \
+  && printf '%s\n' "$output" | grep -q 'warning: skill lint: missing verified_at for status verified: skills/verified-missing/SKILL.md' \
+  && printf '%s\n' "$output" | grep -q 'warning: skill lint: missing verifier_id for status verified: skills/verified-missing/SKILL.md'; then
+  pass "verified skill warns for both missing fields without changing check exit status"
+else
+  fail_case "verified skill warns for both missing fields without changing check exit status" "baseline_rc=$baseline_rc rc=$rc output=$output"
 fi
 
 output=$(SKILL_DESC_MAX=10 "$ROOT/install.sh" --check --workspace "$ws" 2>&1)

--- a/tests/skill-lint.test.sh
+++ b/tests/skill-lint.test.sh
@@ -192,6 +192,58 @@ else
   fail_case "verified skill warns for both missing fields without changing check exit status" "baseline_rc=$baseline_rc rc=$rc output=$output"
 fi
 
+mkdir -p "$ws/skills/verified-padded"
+{
+  printf '%s\n' '---'
+  printf '%s\n' 'name: verified-padded'
+  printf '%s\n' 'description: verified skill with padded status'
+  printf '%s\n' 'trigger: verified-padded'
+  printf '%s \n' 'status: verified'
+  printf '%s\n' '---'
+  printf '%s\n' ''
+  printf '%s\n' '# verified-padded'
+  printf '%s\n' ''
+  printf '%s\n' '## Verification'
+  printf '%s\n' ''
+  printf '%s\n' 'Check.'
+} >"$ws/skills/verified-padded/SKILL.md"
+
+output=$("$ROOT/install.sh" --check --workspace "$ws" 2>&1)
+rc=$?
+if [ "$rc" -eq "$baseline_rc" ] \
+  && printf '%s\n' "$output" | grep -q 'warning: skill lint: missing verified_at for status verified: skills/verified-padded/SKILL.md' \
+  && printf '%s\n' "$output" | grep -q 'warning: skill lint: missing verifier_id for status verified: skills/verified-padded/SKILL.md'; then
+  pass "padded verified status warns for both missing fields without changing check exit status"
+else
+  fail_case "padded verified status warns for both missing fields without changing check exit status" "baseline_rc=$baseline_rc rc=$rc output=$output"
+fi
+
+mkdir -p "$ws/skills/verified-quoted"
+cat >"$ws/skills/verified-quoted/SKILL.md" <<'EOF'
+---
+name: verified-quoted
+description: verified skill with quoted status
+trigger: verified-quoted
+status: "verified"
+---
+
+# verified-quoted
+
+## Verification
+
+Check.
+EOF
+
+output=$("$ROOT/install.sh" --check --workspace "$ws" 2>&1)
+rc=$?
+if [ "$rc" -eq "$baseline_rc" ] \
+  && printf '%s\n' "$output" | grep -q 'warning: skill lint: missing verified_at for status verified: skills/verified-quoted/SKILL.md' \
+  && printf '%s\n' "$output" | grep -q 'warning: skill lint: missing verifier_id for status verified: skills/verified-quoted/SKILL.md'; then
+  pass "quoted verified status warns for both missing fields without changing check exit status"
+else
+  fail_case "quoted verified status warns for both missing fields without changing check exit status" "baseline_rc=$baseline_rc rc=$rc output=$output"
+fi
+
 output=$(SKILL_DESC_MAX=10 "$ROOT/install.sh" --check --workspace "$ws" 2>&1)
 rc=$?
 if [ "$rc" -eq 0 ] \


### PR DESCRIPTION
Child #23 of Epic #19, second lane of the adjudicated order (#21a → **#23** → #20 → #22 → #21b; design-review record: https://github.com/caty-ai/caty-agent-harness/issues/19#issuecomment-5238013312, item 13).

## What this PR does

- `install.sh` (skill-lint block only): the frontmatter key loop now also checks `verified_at` and `verifier_id`, **required only when `status: verified`** — each missing one emits a house-style `warning: skill lint: missing <key> for status verified: <path>` line on stderr. **`--check` exit semantics are unchanged** (the `install.sh:1015` contract holds; the `family-updater` rollback path stays unarmed).
- `skills/_staging/SKILL.tmpl.md`: commented promotion placeholders for the two fields (drafts still legitimately omit them; no real keys added).
- `tests/skill-lint.test.sh`: three new cases — verified-without-fields warns for both **and pins the exit code against a baseline** (proving no semantics change); verified-with-fields and draft-without-fields produce no new warnings.
- `DESIGN.md`: additive 2-line clarification of the draft frontmatter shape (name/description/trigger/status/source; verification fields added at promotion).

Design-review findings honored: the child's original premise ("template itself omits mandated fields") was corrected by the 3-seat review — drafts correctly omit verification fields (Opus m2 / GLM MAJOR-6 / Kimi m2), and "fails the lint" is implemented at warning level because a non-zero `--check` can auto-rollback the harness via `scripts/family-updater:379-403` (Opus C5, adopted 3-seat convergent).

## Files changed (declared vs actual)

Declared in the WIP (https://github.com/caty-ai/caty-agent-harness/issues/23#issuecomment-5238956903): install.sh (lint block), SKILL.tmpl.md, tests/skill-lint.test.sh, DESIGN.md. Actual diff: exactly those four. No frozen identifier touched (grep-verified over the diff hunks).

## Completion record (L1-7)

- Done-when: "Lint and template match the design contract (or the contract is amended); a `status: verified` skill without verification fields fails the lint, with a test" → **PASS** ("fails the lint" = emits the lint warning finding per the adjudicated warning-level scope; test pins both warning lines AND the unchanged exit code).
- Candidate commit: `875acb9`.
- Verification: skill-lint suite 7 PASS / 0 FAIL; full suite **22 suites, 41 PASS, 0 FAIL** (orchestrator's own run); manual probe in the implementer report (verified-missing skill → 2 warnings on stderr, exit code identical with/without the offending skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
