### PR TITLE
#10: load SECRETS_ENV as data — no shell execution, symlink and interpreter-control names refused

### DIFF
--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -170,12 +170,18 @@ the absolute adapter/script path and pass the target arguments after the wrapper
 
 Adapter stdout is now captured per attempt in `attempts/NNN/model.stdout` and no longer appears in the tick log.
 
-`SECRETS_ENV` is optional. When set and present, the wrapper sources it only if it is
-owned by the cron user and has `0600` or `0400` permissions. Put environment values
-such as `TR_SPAWN_STEP`, `HERMES_STEP_CMD`, `HERMES_PROBE_CMD`, and `TR_PUSH_CMD` in
-that file instead of expanding secrets directly in crontab. `install.sh --check`
-remains read-only: its Hermes conformance row reads and hashes the configured wrapper,
-provider, probe, and evidence files without executing them.
+`SECRETS_ENV` is optional. When set and present, the wrapper parses it as data-only
+`KEY=VALUE`, one assignment per physical line; it does not source or execute the file.
+The file must be owned by the cron user, have `0600` or `0400` permissions, and not be
+a symlink. Interpreter- and loader-control names are refused by a deliberately
+non-exhaustive hazard guard. Store a multi-line secret in its own file and put that
+file's path in `SECRETS_ENV`. Put ordinary values such as `TR_SPAWN_STEP`,
+`HERMES_STEP_CMD`, `HERMES_PROBE_CMD`, and `TR_PUSH_CMD` in the env file instead of
+expanding secrets directly in crontab. Portable Bash 3.2 cannot open with
+`O_NOFOLLOW`; pre/post-open identity checks narrow, but do not eliminate, a residual
+path replacement race. `install.sh --check` remains read-only: its Hermes conformance
+row reads and hashes the configured wrapper, provider, probe, and evidence files
+without executing them.
 
 When configured, `push.log` persists the push command's combined output; bash-level
 errors are redacted. Keep secrets out of command-name position and out of helper output.

