### PR TITLE
docs: surface the flush intake consumer in engineering/reference layers (#37)

### DIFF
--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -123,6 +123,16 @@ verifier availability や cron wiring など、optional learning-path row も表
 
 この表は意図的に非対称で、すべての runtime に同一の native 機能があるとは主張しません。
 
+### Flush intake consumer
+
+上の Claude Code の `Stop` / `PreCompact` hook は producer に過ぎません。その産物は `loop/pending/flush-*.md` の未検証の記録です。どちらかの producer を有効にした workspace は、consumer である `adapters/claude-code/flush-intake.sh` の定期実行も必ず設定してください。さもないと、その記録は governed な `STATE.md` の fold に届かないまま溜まり続けます。同じ deterministic な consumer は、Codex CLI と Kimi Code CLI の workspace でも使えます。両者の checkpoint hook が同じ flush format を出力するためです。
+
+consumer は 1 日 2〜4 回実行してください。LaunchAgent なら `StartInterval` を `21600`〜`43200` 秒にします。毎日 1 回の schedule では、既定の deadman threshold に対して jitter の余裕がありません。consumer は model を呼ばないため、scheduler に Claude の credential は不要です。それでも macOS の scheduler surface としては `gui/<uid>` domain の LaunchAgent を推奨します。claude CLI を叩く tick wrapper や spawn adapter はいずれも LaunchAgent が必須です。crontab session は user Keychain に到達できないためです。
+
+fold 経路は workspace につき 1 本だけです。この consumer か、OpenClaw の `distill-audit.sh` のどちらかを使い、両方の併用はできません。consumer 自身は、共有 STATE lock を取得し、infrastructure error なく完了した後にだけ `loop/.deadman/distill.marker` を touch します（self-marking 設計）。チェックイン済みの cron wrapper（`templates/cron-wrapper.tmpl.sh`）はまさにこの consumer を self-marking として認識し、`DEADMAN_MARKER` がその workspace の `distill.marker` を指す場合は自身の pre-touch を抑制します。したがって明示的に設定しても lock starvation や intake failure が隠れることはありません。`DEADMAN_MARKER` を未設定のままにするのは、wrapper が識別できない proxy や rename された対象の場合です。
+
+詳しいセットアップ手順・ledger の形式・schedule の詳細は [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) を参照してください。
+
 ---
 
 <a id="pause"></a>

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -123,6 +123,16 @@ Start with Quickstart, then complete the runtime-specific integration you chose.
 
 The table is deliberately asymmetric and does not claim identical native capabilities across runtimes.
 
+### Flush intake consumer
+
+The Claude Code `Stop` and `PreCompact` hooks above are producers only: their output is unverified records in `loop/pending/flush-*.md`. A workspace that enables either producer must also schedule the consumer, `adapters/claude-code/flush-intake.sh`, or those records accumulate without ever reaching the governed `STATE.md` fold. The same deterministic consumer may also be used by Codex CLI and Kimi Code CLI workspaces, since their checkpoint hooks emit the same flush format.
+
+Run the consumer two to four times per day: for a LaunchAgent, a `StartInterval` between `21600` and `43200` seconds; a daily schedule leaves no jitter margin at the default deadman threshold. The consumer calls no model, so its scheduler does not need Claude credentials. On macOS, a LaunchAgent in the `gui/<uid>` domain remains the recommended scheduler surface; any tick wrapper or spawn adapter that shells out to the claude CLI must use one, since crontab sessions cannot reach the user Keychain.
+
+Exactly one fold route may run per workspace: this consumer, or OpenClaw's `distill-audit.sh`, never both. The consumer touches `loop/.deadman/distill.marker` itself, only after acquiring the shared STATE lock and finishing without an infrastructure error—a self-marking design. The checked-in cron wrapper (`templates/cron-wrapper.tmpl.sh`) recognizes this exact consumer as self-marking and suppresses its own pre-touch when `DEADMAN_MARKER` names that workspace's `distill.marker`, so an explicit setting cannot hide lock starvation or intake failure; leave `DEADMAN_MARKER` unset for a proxy or renamed target the wrapper cannot identify.
+
+See [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) for the full setup steps, ledger format, and scheduling detail.
+
 ---
 
 <a id="pause"></a>

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -55,6 +55,12 @@
 
 ---
 
+## Flush intake consumer の receipt
+
+flush intake consumer の会計 ledger は `loop/pending/intake-runs.log` です。deadman の `distill` marker が証明するのは intake が実行されたことだけです。内容レベルの沈黙・dedup・deferral・eviction・quarantine の各件数は ledger で確認します。`loop/archive/` は append-only で、自動で prune されることはありません。ledger の詳しい形式と schedule は [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) を参照してください。
+
+---
+
 ## 契約文書
 
 | 文書 | 契約 |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -55,6 +55,12 @@ The idempotency marker for appended bootstrap blocks is the literal line `# caty
 
 ---
 
+## Flush intake consumer receipts
+
+The flush intake consumer's accounting ledger is `loop/pending/intake-runs.log`. The deadman `distill` marker proves only that intake ran; inspect the ledger for content-level silence, dedup, deferral, eviction, and quarantine counts. `loop/archive/` is append-only and is never auto-pruned. See [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) for the full ledger format and scheduling.
+
+---
+
 ## Contract documents
 
 | Document | Contract |


### PR DESCRIPTION
Closes #37.

## Why

The flush intake consumer (#27) is documented only in `adapters/claude-code/INSTALL.md`. The README's engineering layer (Runtime setup) and `docs/reference.md` never mention it, so a reader cannot discover from the front door that enabling the flush-producing hooks requires a scheduled consumer.

## What

- `docs/engineering.md` / `docs/engineering.ja.md`: new **Flush intake consumer** subsection under Runtime setup — producer/consumer relationship, 2–4 runs/day window (`StartInterval` 21600–43200), macOS LaunchAgent surface, single-fold-route rule (OpenClaw exclusion), self-marking deadman design incl. the wrapper's pre-touch suppression two-case structure, pointer to INSTALL.md as the normative procedure
- `docs/reference.md` / `docs/reference.ja.md`: receipt ledger entry — `loop/pending/intake-runs.log` counts, the `distill` marker proves only that intake ran, `loop/archive/` is append-only

## Files changed (matches #37 declaration)

`docs/engineering.md`, `docs/engineering.ja.md`, `docs/reference.md`, `docs/reference.ja.md` — 4 files, +32/-0. No overlap with #20 (`fix/20-input-validation`).

## Verification

- All claims source-verified against `adapters/claude-code/INSTALL.md` (and implementation cross-checks: `templates/cron-wrapper.tmpl.sh` self-marking guard, `checkpoint-stop-hook.sh` producer behavior)
- Independent review (fresh-context, read-only): round 1 **NO-GO** — the DEADMAN_MARKER guidance collapsed INSTALL.md's two-case structure into an unconditional rule with an incorrect masking rationale; fixed by restoring the two-case wording. Round 2 **GO-with-comments**; the three optional polish items were also applied
- en/ja parity checked (same claim set both languages); no internal paths, real launchd labels, or private repo names in the additions
- `make test`: 41 PASS, 0 FAIL / `make lint`: 49 shell files OK on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
