### PR TITLE
ci: sync review-labels to template v0.9.2 — RISK_PATHS_AUTH=none 宣言 (#43・同期 2/3)

### DIFF
--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -63,6 +63,11 @@ jobs:
         name: Match changed files against risk paths
         env:
           BASE_REF: ${{ github.base_ref }}
+          # 文字クラス ([[:space:]])・tr・sed を決定論にする。LC_ALL=C だと全角空白 (U+3000)
+          # が空白と分類されず、行内空白の赤検査をすり抜けて 0 マッチの静かな緑になる (実測)。
+          # LANG でなく LC_ALL を pin する — LC_ALL は全 LC_* と LANG に優先し、runner 側の
+          # export に上書きされない (R3 3席収束)。
+          LC_ALL: C.UTF-8
         run: |
           set -euo pipefail
           # 高リスク領域のパス写像 (定義の正本は handbook docs/06 — ここは写像だけ)。
@@ -89,29 +94,113 @@ jobs:
           # 1ファイル PR で無力化する経路 (make test を true 化等) を人間確認の対象に入れる
           # (handbook#28・icase 照合なので makefile 等の大小変種も **/Makefile が拾う)。
           # CUSTOMIZE (宣言必須・カテゴリ別): このリポ固有のパスをカテゴリごとに列挙する。
-          # 該当が無いカテゴリは none と明示宣言する。どちらか一方でも __DECLARE_ME__ のまま
-          # (宣言なし) なら赤 — 「書き忘れたカテゴリだけ静かに fail-open」をカテゴリ単位で
-          # 許さない (fail-closed)。
+          # パターンは 1行1パターンの改行区切り — 空白区切りで1行に並べると「空白を含む1つの
+          # pathspec」として 0 ファイルにマッチする静かな fail-open になるため、行内空白は下の
+          # 検査で赤にする (空白を含む実パスは glob の ? で表す)。該当が無いカテゴリは none と
+          # だけ明示宣言する (受理する語は none のみ・大小文字不問。n/a 等の同義語は不可)。
+          # どれか一つでも __DECLARE_ME__ のまま (宣言なし) なら赤 — 「書き忘れたカテゴリだけ
+          # 静かに fail-open」をカテゴリ単位で許さない (fail-closed)。
           RISK_PATHS_BILLING='none'   # 課金・支出コードなし (#30 で明示宣言)
           RISK_PATHS_OUTBOUND='none'  # 対外送信コード実在なし — curl/wget/webhook 等 grep 確認 (#30 で明示宣言)
           RISK_PATHS_GATES='none'     # Makefile は DEFAULT が覆う・tests/** は一級市民コードで通常レビュー対象・vendored 補助なし (#30 で明示宣言)
+          # AUTH が DEFAULT に **/auth/** を持ちながら常設カテゴリでもある理由 (#31): その glob は
+          # 「認証コードは auth/ ディレクトリにある」という配置前提で、フラット配置 (app/auth.py・
+          # app/apple_signin.py 等) のリポでは 0 ファイルにマッチし、認証高リスク面がまるごと網外に
+          # なる。配置前提を型に埋めず、リポごとの明示宣言 (fail-closed) に乗せる。
+          # 認証コードが auth/ ディレクトリ配下に集約済み (DEFAULT の **/auth/** が実ファイルを
+          # 拾う) なら none。複数パターンの宣言形 (1行1パターン):
+          #   RISK_PATHS_AUTH='
+          #     app/auth*.py
+          #     **/token*.py
+          #   '
+          RISK_PATHS_AUTH='none'      # 認証コードなし (handbook#31 v0.9.2 同期で明示宣言 — 検知ログの AUTH 常在警告は「auth コード無し」確認済みの記録)
 
           RISK_PATHS_REPO=''
           check_category() {
             NAME="$1"; VAL="$2"
             STRIPPED="$(echo "${VAL}" | tr -d '[:space:]')"
+            # none / プレースホルダの照合は小文字化してから — 'None' 等の表記ゆれを厳密比較で
+            # 取り逃すと「0ファイルにマッチする死にパターン」として黙って素通りする (#32)。
+            FOLDED="$(echo "${STRIPPED}" | tr '[:upper:]' '[:lower:]')"
             # 空文字・空白のみも「宣言なし」— none という明示宣言か、実パスのどちらかを必須にする。
-            if [ -z "$STRIPPED" ] || [ "$STRIPPED" = "__DECLARE_ME__" ]; then
+            if [ -z "$STRIPPED" ] || [ "$FOLDED" = "__declare_me__" ]; then
               echo "::error::${NAME} is empty or still the placeholder. Declare paths for this category, or declare 'none' explicitly — an undeclared category must not silently pass (fail-closed)."
               exit 1
             fi
-            if [ "$STRIPPED" != "none" ]; then
-              RISK_PATHS_REPO="${RISK_PATHS_REPO}${VAL}"$'\n'
+            if [ "$FOLDED" = "none" ]; then
+              # AUTH の none は「auth コードが無い」か「DEFAULT の **/auth/** が実カバーしている」
+              # という主張。フラット配置の auth コードを持つリポが none と書くと警告ゼロで網外に
+              # なる (#31 の残余) — 主張を HEAD で自己検証する (LC-5: 検知→警告・赤にしない)。
+              if [ "$NAME" = "RISK_PATHS_AUTH" ]; then
+                AUTH_FILES=$(git ls-files -- ':(glob,icase)**/auth/**') || AUTH_FILES=""
+                if [ -z "$AUTH_FILES" ]; then
+                  echo "::warning::RISK_PATHS_AUTH is 'none' but DEFAULT's **/auth/** matches 0 tracked files — if this repo has flat-layout auth code (e.g. app/auth.py), the auth surface is entirely uncovered (#31). Verify the 'none' claim or declare real paths."
+                fi
+              fi
+              return 0
             fi
+            # 行単位の健全性検査 (3席レビュー収束・#33):
+            # - 行内空白 = 空白区切りの複数パターン誤記。git pathspec では空白が literal 文字の
+            #   1パターンになり 0 件マッチ=静かな fail-open になるため赤。
+            # - declare_me を含む行 = プレースホルダの残骸・打ち間違い (__DECLARE_ME_ 等)。
+            #   実パスと混在した部分宣言も赤 (「宣言なしは赤」の契約を行単位でも守る)。
+            while IFS= read -r line; do
+              line="$(echo "$line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+              [ -n "$line" ] || continue
+              case "$line" in
+                '#'*)
+                  # コメント行は宣言の中では未対応 — 空白の有無で挙動が割れる (空白ありは
+                  # 空白検査・空白なしは死にパターン化) のを許さず、正しい理由で赤にする。
+                  echo "::error::${NAME} contains a comment line ('${line}') — comments are not supported inside category declarations; remove it (fail-closed)."
+                  exit 1
+                  ;;
+                *[[:space:]]*)
+                  echo "::error::${NAME} line '${line}' contains internal whitespace — declare one pattern per line (a space-separated list becomes ONE literal-space pathspec matching 0 files = silent fail-open). Use glob ? for a path that really contains a space."
+                  exit 1
+                  ;;
+              esac
+              # プレースホルダ検査は / も . も含まない行だけに掛ける — 実パターンは区切りか
+              # 拡張子を持つ (app/declare_member.py 等の実在パスを誤って赤にしない)。
+              case "$line" in
+                */*|*.*) : ;;
+                *)
+                  LINE_FOLDED="$(echo "$line" | tr '[:upper:]' '[:lower:]')"
+                  case "$LINE_FOLDED" in
+                    *declare_me*)
+                      echo "::error::${NAME} contains a placeholder-like line ('${line}') — remove it and declare real paths or 'none' (fail-closed)."
+                      exit 1
+                      ;;
+                  esac
+                  ;;
+              esac
+            done <<< "${VAL}"
+            RISK_PATHS_REPO="${RISK_PATHS_REPO}${VAL}"$'\n'
           }
           check_category RISK_PATHS_BILLING "$RISK_PATHS_BILLING"
           check_category RISK_PATHS_OUTBOUND "$RISK_PATHS_OUTBOUND"
           check_category RISK_PATHS_GATES "$RISK_PATHS_GATES"
+          check_category RISK_PATHS_AUTH "$RISK_PATHS_AUTH"
+
+          # 死にパターン検知 (LC-5: 検知→警告・自動では赤にしない): 宣言パターンが HEAD の
+          # 1ファイルにも解決しない場合、リネーム・配置変更で写像が乖離した兆候 — 「存在しない
+          # 敵を守れているように見える」まさに #31 の形。ログの警告で人間の判断に回す。
+          # 展開手順の機械確認にはこのログの ::warning:: 確認を含める (README 手順 6)。
+          while IFS= read -r pat; do
+            pat="$(echo "$pat" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+            [ -n "$pat" ] || continue
+            # stderr は空判定に混ぜない — 成功時の stderr が「0マッチなのに生きて見える」形で
+            # 死にパターン警告を黙らせる経路を作らない (エラー詳細は失敗時に再実行で表示)。
+            if RESOLVED=$(git ls-files -- ":(glob,icase)${pat}" 2>/dev/null); then
+              if [ -z "$RESOLVED" ]; then
+                echo "::warning::declared risk pattern '${pat}' matches 0 tracked files at HEAD — possible dead pattern. Update the category declaration (a stale mapping silently uncovers the area)."
+              fi
+            else
+              # 解決失敗は「死にパターン」でなく構文不正 — 誤診しない (診断を分ける)。
+              # この後の diff 照合ループが同じパターンで fail-closed に落とす。
+              git ls-files -- ":(glob,icase)${pat}" 2>&1 >/dev/null | sed 's/^/  /' || true
+              echo "::warning::declared risk pattern '${pat}' could not be resolved as a pathspec (git error above) — fix the declaration syntax; the diff-matching step will fail closed on it."
+            fi
+          done <<< "${RISK_PATHS_REPO}"
 
           git rev-parse --verify "origin/${BASE_REF}" >/dev/null || {
             echo "::error::base ref not found — failing closed (FP-6)."; exit 1; }


### PR DESCRIPTION
Closes #43. v0.9.2 レーンの同期 PR（2/3）。型改訂本体= handbook PR #33（main `af41ab7`・3席全 GO・R1〜R4 台帳あり）。

## What

`.github/workflows/review-labels.yml` をマージ済み v0.9.2 テンプレから機械再生成（1ファイルのみ・宣言4行だけがテンプレと異なることを diff で機械確認済み）:

- BILLING=`none` / OUTBOUND=`none` / GATES=`none`（#30 の宣言から不変）
- **AUTH=`none` を新規宣言** — 確認実測: `git ls-files ':(glob,icase)**/auth/**'` = 0件・auth 系ワードの一致4件は全て classify テストフィクスチャ（`auth-401.json` 等）と語部分一致（`model-authored.md`）で認証コードではない。検知ログの AUTH 常在警告は「auth コード無し」確認済みの記録（templates/ci README の例外規定どおり）

v0.9.2 で入る硬化: none 大小文字非依存・宣言行の健全性検査（行内空白/コメント/placeholder=赤）・死にパターン警告・AUTH=none 自己検証・LC_ALL pin。

## 翔さんの玉

`.github/workflows/**` 変更のため **risk-reviewed ラベル**が required 緑の条件です。ラベル→CI 緑→マージ GO の順でお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