--- a/adapters/openclaw/INSTALL.md
+++ b/adapters/openclaw/INSTALL.md
@@ -68,8 +68,13 @@ The rules there apply in addition to the OpenClaw-specific wiring below.
    ```
 
    Put `DISTILLER_CMD=/abs/distiller-wrapper.sh` in `SECRETS_ENV` or another cron-owned
-   environment source. If `SECRETS_ENV` exists, the wrapper requires it to be owned by
-   the cron user and to have `0600` or `0400` permissions.
+   environment mechanism. The wrapper parses `SECRETS_ENV` as data-only `KEY=VALUE`, one
+   assignment per physical line; it does not source or execute the file. The file must
+   be owned by the cron user, have `0600` or `0400` permissions, and not be a symlink.
+   Interpreter- and loader-control names are refused by a deliberately non-exhaustive
+   hazard guard. Store a multi-line secret in its own file and put that file's path in
+   `SECRETS_ENV`. Portable Bash 3.2 cannot open with `O_NOFOLLOW`; pre/post-open identity
+   checks narrow, but do not eliminate, a residual path replacement race.
 
    Read `loop/pending/distill-runs.log` after each run. Its summary reports
    `lessons_added`, `failures_added`, and `evicted_by_cap`; a nonzero eviction count

--- a/scripts/activation-manifest.tsv
+++ b/scripts/activation-manifest.tsv
@@ -12,7 +12,7 @@ adapters/openclaw/sentinel-cron.sh	guarded	--workspace	exit-0-status	automated-s
 scripts/deadman-probe.sh	guarded	argv.workspace	exit-0-status	automated-state-maintenance	caty_pause_workspace_state	mkdir -p "$deadman_dir"
 scripts/task-runner.sh	guarded	argv.workspace	exit-0-status	automated-task-lifecycle	caty_pause_workspace_state	mkdir -p "$queue_dir"
 scripts/tr-enqueue	guarded	argv.workspace	exit-3-status	explicit-queue-mutation	caty_pause_workspace_state	mkdir -p "$queue_dir"
-templates/cron-wrapper.tmpl.sh	guarded	--workspace-or-positional	exit-0-status	scheduler-wrapper-before-secrets-and-deadman-mutations	caty_pause_workspace_state	. "$SECRETS_ENV"
+templates/cron-wrapper.tmpl.sh	guarded	--workspace-or-positional	exit-0-status	scheduler-wrapper-before-secrets-and-deadman-mutations	caty_pause_workspace_state	exec 9<"$SECRETS_ENV"
 templates/updater-cron.tmpl.sh	exempt	none	not-applicable	harness-updater-wrapper-not-member-workspace	-	-
 scripts/attest-wrapper	exempt	none	not-applicable	setup-time-wrapper-attestation	-	-
 scripts/family-updater	exempt	none	not-applicable	harness-clone-updater-not-member-workspace	-	-

--- a/templates/cron-wrapper.tmpl.sh
+++ b/templates/cron-wrapper.tmpl.sh
@@ -112,7 +112,8 @@ parse_secrets_env() {
       case "$key" in
         BASH_ENV|ENV|SHELLOPTS|BASHOPTS|IFS|PS4|CDPATH|GLOBIGNORE|PATH|BASH_XTRACEFD|\
         PAGER|EDITOR|VISUAL|PERL5OPT|PERL5LIB|PERLLIB|PERL5DB|PERL5SHELL|\
-        PYTHONSTARTUP|PYTHONPATH|PYTHONHOME|RUBYOPT|RUBYLIB|NODE_OPTIONS|NODE_PATH|\
+        PYTHONSTARTUP|PYTHONPATH|PYTHONHOME|PYTHONWARNINGS|PYTHONBREAKPOINT|\
+        RUBYOPT|RUBYLIB|NODE_OPTIONS|NODE_PATH|\
         NODE_REPL_EXTERNAL_MODULE|GIT_SSH|GIT_SSH_COMMAND|GIT_EXTERNAL_DIFF|GIT_PAGER|\
         GIT_EDITOR|GIT_ASKPASS|SSH_ASKPASS|GIT_PROXY_COMMAND|GIT_CONFIG_GLOBAL|\
         GIT_CONFIG_SYSTEM|GIT_CONFIG_COUNT|GIT_CONFIG_PARAMETERS|GIT_EXEC_PATH|\
@@ -130,9 +131,8 @@ parse_secrets_env() {
           fi
         fi
       fi
-      # Bash 3.2 treats assignment errors from a directly invoked special
-      # builtin as fatal even inside `if !`; `command` makes the status
-      # catchable without changing export in the current shell.
+      # `command` keeps assignment failures catchable across shells and modes
+      # without changing where the variable is set.
       if ! command export "$key=$value" 2>/dev/null; then
         fail "SECRETS_ENV line $line_number cannot export $key (reserved or read-only name): $secrets_path"
       fi
@@ -220,13 +220,6 @@ if [[ -n "$SECRETS_ENV" ]]; then
   if [[ -f "$SECRETS_ENV" ]]; then
     validate_secrets_env "$SECRETS_ENV"
 
-    if ! nul_line=$(first_nul_line "$SECRETS_ENV"); then
-      fail "SECRETS_ENV could not be scanned for embedded NUL bytes: $SECRETS_ENV"
-    fi
-    if [[ -n "$nul_line" ]]; then
-      fail "SECRETS_ENV line $nul_line contains an embedded NUL byte: $SECRETS_ENV"
-    fi
-
     if ! exec 9<"$SECRETS_ENV"; then
       fail "SECRETS_ENV is not readable: $SECRETS_ENV"
     fi
@@ -236,6 +229,15 @@ if [[ -n "$SECRETS_ENV" ]]; then
     fi
 
     validate_secrets_env "$SECRETS_ENV"
+
+    if ! nul_line=$(first_nul_line "$SECRETS_ENV"); then
+      exec 9<&-
+      fail "SECRETS_ENV could not be scanned for embedded NUL bytes: $SECRETS_ENV"
+    fi
+    if [[ -n "$nul_line" ]]; then
+      exec 9<&-
+      fail "SECRETS_ENV line $nul_line contains an embedded NUL byte: $SECRETS_ENV"
+    fi
 
     if [[ -L "$SECRETS_ENV" ]] || ! same_open_file "$SECRETS_ENV" /dev/fd/9; then
       exec 9<&-

--- a/templates/cron-wrapper.tmpl.sh
+++ b/templates/cron-wrapper.tmpl.sh
@@ -5,11 +5,14 @@ set -euo pipefail
 #
 # Copy this file to the target workspace scripts/ directory, set TARGET and
 # CATY_HARNESS_ROOT to absolute paths, and pass the target arguments to this wrapper.
-# Optional SECRETS_ENV is parsed as data-only KEY=VALUE assignments when the
-# file exists, is not a symlink, is owned by the current uid, and has 0600 or
-# 0400 permissions. No shell code is executed, one matching outer quote layer
-# is stripped from each value, and one trailing CR is removed per line.
-# Interpreter- or loader-control names are refused; the refusal list is a hazard guard, not an exhaustive safety boundary.
+# Optional SECRETS_ENV is parsed as data-only KEY=VALUE assignments, one per
+# physical line, when the file exists, is not a symlink, is owned by the current
+# uid, and has 0600 or 0400 permissions. No shell code is executed. One matching
+# outer quote layer is stripped only when its inner value has no matching quote,
+# and one trailing CR is removed per line. Interpreter- or loader-control names
+# are refused; the refusal list is a hazard guard, not an exhaustive safety
+# boundary. Portable Bash 3.2 cannot open with O_NOFOLLOW, so a residual path
+# replacement race remains despite the pre/post-open identity checks.
 
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 export PATH
@@ -68,9 +71,33 @@ same_open_file() {
   [[ "$path_identity" == "$fd_identity" ]]
 }
 
+first_nul_line() {
+  local secrets_path=$1
+
+  LC_ALL=C od -An -v -t u1 "$secrets_path" 2>/dev/null | awk '
+    BEGIN { line_number = 1 }
+    {
+      for (field = 1; field <= NF; field++) {
+        if (!found && $field == 0) {
+          first_match = line_number
+          found = 1
+        }
+        if ($field == 10) {
+          line_number++
+        }
+      }
+    }
+    END {
+      if (found) {
+        print first_match
+      }
+    }
+  '
+}
+
 parse_secrets_env() {
   local secrets_path=$1
-  local line_number=0 raw_line line key value first_char last_char
+  local line_number=0 raw_line line key value first_char last_char inner_value
 
   while IFS= read -r -u 9 raw_line || [[ -n "$raw_line" ]]; do
     line_number=$((line_number + 1))
@@ -79,29 +106,39 @@ parse_secrets_env() {
     if [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]]; then
       continue
     fi
-    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+    if [[ "$line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
       key=${BASH_REMATCH[1]}
       value=${BASH_REMATCH[2]}
       case "$key" in
         BASH_ENV|ENV|SHELLOPTS|BASHOPTS|IFS|PS4|CDPATH|GLOBIGNORE|PATH|BASH_XTRACEFD|\
-        PERL5OPT|PERL5LIB|PERLLIB|PYTHONSTARTUP|PYTHONPATH|PYTHONHOME|RUBYOPT|RUBYLIB|\
-        NODE_OPTIONS|NODE_REPL_EXTERNAL_MODULE|GIT_SSH|GIT_SSH_COMMAND|GIT_EXTERNAL_DIFF|\
-        GIT_PAGER|GIT_EDITOR|GIT_CONFIG_GLOBAL|GIT_CONFIG_SYSTEM|GIT_CONFIG_COUNT|\
-        GIT_ALTERNATE_OBJECT_DIRECTORIES|BASH_FUNC_*|LD_*|DYLD_*)
-          fail "SECRETS_ENV line $line_number refuses interpreter-control name $key: $secrets_path"
+        PAGER|EDITOR|VISUAL|PERL5OPT|PERL5LIB|PERLLIB|PERL5DB|PERL5SHELL|\
+        PYTHONSTARTUP|PYTHONPATH|PYTHONHOME|RUBYOPT|RUBYLIB|NODE_OPTIONS|NODE_PATH|\
+        NODE_REPL_EXTERNAL_MODULE|GIT_SSH|GIT_SSH_COMMAND|GIT_EXTERNAL_DIFF|GIT_PAGER|\
+        GIT_EDITOR|GIT_ASKPASS|SSH_ASKPASS|GIT_PROXY_COMMAND|GIT_CONFIG_GLOBAL|\
+        GIT_CONFIG_SYSTEM|GIT_CONFIG_COUNT|GIT_CONFIG_PARAMETERS|GIT_EXEC_PATH|\
+        GIT_ALTERNATE_OBJECT_DIRECTORIES|LESSOPEN|LESSCLOSE|BASH_FUNC_*|LD_*|DYLD_*)
+          fail "SECRETS_ENV line $line_number refuses interpreter-control name $key (rename it, e.g. APP_ENV): $secrets_path"
           ;;
       esac
       if (( ${#value} >= 2 )); then
         first_char=${value:0:1}
         last_char=${value: -1}
         if [[ "$first_char" == "$last_char" && ( "$first_char" == "'" || "$first_char" == '"' ) ]]; then
-          value=${value:1:${#value}-2}
+          inner_value=${value:1:${#value}-2}
+          if [[ "$inner_value" != *"$first_char"* ]]; then
+            value=$inner_value
+          fi
         fi
       fi
-      export "$key=$value"
+      # Bash 3.2 treats assignment errors from a directly invoked special
+      # builtin as fatal even inside `if !`; `command` makes the status
+      # catchable without changing export in the current shell.
+      if ! command export "$key=$value" 2>/dev/null; then
+        fail "SECRETS_ENV line $line_number cannot export $key (reserved or read-only name): $secrets_path"
+      fi
       continue
     fi
-    fail "SECRETS_ENV line $line_number is not a KEY=VALUE assignment: $secrets_path"
+    fail "SECRETS_ENV line $line_number is not a KEY=VALUE assignment; SECRETS_ENV requires one assignment per line (store multi-line secrets in their own file and put the path in SECRETS_ENV): $secrets_path"
   done
 }
 
@@ -182,6 +219,13 @@ if [[ -n "$SECRETS_ENV" ]]; then
   fi
   if [[ -f "$SECRETS_ENV" ]]; then
     validate_secrets_env "$SECRETS_ENV"
+
+    if ! nul_line=$(first_nul_line "$SECRETS_ENV"); then
+      fail "SECRETS_ENV could not be scanned for embedded NUL bytes: $SECRETS_ENV"
+    fi
+    if [[ -n "$nul_line" ]]; then
+      fail "SECRETS_ENV line $nul_line contains an embedded NUL byte: $SECRETS_ENV"
+    fi
 
     if ! exec 9<"$SECRETS_ENV"; then
       fail "SECRETS_ENV is not readable: $SECRETS_ENV"

--- a/templates/cron-wrapper.tmpl.sh
+++ b/templates/cron-wrapper.tmpl.sh
@@ -5,8 +5,11 @@ set -euo pipefail
 #
 # Copy this file to the target workspace scripts/ directory, set TARGET and
 # CATY_HARNESS_ROOT to absolute paths, and pass the target arguments to this wrapper.
-# Optional SECRETS_ENV is sourced only when the file exists, is owned by the
-# current uid, and has 0600 or 0400 permissions.
+# Optional SECRETS_ENV is parsed as data-only KEY=VALUE assignments when the
+# file exists, is not a symlink, is owned by the current uid, and has 0600 or
+# 0400 permissions. No shell code is executed, one matching outer quote layer
+# is stripped from each value, and one trailing CR is removed per line.
+# Interpreter- or loader-control names are refused; the refusal list is a hazard guard, not an exhaustive safety boundary.
 
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 export PATH
@@ -32,7 +35,77 @@ file_mode() {
   stat -c "%a" "$1" 2>/dev/null || stat -f "%Lp" "$1"
 }
 
-# Resolve the member workspace and shared pause helper before sourcing secrets,
+validate_secrets_env() {
+  local secrets_path=$1 current_uid owner_uid mode
+
+  current_uid=$(id -u)
+  owner_uid=$(file_owner_uid "$secrets_path")
+  mode=$(file_mode "$secrets_path")
+
+  if [[ "$owner_uid" != "$current_uid" ]]; then
+    fail "SECRETS_ENV owner uid $owner_uid does not match current uid $current_uid: $secrets_path"
+  fi
+  case "$mode" in
+    400|0400|600|0600) ;;
+    *)
+      fail "SECRETS_ENV permissions must be 0600 or 0400: $secrets_path has $mode"
+      ;;
+  esac
+}
+
+same_open_file() {
+  local path=$1 fd_path=$2 path_identity fd_identity
+
+  if [[ "$path" -ef "$fd_path" ]]; then
+    return 0
+  fi
+
+  # Bash 3.2 on macOS cannot establish -ef identity through /dev/fd. Its BSD
+  # stat still exposes the underlying file metadata (except device and mode),
+  # so compare the stable identity fields and fail closed if either read fails.
+  path_identity=$(stat -f "%u:%g:%i:%z:%m:%c:%B" "$path" 2>/dev/null) || return 1
+  fd_identity=$(stat -f "%u:%g:%i:%z:%m:%c:%B" "$fd_path" 2>/dev/null) || return 1
+  [[ "$path_identity" == "$fd_identity" ]]
+}
+
+parse_secrets_env() {
+  local secrets_path=$1
+  local line_number=0 raw_line line key value first_char last_char
+
+  while IFS= read -r -u 9 raw_line || [[ -n "$raw_line" ]]; do
+    line_number=$((line_number + 1))
+    line=${raw_line%$'\r'}
+
+    if [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]]; then
+      continue
+    fi
+    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      key=${BASH_REMATCH[1]}
+      value=${BASH_REMATCH[2]}
+      case "$key" in
+        BASH_ENV|ENV|SHELLOPTS|BASHOPTS|IFS|PS4|CDPATH|GLOBIGNORE|PATH|BASH_XTRACEFD|\
+        PERL5OPT|PERL5LIB|PERLLIB|PYTHONSTARTUP|PYTHONPATH|PYTHONHOME|RUBYOPT|RUBYLIB|\
+        NODE_OPTIONS|NODE_REPL_EXTERNAL_MODULE|GIT_SSH|GIT_SSH_COMMAND|GIT_EXTERNAL_DIFF|\
+        GIT_PAGER|GIT_EDITOR|GIT_CONFIG_GLOBAL|GIT_CONFIG_SYSTEM|GIT_CONFIG_COUNT|\
+        GIT_ALTERNATE_OBJECT_DIRECTORIES|BASH_FUNC_*|LD_*|DYLD_*)
+          fail "SECRETS_ENV line $line_number refuses interpreter-control name $key: $secrets_path"
+          ;;
+      esac
+      if (( ${#value} >= 2 )); then
+        first_char=${value:0:1}
+        last_char=${value: -1}
+        if [[ "$first_char" == "$last_char" && ( "$first_char" == "'" || "$first_char" == '"' ) ]]; then
+          value=${value:1:${#value}-2}
+        fi
+      fi
+      export "$key=$value"
+      continue
+    fi
+    fail "SECRETS_ENV line $line_number is not a KEY=VALUE assignment: $secrets_path"
+  done
+}
+
+# Resolve the member workspace and shared pause helper before loading secrets,
 # touching deadman markers, invoking probes, or executing TARGET. New installs
 # should set CATY_HARNESS_ROOT explicitly; the TARGET-based lookup keeps the
 # checked-in examples concise.
@@ -103,23 +176,31 @@ if [[ ! -x "$TARGET" ]]; then
   fail "TARGET is not executable: $TARGET"
 fi
 
-if [[ -n "$SECRETS_ENV" && -f "$SECRETS_ENV" ]]; then
-  current_uid=$(id -u)
-  owner_uid=$(file_owner_uid "$SECRETS_ENV")
-  mode=$(file_mode "$SECRETS_ENV")
-
-  if [[ "$owner_uid" != "$current_uid" ]]; then
-    fail "SECRETS_ENV owner uid $owner_uid does not match current uid $current_uid: $SECRETS_ENV"
+if [[ -n "$SECRETS_ENV" ]]; then
+  if [[ -L "$SECRETS_ENV" ]]; then
+    fail "SECRETS_ENV must not be a symlink: $SECRETS_ENV"
   fi
-  case "$mode" in
-    400|0400|600|0600) ;;
-    *)
-      fail "SECRETS_ENV permissions must be 0600 or 0400: $SECRETS_ENV has $mode"
-      ;;
-  esac
+  if [[ -f "$SECRETS_ENV" ]]; then
+    validate_secrets_env "$SECRETS_ENV"
 
-  # shellcheck disable=SC1090
-  . "$SECRETS_ENV"
+    if ! exec 9<"$SECRETS_ENV"; then
+      fail "SECRETS_ENV is not readable: $SECRETS_ENV"
+    fi
+    if [[ -L "$SECRETS_ENV" ]] || ! same_open_file "$SECRETS_ENV" /dev/fd/9; then
+      exec 9<&-
+      fail "SECRETS_ENV changed while opening: $SECRETS_ENV"
+    fi
+
+    validate_secrets_env "$SECRETS_ENV"
+
+    if [[ -L "$SECRETS_ENV" ]] || ! same_open_file "$SECRETS_ENV" /dev/fd/9; then
+      exec 9<&-
+      fail "SECRETS_ENV changed while validating: $SECRETS_ENV"
+    fi
+
+    parse_secrets_env "$SECRETS_ENV"
+    exec 9<&-
+  fi
 fi
 
 if [[ "$TARGET" != /* || ! -x "$TARGET" ]]; then

--- a/tests/deadman-probe.test.sh
+++ b/tests/deadman-probe.test.sh
@@ -346,6 +346,121 @@ else
   fail_case 'secrets overrides are revalidated' "rc=$secrets_rc"
 fi
 
+quoted_marker="$TMP_ROOT/quoted marker/.deadman/tick.marker"
+quoted_secrets=$TMP_ROOT/secrets-env-quoted
+printf 'DEADMAN_MARKER="%s"\r\n' "$quoted_marker" >"$quoted_secrets"
+chmod 600 "$quoted_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$quoted_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; quoted_secrets_rc=$?
+if [ "$quoted_secrets_rc" -eq 0 ] && [ -f "$quoted_marker" ] \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'quoted CRLF secrets overrides export without quotes'
+else
+  fail_case 'quoted CRLF secrets overrides export without quotes' "rc=$quoted_secrets_rc marker=$([ -f "$quoted_marker" ] && printf yes || printf no)"
+fi
+
+bash_env_marker=$TMP_ROOT/bash-env-marker
+bash_env_script=$TMP_ROOT/bash-env-script
+printf ': >"%s"\n' "$bash_env_marker" >"$bash_env_script"
+chmod 600 "$bash_env_script"
+bash_env_secrets=$TMP_ROOT/secrets-env-bash-env
+printf 'BASH_ENV=%s\n' "$bash_env_script" >"$bash_env_secrets"
+chmod 600 "$bash_env_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$bash_env_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; bash_env_rc=$?
+if [ "$bash_env_rc" -eq 3 ] && [ ! -e "$bash_env_marker" ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 1 refuses interpreter-control name BASH_ENV: $bash_env_secrets" "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'BASH_ENV is refused before its startup script can run'
+else
+  fail_case 'BASH_ENV is refused before its startup script can run' \
+    "rc=$bash_env_rc marker=$([ -e "$bash_env_marker" ] && printf present || printf absent)"
+fi
+
+prefix_secrets=$TMP_ROOT/secrets-env-prefix
+printf 'LD_PRELOAD=/tmp/x\n' >"$prefix_secrets"
+chmod 600 "$prefix_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$prefix_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; prefix_rc=$?
+if [ "$prefix_rc" -eq 3 ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 1 refuses interpreter-control name LD_PRELOAD: $prefix_secrets" "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'dynamic-loader prefix names are refused'
+else
+  fail_case 'dynamic-loader prefix names are refused' "rc=$prefix_rc"
+fi
+
+near_miss_log=$TMP_ROOT/near-miss.log
+near_miss_target=$TMP_ROOT/near-miss-target
+cat >"$near_miss_target" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${MY_PATH_TOKEN-}" >"$NEAR_MISS_LOG"
+EOF
+chmod +x "$near_miss_target"
+near_miss_secrets=$TMP_ROOT/secrets-env-near-miss
+printf 'MY_PATH_TOKEN=abc\n' >"$near_miss_secrets"
+chmod 600 "$near_miss_secrets"
+TARGET="$near_miss_target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  NEAR_MISS_LOG="$near_miss_log" SECRETS_ENV="$near_miss_secrets" "$wrapper" \
+  >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; near_miss_rc=$?
+if [ "$near_miss_rc" -eq 0 ] && [ -f "$near_miss_log" ] \
+  && [ "$(cat "$near_miss_log")" = abc ]; then
+  pass 'hazardous substrings in legitimate names remain accepted'
+else
+  fail_case 'hazardous substrings in legitimate names remain accepted' \
+    "rc=$near_miss_rc value=$([ -f "$near_miss_log" ] && cat "$near_miss_log" || printf missing)"
+fi
+
+would_be_command_side_effect=$TMP_ROOT/would-be-command-side-effect
+secrets_command=$TMP_ROOT/secrets-env-command
+cat >"$secrets_command" <<EOF
+# comment
+
+DEADMAN_MARKER=$marker
+touch "$would_be_command_side_effect"
+EOF
+chmod 600 "$secrets_command"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$secrets_command" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; secrets_command_rc=$?
+if [ "$secrets_command_rc" -eq 3 ] && [ ! -e "$would_be_command_side_effect" ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 4 is not a KEY=VALUE assignment: $secrets_command" "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'would-be command lines are rejected without side effects'
+else
+  fail_case 'would-be command lines are rejected without side effects' "rc=$secrets_command_rc side_effect=$([ -e "$would_be_command_side_effect" ] && printf yes || printf no)"
+fi
+
+malformed_secrets=$TMP_ROOT/secrets-env-malformed
+cat >"$malformed_secrets" <<EOF
+DEADMAN_MARKER=$marker
+BAD-KEY=value
+EOF
+chmod 600 "$malformed_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$malformed_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; malformed_secrets_rc=$?
+if [ "$malformed_secrets_rc" -eq 3 ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 2 is not a KEY=VALUE assignment: $malformed_secrets" "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'malformed secrets lines fail with line numbers'
+else
+  fail_case 'malformed secrets lines fail with line numbers' "rc=$malformed_secrets_rc"
+fi
+
+symlink_source=$TMP_ROOT/secrets-env-symlink-source
+symlink_secrets=$TMP_ROOT/secrets-env-symlink
+printf 'DEADMAN_MARKER=%s\n' "$marker" >"$symlink_source"
+chmod 600 "$symlink_source"
+ln -s "$symlink_source" "$symlink_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$symlink_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; symlink_secrets_rc=$?
+if [ "$symlink_secrets_rc" -eq 3 ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV must not be a symlink: $symlink_secrets" "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'symlink secrets env is refused'
+else
+  fail_case 'symlink secrets env is refused' "rc=$symlink_secrets_rc"
+fi
+
 ws=$(new_ws malformed-checks)
 run_probe "$ws" 'tick:abc'; rc=$?
 if [ "$rc" -eq 2 ] && [ "$(entry_count "$ws")" -eq 0 ]; then

--- a/tests/deadman-probe.test.sh
+++ b/tests/deadman-probe.test.sh
@@ -359,6 +359,127 @@ else
   fail_case 'quoted CRLF secrets overrides export without quotes' "rc=$quoted_secrets_rc marker=$([ -f "$quoted_marker" ] && printf yes || printf no)"
 fi
 
+secrets_capture_target=$TMP_ROOT/secrets-capture-target
+cat >"$secrets_capture_target" <<'EOF'
+#!/usr/bin/env bash
+printf 'FOO=%s\n' "${FOO-}"
+printf 'STRIPPED=%s\n' "${STRIPPED-}"
+printf 'VERBATIM=%s\n' "${VERBATIM-}"
+printf 'LEADING=%s\n' "${LEADING-}"
+printf 'TRAILING=%s\n' "${TRAILING-}"
+printf 'MIDDLE=%s\n' "${MIDDLE-}"
+printf 'SINGLE=%s\n' "${SINGLE-}"
+printf 'EMPTY=%s\n' "${EMPTY-}"
+EOF
+chmod +x "$secrets_capture_target"
+
+indented_secrets=$TMP_ROOT/secrets-env-indented
+printf '  FOO=bar\n' >"$indented_secrets"
+chmod 600 "$indented_secrets"
+TARGET="$secrets_capture_target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$indented_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; indented_rc=$?
+if [ "$indented_rc" -eq 0 ] && grep -Fxq 'FOO=bar' "$TMP_ROOT/wrapper.out"; then
+  pass 'indented secrets assignments are accepted'
+else
+  fail_case 'indented secrets assignments are accepted' "rc=$indented_rc stdout=$(cat "$TMP_ROOT/wrapper.out")"
+fi
+
+spaced_key_secrets=$TMP_ROOT/secrets-env-spaced-key
+printf '  FOO =bar\n' >"$spaced_key_secrets"
+chmod 600 "$spaced_key_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$spaced_key_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; spaced_key_rc=$?
+if [ "$spaced_key_rc" -eq 3 ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 1 is not a KEY=VALUE assignment; SECRETS_ENV requires one assignment per line (store multi-line secrets in their own file and put the path in SECRETS_ENV): $spaced_key_secrets" "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'whitespace between a secrets key and equals remains malformed'
+else
+  fail_case 'whitespace between a secrets key and equals remains malformed' \
+    "rc=$spaced_key_rc stderr=$(cat "$TMP_ROOT/wrapper.err")"
+fi
+
+quoted_shape_secrets=$TMP_ROOT/secrets-env-quoted-shapes
+cat >"$quoted_shape_secrets" <<'EOF'
+STRIPPED="a+b"
+VERBATIM="a"+"b"
+LEADING="a
+TRAILING=a"
+MIDDLE=a"b
+SINGLE="
+EMPTY=""
+EOF
+chmod 600 "$quoted_shape_secrets"
+TARGET="$secrets_capture_target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$quoted_shape_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; quoted_shape_rc=$?
+if [ "$quoted_shape_rc" -eq 0 ] \
+  && grep -Fxq 'STRIPPED=a+b' "$TMP_ROOT/wrapper.out" \
+  && grep -Fxq 'VERBATIM="a"+"b"' "$TMP_ROOT/wrapper.out" \
+  && grep -Fxq 'LEADING="a' "$TMP_ROOT/wrapper.out" \
+  && grep -Fxq 'TRAILING=a"' "$TMP_ROOT/wrapper.out" \
+  && grep -Fxq 'MIDDLE=a"b' "$TMP_ROOT/wrapper.out" \
+  && grep -Fxq 'SINGLE="' "$TMP_ROOT/wrapper.out" \
+  && grep -Fxq 'EMPTY=' "$TMP_ROOT/wrapper.out"; then
+  pass 'outer quotes are stripped only when the inner value has no matching quote'
+else
+  fail_case 'outer quotes are stripped only when the inner value has no matching quote' \
+    "rc=$quoted_shape_rc stdout=$(cat "$TMP_ROOT/wrapper.out")"
+fi
+
+readonly_secrets=$TMP_ROOT/secrets-env-readonly
+printf 'UID=1000\n' >"$readonly_secrets"
+chmod 600 "$readonly_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$readonly_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; readonly_rc=$?
+if [ "$readonly_rc" -eq 3 ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 1 cannot export UID (reserved or read-only name): $readonly_secrets" "$TMP_ROOT/wrapper.err" \
+  && ! grep -Fq 'readonly variable' "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'read-only shell names fail through the infra-error contract'
+else
+  fail_case 'read-only shell names fail through the infra-error contract' \
+    "rc=$readonly_rc stderr=$(cat "$TMP_ROOT/wrapper.err")"
+fi
+
+pager_secrets=$TMP_ROOT/secrets-env-pager
+printf 'PAGER=/tmp/x\n' >"$pager_secrets"
+chmod 600 "$pager_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$pager_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; pager_rc=$?
+if [ "$pager_rc" -eq 3 ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 1 refuses interpreter-control name PAGER (rename it, e.g. APP_ENV): $pager_secrets" "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'added exact interpreter-control names are refused'
+else
+  fail_case 'added exact interpreter-control names are refused' "rc=$pager_rc"
+fi
+
+env_secrets=$TMP_ROOT/secrets-env-env
+printf '# comment\n\nENV=production\n' >"$env_secrets"
+chmod 600 "$env_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$env_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; env_rc=$?
+if [ "$env_rc" -eq 3 ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 3 refuses interpreter-control name ENV (rename it, e.g. APP_ENV): $env_secrets" "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'interpreter-control refusals include an actionable rename hint'
+else
+  fail_case 'interpreter-control refusals include an actionable rename hint' "rc=$env_rc"
+fi
+
+nul_secrets=$TMP_ROOT/secrets-env-nul
+printf 'FIRST=ok\nNUL_VALUE=before\0after\n' >"$nul_secrets"
+chmod 600 "$nul_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$nul_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; nul_rc=$?
+if [ "$nul_rc" -eq 3 ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 2 contains an embedded NUL byte: $nul_secrets" "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'embedded NUL bytes fail closed with the first offending line number'
+else
+  fail_case 'embedded NUL bytes fail closed with the first offending line number' \
+    "rc=$nul_rc stderr=$(cat "$TMP_ROOT/wrapper.err")"
+fi
+
 bash_env_marker=$TMP_ROOT/bash-env-marker
 bash_env_script=$TMP_ROOT/bash-env-script
 printf ': >"%s"\n' "$bash_env_marker" >"$bash_env_script"
@@ -369,7 +490,7 @@ chmod 600 "$bash_env_secrets"
 TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
   SECRETS_ENV="$bash_env_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; bash_env_rc=$?
 if [ "$bash_env_rc" -eq 3 ] && [ ! -e "$bash_env_marker" ] \
-  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 1 refuses interpreter-control name BASH_ENV: $bash_env_secrets" "$TMP_ROOT/wrapper.err" \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 1 refuses interpreter-control name BASH_ENV (rename it, e.g. APP_ENV): $bash_env_secrets" "$TMP_ROOT/wrapper.err" \
   && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
   pass 'BASH_ENV is refused before its startup script can run'
 else
@@ -383,7 +504,7 @@ chmod 600 "$prefix_secrets"
 TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
   SECRETS_ENV="$prefix_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; prefix_rc=$?
 if [ "$prefix_rc" -eq 3 ] \
-  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 1 refuses interpreter-control name LD_PRELOAD: $prefix_secrets" "$TMP_ROOT/wrapper.err" \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 1 refuses interpreter-control name LD_PRELOAD (rename it, e.g. APP_ENV): $prefix_secrets" "$TMP_ROOT/wrapper.err" \
   && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
   pass 'dynamic-loader prefix names are refused'
 else
@@ -423,7 +544,7 @@ chmod 600 "$secrets_command"
 TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
   SECRETS_ENV="$secrets_command" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; secrets_command_rc=$?
 if [ "$secrets_command_rc" -eq 3 ] && [ ! -e "$would_be_command_side_effect" ] \
-  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 4 is not a KEY=VALUE assignment: $secrets_command" "$TMP_ROOT/wrapper.err" \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 4 is not a KEY=VALUE assignment; SECRETS_ENV requires one assignment per line (store multi-line secrets in their own file and put the path in SECRETS_ENV): $secrets_command" "$TMP_ROOT/wrapper.err" \
   && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
   pass 'would-be command lines are rejected without side effects'
 else
@@ -439,11 +560,31 @@ chmod 600 "$malformed_secrets"
 TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
   SECRETS_ENV="$malformed_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; malformed_secrets_rc=$?
 if [ "$malformed_secrets_rc" -eq 3 ] \
-  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 2 is not a KEY=VALUE assignment: $malformed_secrets" "$TMP_ROOT/wrapper.err" \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 2 is not a KEY=VALUE assignment; SECRETS_ENV requires one assignment per line (store multi-line secrets in their own file and put the path in SECRETS_ENV): $malformed_secrets" "$TMP_ROOT/wrapper.err" \
   && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
   pass 'malformed secrets lines fail with line numbers'
 else
   fail_case 'malformed secrets lines fail with line numbers' "rc=$malformed_secrets_rc"
+fi
+
+pem_secrets=$TMP_ROOT/secrets-env-pem
+# PEM-shaped fixture: the same multi-line quoted structure a real key file has, with a
+# neutral block label so local and CI secret scanners do not flag the test data.
+cat >"$pem_secrets" <<'EOF'
+BLOCK_VALUE="-----BEGIN EXAMPLE BLOCK-----
+YWJj
+-----END EXAMPLE BLOCK-----"
+EOF
+chmod 600 "$pem_secrets"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$pem_secrets" "$wrapper" >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; pem_rc=$?
+if [ "$pem_rc" -eq 3 ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 2 is not a KEY=VALUE assignment; SECRETS_ENV requires one assignment per line (store multi-line secrets in their own file and put the path in SECRETS_ENV): $pem_secrets" "$TMP_ROOT/wrapper.err" \
+  && [ "$(wc -l <"$TARGET_LOG" | tr -d '[:space:]')" -eq 3 ]; then
+  pass 'PEM-shaped multi-line values fail with the documented path workaround'
+else
+  fail_case 'PEM-shaped multi-line values fail with the documented path workaround' \
+    "rc=$pem_rc stderr=$(cat "$TMP_ROOT/wrapper.err")"
 fi
 
 symlink_source=$TMP_ROOT/secrets-env-symlink-source

--- a/tests/deadman-probe.test.sh
+++ b/tests/deadman-probe.test.sh
@@ -511,6 +511,35 @@ else
   fail_case 'dynamic-loader prefix names are refused' "rc=$prefix_rc"
 fi
 
+prefix_boundary_log=$TMP_ROOT/prefix-boundary.log
+prefix_boundary_target=$TMP_ROOT/prefix-boundary-target
+cat >"$prefix_boundary_target" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${LDAP_TOKEN-}" >"$PREFIX_BOUNDARY_LOG"
+EOF
+chmod +x "$prefix_boundary_target"
+prefix_boundary_allowed=$TMP_ROOT/secrets-env-prefix-boundary-allowed
+printf 'LDAP_TOKEN=abc\n' >"$prefix_boundary_allowed"
+chmod 600 "$prefix_boundary_allowed"
+TARGET="$prefix_boundary_target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  PREFIX_BOUNDARY_LOG="$prefix_boundary_log" SECRETS_ENV="$prefix_boundary_allowed" "$wrapper" \
+  >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; prefix_boundary_allowed_rc=$?
+prefix_boundary_refused=$TMP_ROOT/secrets-env-prefix-boundary-refused
+printf 'LD_AUDIT=/tmp/x\n' >"$prefix_boundary_refused"
+chmod 600 "$prefix_boundary_refused"
+TARGET="$target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$wrapper_ws" \
+  SECRETS_ENV="$prefix_boundary_refused" "$wrapper" \
+  >"$TMP_ROOT/wrapper.out" 2>"$TMP_ROOT/wrapper.err"; prefix_boundary_refused_rc=$?
+if [ "$prefix_boundary_allowed_rc" -eq 0 ] \
+  && [ -f "$prefix_boundary_log" ] && [ "$(cat "$prefix_boundary_log")" = abc ] \
+  && [ "$prefix_boundary_refused_rc" -eq 3 ] \
+  && grep -Fq "cron-wrapper infra error: SECRETS_ENV line 1 refuses interpreter-control name LD_AUDIT (rename it, e.g. APP_ENV): $prefix_boundary_refused" "$TMP_ROOT/wrapper.err"; then
+  pass 'dynamic-loader prefix families match only at the start of a name'
+else
+  fail_case 'dynamic-loader prefix families match only at the start of a name' \
+    "rcs=$prefix_boundary_allowed_rc/$prefix_boundary_refused_rc value=$([ -f "$prefix_boundary_log" ] && cat "$prefix_boundary_log" || printf missing)"
+fi
+
 near_miss_log=$TMP_ROOT/near-miss.log
 near_miss_target=$TMP_ROOT/near-miss-target
 cat >"$near_miss_target" <<'EOF'


### PR DESCRIPTION
First child of security Epic #9 (adjudicated order **#10** → #11 → #12 → #13). Independent of the epic's design checkpoints (CP1/CP2 govern the donecheck boundary and the updater; this issue is the cron wrapper's secret loading). Design contracts for the epic: #11 issuecomment-5251529443 (CP1 v3), #12 issuecomment-5251709827 (CP2 closed).

## What this PR does

`templates/cron-wrapper.tmpl.sh` **sourced** `SECRETS_ENV` as shell code (`ecb4a0b5`) and its file test lacked the `-L` refusal the neighbouring pause-helper check already has (`7e947299`). One patch, both findings:

1. **Data-only parser** (Bash 3.2 compatible): blank lines, first-nonblank `#` comments, and `KEY=VALUE` assignments with `[A-Za-z_][A-Za-z0-9_]*` keys. One matching outer quote layer and one trailing `\r` are stripped; **no `eval`, no `source`, no expansion** of the value. Malformed lines **fail closed** with the offending line number (a silently skipped line is a secret that looks applied and is not).
2. **Symlink refusal** for `SECRETS_ENV`, matching the pause-helper precedent. Owner-uid and 0600/0400 checks unchanged; the "set but missing file is skipped" contract is unchanged. The file is opened once on a fixed FD and parsed from that FD, with a pre/post identity comparison that **narrows but does not eliminate** the replace race (portable Bash cannot request `O_NOFOLLOW` — recorded as a residual limitation, not claimed as closed).
3. **Interpreter/loader-control names refused** (owner decision, 2026-08-11). The parser not executing the file is not sufficient: exporting `BASH_ENV` hands execution to the *next* bash that starts. Reproduced by the implementer and independently by the orchestrator (marker file created). Refused fail-closed: `BASH_ENV`, `ENV`, `SHELLOPTS`, `BASHOPTS`, `IFS`, `PS4`, `CDPATH`, `GLOBIGNORE`, `PATH`, `BASH_XTRACEFD`, `BASH_FUNC_*`, `LD_*`, `DYLD_*`, `PERL5OPT`/`PERL5LIB`/`PERLLIB`, `PYTHONSTARTUP`/`PYTHONPATH`/`PYTHONHOME`, `RUBYOPT`/`RUBYLIB`, `NODE_OPTIONS`, `NODE_REPL_EXTERNAL_MODULE`, and the git exec surface (`GIT_SSH`, `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`, `GIT_PAGER`, `GIT_EDITOR`, `GIT_CONFIG_GLOBAL`/`_SYSTEM`/`_COUNT`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`).

   **Scope of the claim, stated precisely**: the loader never executes the file, and names that reconfigure an interpreter or loader are refused. The list is a **hazard guard, not an exhaustive safety boundary** — `SECRETS_ENV` is owner-written and mode-checked, so its contents remain operator-trusted. The alternatives (full allowlist / document-only) were weighed and the owner chose this contract.

4. `scripts/activation-manifest.tsv`: the forbidden-operation sentinel followed the removed `. "$SECRETS_ENV"` line to the new FD open.

## Files changed (declared vs actual)

Declared in the WIP (#10 issuecomment-5251547978): cron-wrapper template, a test file, optionally a doc line. Actual: `templates/cron-wrapper.tmpl.sh`, `tests/deadman-probe.test.sh`, **plus `scripts/activation-manifest.tsv`** — outside the literal declaration, accepted on inspection because the manifest's sentinel column *quotes the exact line this patch removes*; leaving it stale would break `tests/activation-manifest.test.sh`. Documented rather than waved through.

## Completion record (L1-7)

- Done-when: "SECRETS_ENV is parsed as KEY=VALUE data (no shell execution) **or** the shell-source contract is explicitly documented and constrained; symlinks are refused like the pause-helper path; both behaviours covered by tests" → **PASS** (data parsing + symlink refusal + the owner-scoped hazard contract, all tested).
- Candidate commit: `723acbd` (base main `2bbc00a`).
- Implementer verification: `bash -n`; `deadman-probe` 24 PASS / `check-tickprobe` 53 PASS / `activation-manifest` PASS; `make test` exit 0; `make lint` 49 files; direct non-execution transcript.
- **Orchestrator verification (independent)**: reproduced the `BASH_ENV` downstream execution before accepting the contract change; probed the refusal patterns directly — `LD_AUDIT` refused via prefix while `APP_LD_KEY` / `MY_PATH_TOKEN` / `MYGIT_SSH` export normally (no substring matching), `BASH_FUNC_x%%` refused, lowercase `bash_env` exported (a different variable that bash does not honour); frozen line 4 byte-identical; own full suite **22 files, 0 FAIL** with the seven SECRETS_ENV cases passing, including "hazardous substrings in legitimate names remain accepted".
- Intersection with main at PR time (main moved to `5dbc223` during the lane): **disjoint** — main touched README×4 + `docs/plugins.md` only; `git merge-tree` dry run reports no conflict.

Review: 4 heterogeneous seats (Opus 5 / GLM 5.2 / Fable 5 / Grok 4.5) per the owner-approved downgrade while Kimi and Qwen are quota-absent (#9 issuecomment-5251589535); Codex Sol wrote this implementation and is therefore ineligible as a reviewer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
