### PR TITLE
docs: self-growth-loop registry entry → public repo URL

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -6,5 +6,5 @@ matching `INTEGRATION.md` in the plugin repo.
 
 | Plugin | Repo | Status | Seams used | Owner |
 |---|---|---|---|---|
-| self-growth-loop (tool/tech adoption: sense→propose→trial→council→adopt) | private | active: ledger, growth-lint, and ops cron live; trial runner shipped | data plane active; enqueue + results active (task ids `sgl-trial-*`) | the maintainers |
+| self-growth-loop (tool/tech adoption: sense→propose→trial→council→adopt) | [caty-ai/self-growth-loop](https://github.com/caty-ai/self-growth-loop) | active: ledger, growth-lint, and ops cron live; trial runner shipped | data plane active; enqueue + results active (task ids `sgl-trial-*`) | the maintainers |
 | persona-growth-loop (persona **overlay** growth: observation → nightly delayed-reward proposals) | private | contracts frozen 2026-08-02; implementation staged behind checkpoint gates — all automated overlay writes forbidden until the governance and per-face GO checkpoints pass | data plane: aggregates only, no raw phrase bodies. Enqueue/results/templates unused. Growth-write is NOT a harness seam — it is a separate plugin↔pack-repo contract | the maintainers |


### PR DESCRIPTION
1-line registry update: the self-growth-loop plugin row's Repo cell `private` → [caty-ai/self-growth-loop](https://github.com/caty-ai/self-growth-loop) (published 2026-08-11, fresh-history initial release `fd0b389`, tag v0.1.0). Dual-bookkeeping counterpart INTEGRATION.md already links this registry.

Post-publish task from the SGL Phase 2 checklist (owner-approved publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)