### PR TITLE
#11: enforce the donecheck/spawn execution boundary (CP1 v3)

### DIFF
--- a/DESIGN-task-runner.md
+++ b/DESIGN-task-runner.md
@@ -273,6 +273,8 @@ attempt consumes budget; identical-error fast-DLQ; infra failures held separatel
 10. Post-enqueue mutation of a queued task is not detected. Enqueue closes the caller
     source-file TOCTOU window by validating the staged snapshot, but there is no queued
     task signature or immutable storage in this version.
+    A hardlink inside `out/` to an outside file is likewise not detected; creating one
+    requires an in-zone actor and is the same residual-risk class as risks 9–10.
 11. Timeout killing is process-group containment, not process-tree containment. A child
     that calls `setsid` can leave the original process group and survive the timeout kill.
 12. `TR_SPAWN_STEP` misconfiguration is operator-level by design. Startup rejects

--- a/DESIGN-task-runner.md
+++ b/DESIGN-task-runner.md
@@ -175,7 +175,7 @@ Every transition = temp-write + atomic rename. Cron every 5 min; singleton flock
 4. On exit/kill: stamp driver.json (timeout charges full step_timeout to
    `active_seconds_used`); update counters; status → verifying; run donecheck.
    - all pass → assert frontmatter `receipt` is a non-symlink, non-empty regular file
-     whose resolved path stays beneath resolved `out/`; then status delivered and move
+     whose resolved path stays beneath the artifact's own non-symlink `out/`; then status delivered and move
      the task file to `delivered/` (rename = commit). A missing/invalid receipt fails
      verification; missing/invalid receipt metadata is DLQ `missing-receipt` before spawn.
    - step_complete=yes → current_step += 1, consec_noncomplete = 0.

--- a/DESIGN-task-runner.md
+++ b/DESIGN-task-runner.md
@@ -88,6 +88,7 @@ time_budget_min: 30            # D5 — cumulative active seconds, driver-measur
 escalate_to: sho               # D6
 verify: mechanical             # fixed literal in v0; any other value rejected (TR-R15)
 parent_id: null                # set only on DLQ re-enqueue (always a NEW id, TR-R15)
+receipt: out/delivery-receipt.json # required delivery target under artifact out/
 ```
 
 (step_timeout is a global driver constant, 10 min — not per-task; TR-R15.)
@@ -95,17 +96,27 @@ parent_id: null                # set only on DLQ re-enqueue (always a NEW id, TR
 Body sections (all required; "none" allowed, deletion not):
 
 - `## Goal` — one paragraph.
-- `## Done-when` — a `donecheck` fenced block of executable assertions. Contract
-  (TR-R7): the driver runs it with `bash -euo pipefail`, cwd = workspace,
-  `TASK_ID`/`TASK_FILE`/`ARTIFACT_DIR` exported, 60 s timeout, output captured to the
-  attempt's `donecheck.log`. Assertions are READ-ONLY (they run after every attempt).
-  Prefer magic-byte checks over `file | grep`. MUST include a delivery-receipt
-  assertion (D2), e.g.:
+- `## Done-when` — exactly one column-zero `donecheck` fenced block of executable
+  assertions. Contract (TR-R7): the driver runs it with the Bash pinned in
+  `loop/.tr-interpreters`, `-euo pipefail`, cwd = workspace, and a 60 s timeout.
+  `env -i` supplies only `TASK_ID`, `TASK_FILE`, `ARTIFACT_DIR`, `TR_DC_CWD`, fixed
+  `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, `HOME`, and set `LANG`/`LC_ALL`/`TZ` values;
+  Bash may add `PWD`, `SHLVL`, and `_`. Output is captured in `donecheck.log`.
+  Assertions are READ-ONLY by task contract (they run after every attempt).
+  Prefer magic-byte checks over `file | grep`. After the block exits zero, the runner
+  mechanically asserts the frontmatter `receipt`; a task may also inspect its content,
+  e.g.:
   ```donecheck
   test -s "$ARTIFACT_DIR/out/image.png" || { echo "FAIL: image exists"; exit 1; }
   head -c8 "$ARTIFACT_DIR/out/image.png" | grep -q $'\x89PNG' || { echo "FAIL: PNG magic bytes"; exit 1; }
   test -s "$ARTIFACT_DIR/out/delivery-receipt.json" || { echo "FAIL: delivery ack captured"; exit 1; }
   ```
+  Extraction is textual: a column-zero closing fence inside a heredoc terminates the
+  block and is prohibited. The wrapper applies best-effort limits of CPU seconds =
+  `TR_DONECHECK_TIMEOUT_S + 60`, file size = 2,097,152 512-byte blocks (1 GiB), open
+  files = 256, and processes = 512. A platform may refuse a lower limit; the process
+  limit is skipped when current per-user usage cannot be observed safely or lacks
+  headroom. These are process-group bounds, not a sandbox or process-tree container.
 - `## Step plan` — enumerated `plan_steps`; invariant `plan_steps ≤ attempts_budget`
   (enqueue-validated). The agent executes exactly the injected step k; it may file a
   `deviation_report` (§3.3) but never re-plans (TR-R12). The LAST step is always
@@ -163,7 +174,10 @@ Every transition = temp-write + atomic rename. Cron every 5 min; singleton flock
      no budget burn on an xAI outage (TR-R2).
 4. On exit/kill: stamp driver.json (timeout charges full step_timeout to
    `active_seconds_used`); update counters; status → verifying; run donecheck.
-   - all pass → status delivered, move task file to `delivered/` (rename = commit).
+   - all pass → assert frontmatter `receipt` is a non-symlink, non-empty regular file
+     whose resolved path stays beneath resolved `out/`; then status delivered and move
+     the task file to `delivered/` (rename = commit). A missing/invalid receipt fails
+     verification; missing/invalid receipt metadata is DLQ `missing-receipt` before spawn.
    - step_complete=yes → current_step += 1, consec_noncomplete = 0.
    - non-complete: consec_noncomplete += 1. Two consecutive with IDENTICAL
      error_class → DLQ reason=persistent-failure. Otherwise yield (next tick retries
@@ -193,9 +207,12 @@ artifact path. Re-enqueue is manual, always under a NEW id with `parent_id` set.
 
 ### 3.6 Enqueue validation (tr-enqueue)
 
-Rejects: missing/duplicate id, missing sections, no delivery step, no delivery
-assertion, `verify` ≠ mechanical, `plan_steps > attempts_budget`,
-`step_timeout > time_budget`, donecheck that fails `bash -n`, unwritable artifact dir.
+`tr-enqueue` first copies to the queue-side dot-prefixed staging file, then validates
+the exact staged bytes. Rejects: missing/duplicate id, missing sections, no delivery
+step, missing/invalid `receipt`, `verify` ≠ mechanical, `plan_steps > attempts_budget`,
+`step_timeout > time_budget`, invalid UTF-8, missing/multiple/unclosed donecheck, a raw
+donecheck that fails pinned-Bash `-n`, or an unwritable artifact dir. `receipt` must
+match `^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$` and no segment may be `.` or `..`.
 Warns (does not block): `time_budget_min < plan_steps × 8 min` — the pilot image task
 ships with `time_budget_min: 60` (D5 override; defaults unchanged).
 
@@ -250,6 +267,17 @@ attempt consumes budget; identical-error fast-DLQ; infra failures held separatel
    clock, never from timestamps in files.
 8. Disk-full mid-artifact-write → donecheck `test -s` catches truncation; the attempt
    fails without corrupting state.json (atomic rename on a full disk fails whole).
+9. A malicious task runs arbitrary shell as the runner user by design. The environment,
+   receipt, timeout, and ulimit boundaries reduce accidents; they are not a privilege
+   boundary or sandbox.
+10. Post-enqueue mutation of a queued task is not detected. Enqueue closes the caller
+    source-file TOCTOU window by validating the staged snapshot, but there is no queued
+    task signature or immutable storage in this version.
+11. Timeout killing is process-group containment, not process-tree containment. A child
+    that calls `setsid` can leave the original process group and survive the timeout kill.
+12. `TR_SPAWN_STEP` misconfiguration is operator-level by design. Startup rejects
+    non-absolute, non-regular, or non-executable values, but does not attest provider
+    contents or constrain what an intentionally configured provider can do.
 
 ## 8. Cross-cutting contracts (grok-build study, Issue #43 → #49)
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -63,7 +63,7 @@ WORKSPACE="/absolute/path/to/the/project"
 ./install.sh --workspace "$WORKSPACE" --bootstrap-runtime <your-runtime> --append-bootstrap "$WORKSPACE/<instruction-file>"
 ```
 
-Fill `<your-runtime>` and `<instruction-file>` from the Step 1 table (Hermes and OpenClaw: use the exact invocation from your adapter document instead of this template). Missing folders and files are created; existing ones are never replaced. If the block is already present you'll see `skip: bootstrap already present` — that's fine, it's idempotent.
+Fill `<your-runtime>` and `<instruction-file>` from the Step 1 table (Hermes and OpenClaw: use the exact invocation from your adapter document instead of this template). Missing folders and files are created; existing ones are never replaced. Initialization also pins the absolute Bash and Perl paths in `$WORKSPACE/loop/.tr-interpreters`, so donecheck validation and execution use the same binaries. If the block is already present you'll see `skip: bootstrap already present` — that's fine, it's idempotent.
 
 ## Step 4 — health check
 
@@ -114,7 +114,7 @@ I'll remember where we were. Or ask me to run the bundled example at
 templates/examples/img-pilot.task.md.
 ```
 
-The bundled example you can run builds a self-contained SVG image card and a JSON delivery receipt using local tools only. From the harness repository root, set `STEP_PROVIDER` to your AI tool's step provider — the runner invokes it with four positional arguments (task file, workspace, attempt directory, current step; see the `TR_SPAWN_STEP` call in `scripts/task-runner.sh`), and each step must write the `step-result.json` described in [`DESIGN-task-runner.md`](../DESIGN-task-runner.md) — and run it end to end:
+The bundled example you can run builds a self-contained SVG image card and a JSON delivery receipt using local tools only. From the harness repository root, set `STEP_PROVIDER` to the absolute path of your AI tool's executable step provider — relative and PATH-resolved `TR_SPAWN_STEP` values are rejected. The runner invokes it with four positional arguments (task file, workspace, attempt directory, current step; see the `TR_SPAWN_STEP` call in `scripts/task-runner.sh`), and each step must write the `step-result.json` described in [`DESIGN-task-runner.md`](../DESIGN-task-runner.md) — and run it end to end:
 
 ```sh
 scripts/loop-init --workspace "$WORKSPACE"

--- a/docs/plugin-convention.md
+++ b/docs/plugin-convention.md
@@ -38,6 +38,30 @@ Anything not listed above is engine-internal and may change without notice.
    coverage; the engine's watchdogs only watch engine ticks.
 6. **Naming.** Plugin repos are named `<topic>-loop` (e.g. `self-growth-loop`).
 
+## Task execution boundary
+
+- Every task frontmatter must declare `receipt: out/<path>`. The exact grammar is
+  `^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$`; `.` and `..` path segments are also
+  forbidden. The runner delivers only when that target is a non-symlink, non-empty
+  regular file whose resolved path remains under the task's resolved `out/` directory.
+  Queue-dropped legacy tasks with a missing or invalid value go to DLQ with
+  `missing-receipt` before a model attempt.
+- A donecheck opener is a column-zero `` ```donecheck `` line with only trailing
+  whitespace; its closer is the first subsequent column-zero `` ``` `` line with
+  only trailing whitespace. Exactly one closed block is required. Because extraction
+  is deliberately textual, a column-zero fence inside a shell heredoc closes the
+  block: plugins must not put column-zero Markdown fences inside donecheck heredocs.
+- Donechecks run with `env -i`. The supplied variables are `TASK_ID`, `TASK_FILE`,
+  `ARTIFACT_DIR`, `TR_DC_CWD`, `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, and `HOME`, plus
+  `LANG`, `LC_ALL`, and `TZ` only when the runner has them. The shell also creates
+  variables such as `PWD`, `SHLVL`, and `_`. Donechecks that depended on any other
+  inherited variable, including `TR_PUSH_CMD`, break loudly at their next run.
+- `TR_SPAWN_STEP` must be an absolute path to an executable file. PATH-resolved
+  command names and relative configurations must migrate to an absolute provider path.
+- Workspace initialization records the absolute Bash and Perl used for validation
+  and execution in `loop/.tr-interpreters`. Existing workspaces self-heal this record
+  on first enqueue or runner use; invalid recorded paths fail closed.
+
 ## Extraction policy (avoiding premature frameworks)
 
 Shared machinery (ledger schema, council runner, approval queue) starts life inside

--- a/docs/plugin-convention.md
+++ b/docs/plugin-convention.md
@@ -43,7 +43,8 @@ Anything not listed above is engine-internal and may change without notice.
 - Every task frontmatter must declare `receipt: out/<path>`. The exact grammar is
   `^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$`; `.` and `..` path segments are also
   forbidden. The runner delivers only when that target is a non-symlink, non-empty
-  regular file whose resolved path remains under the task's resolved `out/` directory.
+  regular file whose resolved path remains under the task artifact's own non-symlink
+  `out/` directory.
   Queue-dropped legacy tasks with a missing or invalid value go to DLQ with
   `missing-receipt` before a model attempt.
 - A donecheck opener is a column-zero `` ```donecheck `` line with only trailing
@@ -52,10 +53,14 @@ Anything not listed above is engine-internal and may change without notice.
   is deliberately textual, a column-zero fence inside a shell heredoc closes the
   block: plugins must not put column-zero Markdown fences inside donecheck heredocs.
 - Donechecks run with `env -i`. The supplied variables are `TASK_ID`, `TASK_FILE`,
-  `ARTIFACT_DIR`, `TR_DC_CWD`, `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, and `HOME`, plus
+  `ARTIFACT_DIR`, `TR_DC_CWD`, and `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, plus `HOME`,
   `LANG`, `LC_ALL`, and `TZ` only when the runner has them. The shell also creates
-  variables such as `PWD`, `SHLVL`, and `_`. Donechecks that depended on any other
-  inherited variable, including `TR_PUSH_CMD`, break loudly at their next run.
+  variables such as `PWD`, `SHLVL`, and `_`. Because `PATH` is fixed, tools such as
+  `python3` must be reachable there or invoked by absolute path in donechecks. The
+  bundled `templates/examples/img-pilot.task.md` donecheck depends on `python3` in
+  that `PATH`; macOS ships `/usr/bin/python3`, while Linux distributions may not.
+  Donechecks that depended on any other inherited variable, including `TR_PUSH_CMD`,
+  break loudly at their next run.
 - `TR_SPAWN_STEP` must be an absolute path to an executable file. PATH-resolved
   command names and relative configurations must migrate to an absolute provider path.
 - Workspace initialization records the absolute Bash and Perl used for validation

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -67,13 +67,16 @@ flush intake consumer の会計 ledger は `loop/pending/intake-runs.log` です
 - task frontmatter の `receipt:` は
   `^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$` に一致し、`.` と `..` の segment を
   含んではいけません。delivery にはさらに、その target が symlink ではない non-empty な
-  regular file で、解決後も task artifact の `out/` 配下にあることが必要です。
+  regular file で、解決後も task artifact 自身の symlink ではない `out/` 配下にあることが必要です。
 - donecheck fence は column zero から始めます。heredoc 内の column-zero fence も文字列として
   extraction を終了させるため、使用禁止です。
 - donecheck に渡るのは `TASK_ID`、`TASK_FILE`、`ARTIFACT_DIR`、`TR_DC_CWD`、固定の
-  `PATH=/usr/bin:/bin:/usr/sbin:/sbin`、`HOME`、runner 側で set 済みの
-  `LANG`/`LC_ALL`/`TZ`、および shell が作る変数だけです。それ以外の継承変数は消え、
-  依存していた check は次回実行時に明示的に失敗します。
+  `PATH=/usr/bin:/bin:/usr/sbin:/sbin`、runner 側で set 済みの
+  `HOME`/`LANG`/`LC_ALL`/`TZ`、および shell が作る変数だけです。`python3` などの tool は
+  この固定 `PATH` から到達できるか、donecheck 内で絶対パス指定する必要があります。
+  同梱の `templates/examples/img-pilot.task.md` の donecheck はこの `PATH` 内の `python3` に
+  依存します。macOS には `/usr/bin/python3` がありますが、Linux distribution にはない場合が
+  あります。それ以外の継承変数は消え、依存していた check は次回実行時に明示的に失敗します。
 - `TR_SPAWN_STEP` は1個の argv として実行され、実行可能な通常ファイルへの絶対パスが必須です。
   relative または PATH lookup 前提の provider 設定は runner 実行前に移行してください。
 

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -32,6 +32,9 @@
 | `--enable --workspace <dir> [--dry-run]` | pause を解除。harness 所有の通常 `DISABLED` marker だけを削除し、悪意ある marker object は決して辿らない |
 
 追記される bootstrap block の冪等 marker は、リテラル行 `# caty-agent-harness bootstrap v2` です（機械用の marker であり、プロダクト名を変更しても rename しません）。
+workspace 初期化時には `loop/.tr-interpreters` も作成されます。これは donecheck の
+validation と execution の両方で使う Bash / Perl の絶対パスを記録した2行のファイルです。
+既存 workspace では最初の enqueue または runner 実行時に自己修復し、不正な記録は fail closed になります。
 
 ---
 
@@ -58,6 +61,21 @@
 ## Flush intake consumer の receipt
 
 flush intake consumer の会計 ledger は `loop/pending/intake-runs.log` です。deadman の `distill` marker が証明するのは intake が実行されたことだけです。内容レベルの沈黙・dedup・deferral・eviction・quarantine の各件数は ledger で確認します。`loop/archive/` は append-only で、自動で prune されることはありません。ledger の詳しい形式と schedule は [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) を参照してください。
+
+## task-runner の実行境界
+
+- task frontmatter の `receipt:` は
+  `^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$` に一致し、`.` と `..` の segment を
+  含んではいけません。delivery にはさらに、その target が symlink ではない non-empty な
+  regular file で、解決後も task artifact の `out/` 配下にあることが必要です。
+- donecheck fence は column zero から始めます。heredoc 内の column-zero fence も文字列として
+  extraction を終了させるため、使用禁止です。
+- donecheck に渡るのは `TASK_ID`、`TASK_FILE`、`ARTIFACT_DIR`、`TR_DC_CWD`、固定の
+  `PATH=/usr/bin:/bin:/usr/sbin:/sbin`、`HOME`、runner 側で set 済みの
+  `LANG`/`LC_ALL`/`TZ`、および shell が作る変数だけです。それ以外の継承変数は消え、
+  依存していた check は次回実行時に明示的に失敗します。
+- `TR_SPAWN_STEP` は1個の argv として実行され、実行可能な通常ファイルへの絶対パスが必須です。
+  relative または PATH lookup 前提の provider 設定は runner 実行前に移行してください。
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -32,6 +32,9 @@ Exact flags, states, and the contract documents. When this page and a design doc
 | `--enable --workspace <dir> [--dry-run]` | resume a paused workspace; removes only the harness-owned regular `DISABLED` marker and never follows hostile marker objects |
 
 The idempotency marker for appended bootstrap blocks is the literal line `# caty-agent-harness bootstrap v2` (a machine marker; it is not renamed when the product name changes).
+Workspace initialization also creates `loop/.tr-interpreters`, a two-line record of
+the absolute Bash and Perl executables used by both donecheck validation and execution.
+Pre-existing workspaces create it on first enqueue/runner use; invalid entries fail closed.
 
 ---
 
@@ -58,6 +61,21 @@ The idempotency marker for appended bootstrap blocks is the literal line `# caty
 ## Flush intake consumer receipts
 
 The flush intake consumer's accounting ledger is `loop/pending/intake-runs.log`. The deadman `distill` marker proves only that intake ran; inspect the ledger for content-level silence, dedup, deferral, eviction, and quarantine counts. `loop/archive/` is append-only and is never auto-pruned. See [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) for the full ledger format and scheduling.
+
+## Task-runner execution boundary
+
+- Task frontmatter requires `receipt:` matching
+  `^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$`, with `.` and `..` segments forbidden.
+  Delivery additionally requires that target to be a non-symlink, non-empty regular
+  file resolving inside the task artifact's `out/` directory.
+- Donecheck fences must start at column zero. A column-zero fence inside a heredoc
+  terminates extraction textually and is therefore prohibited.
+- Donechecks receive only `TASK_ID`, `TASK_FILE`, `ARTIFACT_DIR`, `TR_DC_CWD`, fixed
+  `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, `HOME`, and any set `LANG`/`LC_ALL`/`TZ`, plus
+  shell-created variables. Other inherited variables disappear and dependent checks
+  fail loudly.
+- `TR_SPAWN_STEP` is one argv word and must be an absolute executable-file path.
+  Migrate relative or PATH-resolved provider configurations before running the runner.
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -67,12 +67,15 @@ The flush intake consumer's accounting ledger is `loop/pending/intake-runs.log`.
 - Task frontmatter requires `receipt:` matching
   `^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$`, with `.` and `..` segments forbidden.
   Delivery additionally requires that target to be a non-symlink, non-empty regular
-  file resolving inside the task artifact's `out/` directory.
+  file resolving inside the task artifact's own non-symlink `out/` directory.
 - Donecheck fences must start at column zero. A column-zero fence inside a heredoc
   terminates extraction textually and is therefore prohibited.
 - Donechecks receive only `TASK_ID`, `TASK_FILE`, `ARTIFACT_DIR`, `TR_DC_CWD`, fixed
-  `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, `HOME`, and any set `LANG`/`LC_ALL`/`TZ`, plus
-  shell-created variables. Other inherited variables disappear and dependent checks
+  `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, any set `HOME`/`LANG`/`LC_ALL`/`TZ`, and
+  shell-created variables. Tools such as `python3` must be reachable in that fixed
+  `PATH` or invoked by absolute path. The bundled `templates/examples/img-pilot.task.md`
+  donecheck depends on `python3` there; macOS ships `/usr/bin/python3`, while Linux
+  distributions may not. Other inherited variables disappear and dependent checks
   fail loudly.
 - `TR_SPAWN_STEP` is one argv word and must be an absolute executable-file path.
   Migrate relative or PATH-resolved provider configurations before running the runner.

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,8 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$repo_root/scripts/lib-wrapper-conformance.sh"
 # shellcheck disable=SC1091
 source "$repo_root/scripts/lib-pause.sh"
+# shellcheck disable=SC1091
+source "$repo_root/scripts/lib-donecheck.sh"
 legacy_marker_line="# fable-loop bootstrap v1"
 current_marker_line="# caty-agent-harness bootstrap v2"
 
@@ -483,6 +485,8 @@ run_loop_init() {
   local workspace=$1
 
   "$repo_root/scripts/loop-init" --workspace "$workspace"
+  workspace=$(cd "$workspace" && pwd -P)
+  caty_load_interpreters "$workspace" || exit 2
 }
 
 print_hermes_next_steps() {

--- a/scripts/activation-manifest.tsv
+++ b/scripts/activation-manifest.tsv
@@ -18,6 +18,7 @@ scripts/attest-wrapper	exempt	none	not-applicable	setup-time-wrapper-attestation
 scripts/family-updater	exempt	none	not-applicable	harness-clone-updater-not-member-workspace	-	-
 scripts/lib-bounded.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-classify.sh	exempt	none	not-applicable	sourced-library	-	-
+scripts/lib-donecheck.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-pause.sh	exempt	explicit-function-argument	not-applicable	sourced-library	-	-
 scripts/lib-state-fold.sh	exempt	explicit-function-argument	not-applicable	sourced-library	-	-
 scripts/lib-wrapper-conformance.sh	exempt	none	not-applicable	sourced-library	-	-

--- a/scripts/lib-donecheck.sh
+++ b/scripts/lib-donecheck.sh
@@ -69,7 +69,10 @@ caty_valid_receipt() {
   local value=$1
   local old_ifs segment first=1 segments=0
 
-  printf '%s\n' "$value" | grep -Eq '^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$' || return 1
+  case "$value" in
+    *$'\n'*) return 1 ;;
+  esac
+  printf '%s\n' "$value" | grep -Eqx '^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$' || return 1
   old_ifs=$IFS
   IFS=/
   # Intentional word splitting: the regex above has already excluded empty

--- a/scripts/lib-donecheck.sh
+++ b/scripts/lib-donecheck.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+# Shared donecheck and interpreter contracts. Callers are responsible for
+# turning the extractor status into the user-facing enqueue/verification error.
+
+caty_extract_donecheck() {
+  local task_file=$1
+  local out_file=$2
+
+  python3 -B - "$task_file" "$out_file" <<'PY'
+import re
+import sys
+
+task_file, out_file = sys.argv[1:3]
+try:
+    with open(task_file, "rb") as handle:
+        text = handle.read().decode("utf-8")
+except UnicodeDecodeError:
+    sys.exit(3)
+except OSError:
+    sys.exit(6)
+
+# The task grammar is line-oriented and normalizes CRLF before matching or
+# emitting the extracted bytes.
+text = text.replace("\r\n", "\n")
+lines = text.split("\n")
+opener = re.compile(r"^```donecheck[\t\v\f\r ]*$")
+closer = re.compile(r"^```[\t\v\f\r ]*$")
+
+openers = []
+for index, line in enumerate(lines):
+    if opener.fullmatch(line):
+        openers.append(index)
+
+if not openers:
+    sys.exit(2)
+if len(openers) != 1:
+    sys.exit(4)
+
+start = openers[0]
+end = None
+for index in range(start + 1, len(lines)):
+    line = lines[index]
+    if closer.fullmatch(line):
+        end = index
+        break
+if end is None:
+    sys.exit(5)
+
+with open(out_file, "wb") as handle:
+    content = "\n".join(lines[start + 1:end])
+    if end > start + 1:
+        content += "\n"
+    handle.write(content.encode("utf-8"))
+PY
+}
+
+caty_donecheck_error() {
+  case "$1" in
+    2) printf '%s\n' 'missing donecheck block' ;;
+    3) printf '%s\n' 'task file is not valid UTF-8' ;;
+    4) printf '%s\n' 'multiple donecheck blocks' ;;
+    5) printf '%s\n' 'unclosed donecheck block' ;;
+    *) printf 'donecheck extraction failed (exit %s)\n' "$1" ;;
+  esac
+}
+
+caty_valid_receipt() {
+  local value=$1
+  local old_ifs segment first=1 segments=0
+
+  printf '%s\n' "$value" | grep -Eq '^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$' || return 1
+  old_ifs=$IFS
+  IFS=/
+  # Intentional word splitting: the regex above has already excluded empty
+  # segments and all characters outside the frozen receipt grammar.
+  # shellcheck disable=SC2086
+  set -- $value
+  IFS=$old_ifs
+  for segment in "$@"; do
+    segments=$((segments + 1))
+    if [ "$first" -eq 1 ]; then
+      [ "$segment" = out ] || return 1
+      first=0
+      continue
+    fi
+    [ "$segment" != . ] && [ "$segment" != .. ] || return 1
+  done
+  [ "$segments" -ge 2 ]
+}
+
+caty_resolve_command() {
+  local name=$1
+  local resolved parent
+  resolved=$(command -v "$name" 2>/dev/null) || return 1
+  case "$resolved" in
+    /*) ;;
+    */*)
+      parent=$(cd -P -- "$(dirname "$resolved")" 2>/dev/null && pwd) || return 1
+      resolved=$parent/$(basename "$resolved")
+      ;;
+    *) return 1 ;;
+  esac
+  [ -x "$resolved" ] || return 1
+  printf '%s\n' "$resolved"
+}
+
+caty_read_interpreters() {
+  local record=$1
+  local line key value count=0 bash_value='' perl_value=''
+
+  [ -f "$record" ] && [ -r "$record" ] || {
+    printf 'invalid interpreter record: file=%s value=<unreadable>\n' "$record" >&2
+    return 1
+  }
+  while IFS= read -r line || [ -n "$line" ]; do
+    count=$((count + 1))
+    key=${line%%=*}
+    value=${line#*=}
+    [ "$line" != "$key" ] || {
+      printf 'invalid interpreter record: file=%s value=%s\n' "$record" "$line" >&2
+      return 1
+    }
+    case "$key" in
+      TR_BASH)
+        [ -z "$bash_value" ] || {
+          printf 'invalid interpreter record: file=%s value=%s\n' "$record" "$line" >&2
+          return 1
+        }
+        bash_value=$value
+        ;;
+      TR_PERL)
+        [ -z "$perl_value" ] || {
+          printf 'invalid interpreter record: file=%s value=%s\n' "$record" "$line" >&2
+          return 1
+        }
+        perl_value=$value
+        ;;
+      *)
+        printf 'invalid interpreter record: file=%s value=%s\n' "$record" "$line" >&2
+        return 1
+        ;;
+    esac
+  done <"$record"
+
+  [ "$count" -eq 2 ] || {
+    printf 'invalid interpreter record: file=%s value=<expected-two-lines>\n' "$record" >&2
+    return 1
+  }
+  for value in "$bash_value" "$perl_value"; do
+    case "$value" in
+      /*) ;;
+      *)
+        printf 'invalid interpreter record: file=%s value=%s\n' "$record" "$value" >&2
+        return 1
+        ;;
+    esac
+    [ -x "$value" ] || {
+      printf 'invalid interpreter record: file=%s value=%s\n' "$record" "$value" >&2
+      return 1
+    }
+  done
+
+  TR_BASH=$bash_value
+  TR_PERL=$perl_value
+  export TR_BASH TR_PERL
+}
+
+caty_load_interpreters() {
+  local workspace=$1
+  local record="$workspace/loop/.tr-interpreters"
+  local bash_value perl_value tmp
+
+  if [ ! -e "$record" ]; then
+    bash_value=$(caty_resolve_command bash) || {
+      printf 'cannot resolve interpreter: file=%s value=bash\n' "$record" >&2
+      return 1
+    }
+    perl_value=$(caty_resolve_command perl) || {
+      printf 'cannot resolve interpreter: file=%s value=perl\n' "$record" >&2
+      return 1
+    }
+    mkdir -p "$workspace/loop" || return 1
+    tmp="$record.tmp.$$.$RANDOM"
+    if (umask 077; set -C; printf 'TR_BASH=%s\nTR_PERL=%s\n' "$bash_value" "$perl_value" >"$tmp") 2>/dev/null; then
+      if ! mv -n "$tmp" "$record" 2>/dev/null; then
+        rm -f "$tmp"
+      fi
+      # BSD mv -n returns success when it declines to replace. Remove the
+      # losing temporary record and always re-read the winner.
+      rm -f "$tmp"
+    fi
+  fi
+  caty_read_interpreters "$record"
+}

--- a/scripts/task-runner.sh
+++ b/scripts/task-runner.sh
@@ -42,6 +42,7 @@ esac
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$script_dir/.." && pwd)
 source "$repo_root/scripts/lib-pause.sh"
+source "$repo_root/scripts/lib-donecheck.sh"
 workspace=$(caty_pause_canonical_workspace "$workspace" 2>/dev/null) || {
   printf 'invalid workspace: %s\n' "$workspace" >&2
   exit 2
@@ -54,6 +55,13 @@ fi
 
 if [[ -z "$TR_SPAWN_STEP" ]]; then
   printf 'TR_SPAWN_STEP is required\n' >&2
+  exit 2
+fi
+if [[ "$TR_SPAWN_STEP" != /* ]] || [[ ! -f "$TR_SPAWN_STEP" ]] || [[ ! -x "$TR_SPAWN_STEP" ]]; then
+  printf 'TR_SPAWN_STEP must be an absolute executable file: value=%s\n' "$TR_SPAWN_STEP" >&2
+  exit 2
+fi
+if ! caty_load_interpreters "$workspace"; then
   exit 2
 fi
 
@@ -145,8 +153,10 @@ with open(path, encoding="utf-8") as f:
             value = unquote(value)
             if value in ("null", "~"):
                 value = ""
-            meta[key.strip()] = value
-for key in ("id", "created", "attempts_budget", "time_budget_min", "parent_id"):
+            key = key.strip()
+            if key not in meta:
+                meta[key] = value
+for key in ("id", "created", "attempts_budget", "time_budget_min", "parent_id", "receipt"):
     print("%s=%s" % (key, shlex.quote(meta.get(key, ""))))
 PY
 )"
@@ -881,28 +891,6 @@ PY
   rm -f "$prompt_tmp"
 }
 
-extract_donecheck() {
-  local task_file=$1
-  local out_file=$2
-  python3 - "$task_file" "$out_file" <<'PY'
-import sys
-task, out = sys.argv[1:3]
-inside = False
-lines = []
-for raw in open(task, encoding="utf-8"):
-    line = raw.rstrip("\n")
-    if line.strip() == "```donecheck":
-        inside = True
-        continue
-    if inside and line.strip() == "```":
-        break
-    if inside:
-        lines.append(raw)
-with open(out, "w", encoding="utf-8") as f:
-    f.writelines(lines)
-PY
-}
-
 run_donecheck() {
   local task_id=$1
   local task_file=$2
@@ -913,11 +901,18 @@ run_donecheck() {
   local log_file="$attempt_dir/donecheck.log"
   local trace_file="$attempt_dir/donecheck.trace"
   local failing_file="$attempt_dir/donecheck.failing"
-  rm -f "$trace_file" "$failing_file"
-  extract_donecheck "$task_file" "$check_file"
-  # The generated header is exactly 3 lines. Keep this constant adjacent to
+  rm -f "$check_file" "$trace_file" "$failing_file"
+  local extract_rc
+  if caty_extract_donecheck "$task_file" "$check_file"; then
+    :
+  else
+    extract_rc=$?
+    printf '%s\n' "$(caty_donecheck_error "$extract_rc")" >"$log_file"
+    return 125
+  fi
+  # The generated header is exactly 7 lines. Keep this constant adjacent to
   # the header so donecheck.failing remains relative to the user's script.
-  local donecheck_header_lines=3
+  local donecheck_header_lines=7
   local donecheck_err_trap
   donecheck_err_trap=$(cat <<'ERR_TRAP'
 __tr_dc_line=$LINENO
@@ -940,13 +935,34 @@ ERR_TRAP
     printf '%s\n' 'set -o errtrace'
     printf 'readonly __TR_DC_TRACE=%q\n' "$trace_file"
     printf 'trap %q ERR\n' "$donecheck_err_trap"
+    # These are best-effort process limits: some platforms refuse lowering a
+    # specific resource, so each limit deliberately preserves gate execution.
+    printf 'ulimit -t %q || true\n' "$(( TR_DONECHECK_TIMEOUT_S + 60 ))"
+    printf '%s\n' 'ulimit -f 2097152 || true'
+    printf '%s\n' 'ulimit -n 256 || true'
+    # RLIMIT_NPROC is per user on macOS. Do not lower it below the runner's
+    # already-live user process count, and skip when sandboxed ps cannot observe it.
+    printf '%s\n' '__tr_dc_nproc_count=$(ps -U "$(id -u)" -o pid= 2>/dev/null | wc -l | tr -d "[:space:]" || true); if [[ "$__tr_dc_nproc_count" =~ ^[0-9]+$ ]] && (( __tr_dc_nproc_count > 0 && __tr_dc_nproc_count < 480 )); then ulimit -u 512 || true; fi'
     cat "$check_file"
   } >"$wrapped_file"
   # Own process group so a timeout kills the whole donecheck tree, not just
   # the wrapper (orphaned children would keep mutating artifacts).
-  TASK_ID="$task_id" TASK_FILE="$task_file" ARTIFACT_DIR="$artifact_dir" TR_DC_CWD="$workspace" \
-    perl -MPOSIX=setsid -e 'setsid() or die "setsid: $!"; chdir $ENV{TR_DC_CWD} or die "chdir: $!"; exec @ARGV or die "exec: $!"' \
-    bash -euo pipefail "$wrapped_file" >"$log_file" 2>&1 &
+  local -a donecheck_env
+  donecheck_env=(
+    env -i
+    "TASK_ID=$task_id"
+    "TASK_FILE=$task_file"
+    "ARTIFACT_DIR=$artifact_dir"
+    "TR_DC_CWD=$workspace"
+    "PATH=/usr/bin:/bin:/usr/sbin:/sbin"
+    "HOME=${HOME-}"
+  )
+  [[ ${LANG+x} ]] && donecheck_env+=("LANG=$LANG")
+  [[ ${LC_ALL+x} ]] && donecheck_env+=("LC_ALL=$LC_ALL")
+  [[ ${TZ+x} ]] && donecheck_env+=("TZ=$TZ")
+  "${donecheck_env[@]}" \
+    "$TR_PERL" -MPOSIX=setsid -e 'setsid() or die "setsid: $!"; chdir $ENV{TR_DC_CWD} or die "chdir: $!"; exec @ARGV or die "exec: $!"' \
+    "$TR_BASH" -euo pipefail "$wrapped_file" >"$log_file" 2>&1 &
   local pid=$!
   local start=$SECONDS
   while kill -0 "$pid" 2>/dev/null; do
@@ -976,6 +992,26 @@ ERR_TRAP
     tail -n 1 "$trace_file" >"$failing_file"
   fi
   return "$donecheck_rc"
+}
+
+assert_delivery_receipt() {
+  local artifact_dir=$1
+  local receipt=$2
+  local target="$artifact_dir/$receipt"
+
+  [[ ! -L "$target" ]] && [[ -f "$target" ]] && [[ -s "$target" ]] || return 1
+  python3 -B - "$artifact_dir" "$target" <<'PY'
+import os
+import sys
+
+artifact_dir, target = sys.argv[1:3]
+artifact_real = os.path.realpath(artifact_dir)
+out_real = os.path.realpath(os.path.join(artifact_real, "out"))
+target_real = os.path.realpath(target)
+prefix = out_real.rstrip(os.sep) + os.sep
+if not target_real.startswith(prefix):
+    sys.exit(1)
+PY
 }
 
 gap_fingerprint_of() {
@@ -1379,7 +1415,7 @@ push_dlq_report() {
   ( umask 077; : >>"$push_log" ) || true
   push_output=$(mktemp "$dest/.push-output.XXXXXX")
   printf '\n== push attempt %s dest=%s ==\n' "$attempted_at" "$dest" >>"$push_log" || true
-  if bash -c "$TR_PUSH_CMD \"\$1\"" _ "$report_file" >"$push_output" 2>&1; then
+  if "$TR_BASH" -c "$TR_PUSH_CMD \"\$1\"" _ "$report_file" >"$push_output" 2>&1; then
     push_rc=0
   else
     push_rc=$?
@@ -1558,8 +1594,19 @@ finalize_attempt() {
     exit 137
   fi
 
-  local donecheck_rc
+  local donecheck_rc verification_passed=0
   if run_donecheck "$task_id" "$task_file" "$artifact_dir" "$attempt_dir"; then
+    if assert_delivery_receipt "$artifact_dir" "$receipt"; then
+      verification_passed=1
+    else
+      donecheck_rc=1
+      printf 'delivery receipt missing or invalid: %s\n' "$receipt" >"$attempt_dir/verify-reason" || true
+      printf 'delivery receipt missing or invalid: %s\n' "$receipt" >>"$attempt_dir/donecheck.log" || true
+    fi
+  else
+    donecheck_rc=$?
+  fi
+  if (( verification_passed )); then
     # Test-only crash injection point: verifies recovery after the gate passed.
     if [[ "$TR_CRASH_AFTER" = "donecheck-pass" ]]; then
       exit 137
@@ -1567,10 +1614,11 @@ finalize_attempt() {
     deliver_task "$task_file" "$artifact_dir"
     return 0
   else
-    donecheck_rc=$?
     if (( donecheck_rc == 124 )); then
       printf 'donecheck timed out after %ss\n' "$TR_DONECHECK_TIMEOUT_S" >"$attempt_dir/verify-reason" || true
-    else
+    elif (( donecheck_rc == 125 )); then
+      cp "$attempt_dir/donecheck.log" "$attempt_dir/verify-reason" || true
+    elif (( donecheck_rc != 1 )) || [[ ! -s "$attempt_dir/verify-reason" ]]; then
       printf 'donecheck failed (exit %d)\n' "$donecheck_rc" >"$attempt_dir/verify-reason" || true
     fi
     if [[ "$step_complete" = "true" ]]; then
@@ -1625,17 +1673,34 @@ recover_verifying() {
     task_id=$(basename "$artifact_dir")
     local task_file="$queue_dir/$task_id.task.md"
     [[ -f "$task_file" ]] || continue
+    load_task_meta "$task_file"
+    if ! caty_valid_receipt "$receipt"; then
+      dlq_task "$task_file" "$artifact_dir" missing-receipt
+      continue
+    fi
     local attempt_dir
     attempt_dir=$(find "$artifact_dir/attempts" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | tail -n 1)
     [[ -n "$attempt_dir" ]] || continue
-    local donecheck_rc
+    local donecheck_rc verification_passed=0
     if run_donecheck "$task_id" "$task_file" "$artifact_dir" "$attempt_dir"; then
-      deliver_task "$task_file" "$artifact_dir"
+      if assert_delivery_receipt "$artifact_dir" "$receipt"; then
+        verification_passed=1
+      else
+        donecheck_rc=1
+        printf 'delivery receipt missing or invalid: %s\n' "$receipt" >"$attempt_dir/verify-reason" || true
+        printf 'delivery receipt missing or invalid: %s\n' "$receipt" >>"$attempt_dir/donecheck.log" || true
+      fi
     else
       donecheck_rc=$?
+    fi
+    if (( verification_passed )); then
+      deliver_task "$task_file" "$artifact_dir"
+    else
       if (( donecheck_rc == 124 )); then
         printf 'donecheck timed out after %ss\n' "$TR_DONECHECK_TIMEOUT_S" >"$attempt_dir/verify-reason" || true
-      else
+      elif (( donecheck_rc == 125 )); then
+        cp "$attempt_dir/donecheck.log" "$attempt_dir/verify-reason" || true
+      elif (( donecheck_rc != 1 )) || [[ ! -s "$attempt_dir/verify-reason" ]]; then
         printf 'donecheck failed (exit %d)\n' "$donecheck_rc" >"$attempt_dir/verify-reason" || true
       fi
       # A crash inside the verifying window loses finalize_attempt's local
@@ -1897,6 +1962,10 @@ run_one_attempt() {
     return 0
   fi
   [[ "$status" = "queued" ]] || return 0
+  if ! caty_valid_receipt "$receipt"; then
+    dlq_task "$task_file" "$artifact_dir" missing-receipt
+    return 0
+  fi
 
   local nnn
   nnn=$(printf '%03d' $(( attempts_used + 1 )))
@@ -1908,8 +1977,8 @@ run_one_attempt() {
   started_at=$(utc_now)
   local owner_sentinel="$attempt_dir/owner.sentinel"
   local owner_nonce="sentinel:$started_at:$$:$RANDOM:$nnn"
-  perl -MPOSIX=setsid -e 'setsid() or die "setsid: $!"; exec @ARGV or die "exec: $!"' \
-    bash -c 'sentinel=$1; nonce=$2; shift 2; printf "%s\n" "$nonce" >"$sentinel"; "$@"; rc=$?; rm -f "$sentinel"; exit "$rc"' \
+  "$TR_PERL" -MPOSIX=setsid -e 'setsid() or die "setsid: $!"; exec @ARGV or die "exec: $!"' \
+    "$TR_BASH" -c 'sentinel=$1; nonce=$2; shift 2; printf "%s\n" "$nonce" >"$sentinel"; "$@"; rc=$?; rm -f "$sentinel"; exit "$rc"' \
     _ "$owner_sentinel" "$owner_nonce" "$TR_SPAWN_STEP" "$task_file" "$workspace" "$attempt_dir" "$current_step" >"$attempt_dir/model.stdout" 2>"$attempt_dir/model.stderr" &
   local pid=$!
   local pgid=$pid

--- a/scripts/task-runner.sh
+++ b/scripts/task-runner.sh
@@ -955,8 +955,8 @@ ERR_TRAP
     "ARTIFACT_DIR=$artifact_dir"
     "TR_DC_CWD=$workspace"
     "PATH=/usr/bin:/bin:/usr/sbin:/sbin"
-    "HOME=${HOME-}"
   )
+  [[ ${HOME+x} ]] && donecheck_env+=("HOME=$HOME")
   [[ ${LANG+x} ]] && donecheck_env+=("LANG=$LANG")
   [[ ${LC_ALL+x} ]] && donecheck_env+=("LC_ALL=$LC_ALL")
   [[ ${TZ+x} ]] && donecheck_env+=("TZ=$TZ")
@@ -1006,9 +1006,11 @@ import sys
 
 artifact_dir, target = sys.argv[1:3]
 artifact_real = os.path.realpath(artifact_dir)
-out_real = os.path.realpath(os.path.join(artifact_real, "out"))
+out_dir = os.path.join(artifact_real, "out")
+if os.path.realpath(out_dir) != out_dir or not os.path.isdir(out_dir):
+    sys.exit(1)
 target_real = os.path.realpath(target)
-prefix = out_real.rstrip(os.sep) + os.sep
+prefix = out_dir + os.sep
 if not target_real.startswith(prefix):
     sys.exit(1)
 PY
@@ -1545,6 +1547,10 @@ finalize_attempt() {
   local charge_s=$4
   local state_file="$artifact_dir/state.json"
   load_task_meta "$task_file"
+  if ! caty_valid_receipt "$receipt"; then
+    dlq_task "$task_file" "$artifact_dir" missing-receipt
+    return 0
+  fi
   local task_id=$id
   local attempts_budget_value=${attempts_budget:-0}
   local time_budget_s=$(( ${time_budget_min:-0} * 60 ))
@@ -1902,7 +1908,9 @@ for path in glob.glob(os.path.join(queue, "*.task.md")):
             break
         if in_fm and ":" in line:
             k, v = line.split(":", 1)
-            meta[k.strip()] = unquote(v)
+            key = k.strip()
+            if key not in meta:
+                meta[key] = unquote(v)
     task_id = meta.get("id")
     if not task_id:
         continue

--- a/scripts/tr-enqueue
+++ b/scripts/tr-enqueue
@@ -131,7 +131,8 @@ mkdir -p "$queue_dir" "$delivered_dir" "$dlq_dir" >/dev/null 2>&1 || fail "canno
 mkdir -p "$artifacts_root" >/dev/null 2>&1 || fail "artifacts dir not writable: directory='$artifacts_root'"
 
 install_tmp=$queue_dir/.$route_id.task.md.tmp.$$
-tmp_donecheck=${TMPDIR:-/tmp}/tr-enqueue-donecheck.$$
+tmp_donecheck=$(mktemp "${TMPDIR:-/tmp}/tr-enqueue-donecheck.XXXXXX") \
+  || fail "cannot create donecheck temp file"
 trap 'rm -f "$tmp_donecheck" "$install_tmp"' EXIT HUP INT TERM
 if ! cp "$task_file" "$install_tmp"; then
   rm -f "$install_tmp"

--- a/scripts/tr-enqueue
+++ b/scripts/tr-enqueue
@@ -45,16 +45,6 @@ has_section() {
   grep -Eq "^##[[:space:]]+$section[[:space:]]*$" "$file"
 }
 
-extract_donecheck() {
-  file=$1
-  awk '
-    /^```donecheck[[:space:]]*$/ { in_block = 1; found = 1; next }
-    in_block && /^```[[:space:]]*$/ { exit }
-    in_block { print }
-    END { if (!found) exit 2 }
-  ' "$file"
-}
-
 extract_plan_steps() {
   file=$1
   awk '
@@ -92,16 +82,12 @@ is_safe_id() {
   printf '%s\n' "$value" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$'
 }
 
-strip_donecheck_comments() {
-  input=$1
-  output=$2
-  sed 's/[[:space:]]*#.*$//' "$input" | sed '/^[[:space:]]*$/d' > "$output"
-}
-
-has_receipt_assertion() {
-  file=$1
-  grep -Eq '^[[:space:]]*test[[:space:]]+-(s|f)[[:space:]]+["'\'']?\$ARTIFACT_DIR/out/[^"'\''[:space:]]*receipt[^"'\''[:space:]]*["'\'']?([[:space:]]|$)' "$file" \
-    || grep -Eq '^[[:space:]]*grep[[:space:]]+-q([[:space:]]+[^[:space:]]+)+[[:space:]]+["'\'']?\$ARTIFACT_DIR/out/[^"'\''[:space:]]*receipt[^"'\''[:space:]]*["'\'']?([[:space:]]|$)' "$file"
+is_utf8_file() {
+  python3 -B - "$1" <<'PY'
+import sys
+with open(sys.argv[1], "rb") as handle:
+    handle.read().decode("utf-8")
+PY
 }
 
 [ "$#" -eq 2 ] || usage
@@ -114,6 +100,7 @@ install_tmp=''
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$script_dir/lib-pause.sh"
+source "$script_dir/lib-donecheck.sh"
 [ -d "$workspace" ] || fail "workspace dir not found: directory='$workspace'"
 workspace=$(caty_pause_canonical_workspace "$workspace") || fail "invalid workspace: directory='$workspace_input'"
 pause_state=$(caty_pause_workspace_state "$workspace")
@@ -125,14 +112,50 @@ fi
 [ -f "$task_file" ] || fail "task file not found: file='$task_file'"
 [ -r "$task_file" ] || fail "task file not readable: file='$task_file'"
 
-id=$(frontmatter_value id "$task_file")
+# Routing needs the caller-side id before the prescribed staging name can be
+# constructed. UTF-8 is checked here so that read is well-defined, then checked
+# again by the extractor against the staged snapshot that gates installation.
+is_utf8_file "$task_file" 2>/dev/null || fail "task file is not valid UTF-8: file='$task_file'"
+route_id=$(frontmatter_value id "$task_file")
+[ -n "$route_id" ] || fail "missing/empty id: file='$task_file'"
+is_safe_id "$route_id" || fail "invalid id: must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$: value='$route_id' file='$task_file'"
+
+loop_dir=$workspace/loop
+queue_dir=$loop_dir/tasks/queue
+delivered_dir=$loop_dir/tasks/delivered
+dlq_dir=$loop_dir/tasks/dlq
+artifacts_root=$loop_dir/artifacts
+artifact_dir=$loop_dir/artifacts/$route_id
+
+mkdir -p "$queue_dir" "$delivered_dir" "$dlq_dir" >/dev/null 2>&1 || fail "cannot create task ledger dirs: directories='$queue_dir $delivered_dir $dlq_dir'"
+mkdir -p "$artifacts_root" >/dev/null 2>&1 || fail "artifacts dir not writable: directory='$artifacts_root'"
+
+install_tmp=$queue_dir/.$route_id.task.md.tmp.$$
+tmp_donecheck=${TMPDIR:-/tmp}/tr-enqueue-donecheck.$$
+trap 'rm -f "$tmp_donecheck" "$install_tmp"' EXIT HUP INT TERM
+if ! cp "$task_file" "$install_tmp"; then
+  rm -f "$install_tmp"
+  fail "failed to install task file: file='$task_file' destination='$queue_dir/$route_id.task.md'"
+fi
+
+if caty_extract_donecheck "$install_tmp" "$tmp_donecheck"; then
+  :
+else
+  extract_rc=$?
+  fail "$(caty_donecheck_error "$extract_rc"): file='$task_file'"
+fi
+
+# Only the caller-side id read needed to choose the dot-prefixed staging path.
+# Every enqueue gate below reads the exact staged bytes that will be installed.
+id=$(frontmatter_value id "$install_tmp")
 [ -n "$id" ] || fail "missing/empty id: file='$task_file'"
 is_safe_id "$id" || fail "invalid id: must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$: value='$id' file='$task_file'"
+[ "$id" = "$route_id" ] || fail "task id changed while staging: expected='$route_id' value='$id' file='$task_file'"
 
-created=$(frontmatter_value created "$task_file")
+created=$(frontmatter_value created "$install_tmp")
 is_utc_iso8601 "$created" || fail "created must be UTC ISO-8601 with seconds: value='$created' file='$task_file'"
 
-parent_id=$(frontmatter_value parent_id "$task_file")
+parent_id=$(frontmatter_value parent_id "$install_tmp")
 case "$parent_id" in
   ''|null|'~') ;;
   *)
@@ -140,48 +163,36 @@ case "$parent_id" in
     ;;
 esac
 
-verify=$(frontmatter_value verify "$task_file")
+verify=$(frontmatter_value verify "$install_tmp")
 [ "$verify" = "mechanical" ] || fail "verify must be mechanical: value='$verify' file='$task_file'"
 
-attempts_budget=$(frontmatter_value attempts_budget "$task_file")
+attempts_budget=$(frontmatter_value attempts_budget "$install_tmp")
 is_positive_integer "$attempts_budget" || fail "attempts_budget must be a positive integer: value='$attempts_budget' file='$task_file'"
 
-time_budget_min=$(frontmatter_value time_budget_min "$task_file")
+time_budget_min=$(frontmatter_value time_budget_min "$install_tmp")
 is_positive_integer "$time_budget_min" || fail "time_budget_min must be a positive integer: value='$time_budget_min' file='$task_file'"
 
 [ "$time_budget_min" -ge "$step_timeout_min" ] || fail "global step_timeout exceeds time_budget_min: value='$time_budget_min' step_timeout_min='$step_timeout_min' file='$task_file'"
 
+receipt=$(frontmatter_value receipt "$install_tmp")
+[ -n "$receipt" ] || fail "missing required frontmatter key: receipt file='$task_file'"
+caty_valid_receipt "$receipt" || fail "invalid receipt: value='$receipt' file='$task_file'"
+
 for section in Goal "Done-when" "Step plan" Resources "Non-goals"; do
-  has_section "$section" "$task_file" || fail "missing required body section: $section file='$task_file'"
+  has_section "$section" "$install_tmp" || fail "missing required body section: $section file='$task_file'"
 done
 
-tmp_donecheck=${TMPDIR:-/tmp}/tr-enqueue-donecheck.$$
-tmp_donecheck_clean=${TMPDIR:-/tmp}/tr-enqueue-donecheck.clean.$$
-trap 'rm -f "$tmp_donecheck" "$tmp_donecheck_clean" "$install_tmp"' EXIT HUP INT TERM
-extract_donecheck "$task_file" > "$tmp_donecheck" || fail "missing donecheck block: file='$task_file'"
-strip_donecheck_comments "$tmp_donecheck" "$tmp_donecheck_clean"
+grep -Eqv '^[[:space:]]*(#.*)?$' "$tmp_donecheck" || fail "missing donecheck block: file='$task_file'"
+caty_load_interpreters "$workspace" || fail "cannot load pinned interpreters: file='$workspace/loop/.tr-interpreters'"
+"$TR_BASH" -n "$tmp_donecheck" >/dev/null 2>&1 || fail "donecheck fails bash -n: file='$task_file'"
 
-[ -s "$tmp_donecheck_clean" ] || fail "missing donecheck block: file='$task_file'"
-has_receipt_assertion "$tmp_donecheck_clean" || fail "donecheck has no delivery receipt assertion: file='$task_file'"
-bash -n "$tmp_donecheck_clean" >/dev/null 2>&1 || fail "donecheck fails bash -n: file='$task_file'"
-
-plan_steps=$(extract_plan_steps "$task_file" | wc -l | tr -d ' ')
+plan_steps=$(extract_plan_steps "$install_tmp" | wc -l | tr -d ' ')
 [ "$plan_steps" -gt 0 ] || fail "missing plan steps: file='$task_file'"
 [ "$plan_steps" -le "$attempts_budget" ] || fail "plan-step count exceeds attempts_budget: value='$plan_steps' attempts_budget='$attempts_budget' file='$task_file'"
 
-last_step=$(extract_plan_steps "$task_file" | tail -n 1)
+last_step=$(extract_plan_steps "$install_tmp" | tail -n 1)
 printf '%s\n' "$last_step" | grep -Eiq 'deliver' || fail "last Step-plan step does not mention deliver/receipt: value='$last_step' file='$task_file'"
 printf '%s\n' "$last_step" | grep -Eiq 'receipt' || fail "last Step-plan step does not mention deliver/receipt: value='$last_step' file='$task_file'"
-
-loop_dir=$workspace/loop
-queue_dir=$loop_dir/tasks/queue
-delivered_dir=$loop_dir/tasks/delivered
-dlq_dir=$loop_dir/tasks/dlq
-artifacts_root=$loop_dir/artifacts
-artifact_dir=$loop_dir/artifacts/$id
-
-mkdir -p "$queue_dir" "$delivered_dir" "$dlq_dir" >/dev/null 2>&1 || fail "cannot create task ledger dirs: directories='$queue_dir $delivered_dir $dlq_dir'"
-mkdir -p "$artifacts_root" >/dev/null 2>&1 || fail "artifacts dir not writable: directory='$artifacts_root'"
 
 if [ -e "$queue_dir/$id.task.md" ] \
   || [ -e "$delivered_dir/$id" ] \
@@ -197,11 +208,6 @@ if [ "$time_budget_min" -lt $((plan_steps * 8)) ]; then
   warn "time_budget_min is less than plan_steps x 8"
 fi
 
-install_tmp=$queue_dir/.$id.task.md.tmp.$$
-if ! cp "$task_file" "$install_tmp"; then
-  rm -f "$install_tmp"
-  fail "failed to install task file: file='$task_file' destination='$queue_dir/$id.task.md'"
-fi
 if ! mkdir "$artifact_dir" >/dev/null 2>&1; then
   rm -f "$install_tmp"
   if [ -d "$artifact_dir" ]; then

--- a/templates/TASK.tmpl.md
+++ b/templates/TASK.tmpl.md
@@ -8,6 +8,7 @@ time_budget_min: 30
 escalate_to: example-operator
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal
@@ -20,11 +21,11 @@ parent_id: null
 donecheck contract:
 - The driver runs this block with bash -euo pipefail.
 - cwd is the workspace root.
-- TASK_ID, TASK_FILE, and ARTIFACT_DIR are exported.
+- TASK_ID, TASK_FILE, ARTIFACT_DIR, and TR_DC_CWD are exported.
 - Assertions are READ-ONLY and may not create, edit, move, or delete files.
 - Runtime timeout is 60 seconds.
 - stdout and stderr are captured to the attempt's donecheck.log.
-- Include a delivery-receipt assertion; delivery is the terminal weak-model failure mode.
+- The runner mechanically asserts the frontmatter receipt after this block exits zero.
 -->
 
 ```donecheck

--- a/templates/examples/img-pilot.task.md
+++ b/templates/examples/img-pilot.task.md
@@ -8,6 +8,7 @@ time_budget_min: 60
 escalate_to: example-operator
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal

--- a/tests/donecheck-extract.test.sh
+++ b/tests/donecheck-extract.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+source "$ROOT/scripts/lib-donecheck.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/donecheck-extract.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+pass_count=0
+fail_count=0
+
+pass() {
+  pass_count=$((pass_count + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+fail() {
+  fail_count=$((fail_count + 1))
+  printf 'FAIL %s: %s\n' "$1" "$2"
+}
+
+expect_status() {
+  local name=$1 expected=$2 input=$3 output rc
+  output="$tmp/$name.out"
+  set +e
+  caty_extract_donecheck "$input" "$output"
+  rc=$?
+  set -e
+  if [[ "$rc" -eq "$expected" ]] && [[ ! -e "$output" ]]; then
+    pass "$name"
+  else
+    fail "$name" "expected status=$expected/no output, got status=$rc output_exists=$([[ -e "$output" ]] && echo yes || echo no)"
+  fi
+}
+
+cat >"$tmp/indented-heredoc.task.md" <<'EOF'
+```donecheck
+cat <<'TEXT' >/dev/null
+  ```donecheck
+TEXT
+echo ok
+```
+EOF
+if caty_extract_donecheck "$tmp/indented-heredoc.task.md" "$tmp/indented-heredoc.out" \
+  && grep -Fqx '  ```donecheck' "$tmp/indented-heredoc.out" \
+  && bash -n "$tmp/indented-heredoc.out"; then
+  pass indented-fence-is-not-opener
+else
+  fail indented-fence-is-not-opener 'indented fence was not preserved inside the single block'
+fi
+
+printf '%s\r\n' '```donecheck' 'echo crlf' '```' >"$tmp/crlf.task.md"
+if caty_extract_donecheck "$tmp/crlf.task.md" "$tmp/crlf.out" \
+  && [[ "$(od -An -t x1 "$tmp/crlf.out" | tr -d '[:space:]')" = 6563686f2063726c660a ]]; then
+  pass crlf-normalized-to-lf
+else
+  fail crlf-normalized-to-lf 'extracted bytes were not LF-normalized'
+fi
+
+printf '%s\n%s\n%s' '```donecheck' 'echo no-final-newline' '```' >"$tmp/no-final-newline.task.md"
+if caty_extract_donecheck "$tmp/no-final-newline.task.md" "$tmp/no-final-newline.out" \
+  && [[ "$(cat "$tmp/no-final-newline.out")" = 'echo no-final-newline' ]]; then
+  pass missing-final-newline
+else
+  fail missing-final-newline 'closing fence without final LF was not accepted'
+fi
+
+cat >"$tmp/second-opener.task.md" <<'EOF'
+```donecheck
+true
+```
+ordinary text
+```donecheck
+false
+```
+EOF
+expect_status second-opener-after-close 4 "$tmp/second-opener.task.md"
+
+printf '%s\n' '```donecheck' 'true' >"$tmp/unclosed.task.md"
+expect_status unclosed-fence 5 "$tmp/unclosed.task.md"
+
+printf '%s\n' '```donecheck extra' 'true' '```' >"$tmp/info-string.task.md"
+expect_status info-string-not-opener 2 "$tmp/info-string.task.md"
+
+printf '\377```donecheck\ntrue\n```\n' >"$tmp/non-utf8.task.md"
+expect_status non-utf8 3 "$tmp/non-utf8.task.md"
+
+cat >"$tmp/column-zero-heredoc.task.md" <<'EOF'
+```donecheck
+cat <<'TEXT'
+```
+echo this-is-outside-the-extracted-block
+TEXT
+```
+EOF
+if caty_extract_donecheck "$tmp/column-zero-heredoc.task.md" "$tmp/column-zero-heredoc.out" \
+  && [[ "$(cat "$tmp/column-zero-heredoc.out")" = "cat <<'TEXT'" ]] \
+  && bash -n "$tmp/column-zero-heredoc.out" >/dev/null 2>&1; then
+  pass column-zero-fence-textually-truncates-heredoc
+else
+  fail column-zero-fence-textually-truncates-heredoc 'documented textual truncation behavior changed'
+fi
+
+install_ws="$tmp/install-workspace"
+if "$ROOT/install.sh" --workspace "$install_ws" >/dev/null \
+  && [[ -f "$install_ws/loop/.tr-interpreters" ]] \
+  && [[ "$(sed -n '1p' "$install_ws/loop/.tr-interpreters")" = TR_BASH=/* ]] \
+  && [[ "$(sed -n '2p' "$install_ws/loop/.tr-interpreters")" = TR_PERL=/* ]]; then
+  source "$install_ws/loop/.tr-interpreters"
+  if [[ -x "$TR_BASH" && -x "$TR_PERL" ]]; then
+    pass install-records-absolute-interpreters
+  else
+    fail install-records-absolute-interpreters 'recorded interpreter is not executable'
+  fi
+else
+  fail install-records-absolute-interpreters 'install did not create the two-line interpreter record'
+fi
+
+invalid_record="$tmp/invalid-interpreters"
+printf '%s\n' 'TR_BASH=relative/bash' 'TR_PERL=/usr/bin/perl' >"$invalid_record"
+set +e
+invalid_output=$(caty_read_interpreters "$invalid_record" 2>&1)
+invalid_rc=$?
+set -e
+if [[ "$invalid_rc" -ne 0 ]] \
+  && grep -Fq "file=$invalid_record" <<<"$invalid_output" \
+  && grep -Fq 'value=relative/bash' <<<"$invalid_output"; then
+  pass invalid-interpreter-record-fails-closed
+else
+  fail invalid-interpreter-record-fails-closed "rc=$invalid_rc output=$invalid_output"
+fi
+
+printf 'Summary: %s PASS, %s FAIL\n' "$pass_count" "$fail_count"
+[[ "$fail_count" -eq 0 ]]

--- a/tests/fixtures/mock-spawn-step.sh
+++ b/tests/fixtures/mock-spawn-step.sh
@@ -87,6 +87,32 @@ with open(path, "w", encoding="utf-8") as f:
     f.write("\n")
 PY
     ;;
+  receipt-symlink|receipt-directory|receipt-parent-symlink)
+    printf 'claimed\n' >"$artifact_dir/out/claimed.txt"
+    if [[ "$behavior" = receipt-symlink ]]; then
+      printf 'outside\n' >"$artifact_dir/outside-receipt.json"
+      ln -s "$artifact_dir/outside-receipt.json" "$artifact_dir/out/delivery-receipt.json"
+    elif [[ "$behavior" = receipt-directory ]]; then
+      mkdir -p "$artifact_dir/out/delivery-receipt.json"
+      printf 'nested\n' >"$artifact_dir/out/delivery-receipt.json/value"
+    else
+      mkdir -p "$artifact_dir/outside"
+      printf 'outside\n' >"$artifact_dir/outside/delivery-receipt.json"
+      ln -s "$artifact_dir/outside" "$artifact_dir/out/link"
+    fi
+    python3 - "$attempt_dir/step-result.json" <<'PY'
+import json, sys
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump({
+        "step_complete": True,
+        "files_created": ["out/claimed.txt"],
+        "error_class": None,
+        "deviation_report": None,
+        "next_hint": "receipt-boundary",
+    }, f)
+    f.write("\n")
+PY
+    ;;
   hang)
     while :; do
       sleep 30

--- a/tests/fixtures/mock-spawn-step.sh
+++ b/tests/fixtures/mock-spawn-step.sh
@@ -87,7 +87,7 @@ with open(path, "w", encoding="utf-8") as f:
     f.write("\n")
 PY
     ;;
-  receipt-symlink|receipt-directory|receipt-parent-symlink)
+  receipt-symlink|receipt-directory|receipt-parent-symlink|receipt-out-symlink)
     printf 'claimed\n' >"$artifact_dir/out/claimed.txt"
     if [[ "$behavior" = receipt-symlink ]]; then
       printf 'outside\n' >"$artifact_dir/outside-receipt.json"
@@ -95,6 +95,12 @@ PY
     elif [[ "$behavior" = receipt-directory ]]; then
       mkdir -p "$artifact_dir/out/delivery-receipt.json"
       printf 'nested\n' >"$artifact_dir/out/delivery-receipt.json/value"
+    elif [[ "$behavior" = receipt-out-symlink ]]; then
+      mkdir -p "$workspace/receipt-out-symlink-outside"
+      printf 'claimed\n' >"$workspace/receipt-out-symlink-outside/claimed.txt"
+      printf 'outside\n' >"$workspace/receipt-out-symlink-outside/delivery-receipt.json"
+      rm -rf "$artifact_dir/out"
+      ln -s "$workspace/receipt-out-symlink-outside" "$artifact_dir/out"
     else
       mkdir -p "$artifact_dir/outside"
       printf 'outside\n' >"$artifact_dir/outside/delivery-receipt.json"

--- a/tests/fixtures/task-attempts-budget.task.md
+++ b/tests/fixtures/task-attempts-budget.task.md
@@ -8,6 +8,7 @@ time_budget_min: 5
 escalate_to: test
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal

--- a/tests/fixtures/task-basic.task.md
+++ b/tests/fixtures/task-basic.task.md
@@ -8,6 +8,7 @@ time_budget_min: 5
 escalate_to: test
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal

--- a/tests/fixtures/task-dlq-failing-line.task.md
+++ b/tests/fixtures/task-dlq-failing-line.task.md
@@ -8,6 +8,7 @@ time_budget_min: 5
 escalate_to: test
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal

--- a/tests/fixtures/task-gap-replay.task.md
+++ b/tests/fixtures/task-gap-replay.task.md
@@ -8,6 +8,7 @@ time_budget_min: 5
 escalate_to: test
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal

--- a/tests/fixtures/task-no-progress.task.md
+++ b/tests/fixtures/task-no-progress.task.md
@@ -8,6 +8,7 @@ time_budget_min: 5
 escalate_to: test
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal

--- a/tests/fixtures/task-time-boundary.task.md
+++ b/tests/fixtures/task-time-boundary.task.md
@@ -8,6 +8,7 @@ time_budget_min: 10
 escalate_to: test
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal

--- a/tests/fixtures/task-tiny-budget.task.md
+++ b/tests/fixtures/task-tiny-budget.task.md
@@ -8,6 +8,7 @@ time_budget_min: 0
 escalate_to: test
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal

--- a/tests/no-progress-stop.test.sh
+++ b/tests/no-progress-stop.test.sh
@@ -40,6 +40,7 @@ time_budget_min: 5
 escalate_to: test
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal
@@ -90,6 +91,7 @@ time_budget_min: 5
 escalate_to: test
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal
@@ -181,6 +183,9 @@ case_failure_then_pass_delivers() {
   printf 'single failure at %s/first 01:02:03\n' "$ws" >"$ws/loop/artifacts/tr-no-progress/gate-output"
   run_tick "$ws" TR_MOCK_BEHAVIOR=noncomplete TR_MOCK_ERROR_CLASS=alpha-error
   touch "$ws/loop/artifacts/tr-no-progress/gate-pass"
+  mkdir -p "$ws/loop/artifacts/tr-no-progress/out"
+  printf '{"task_id":"tr-no-progress"}\n' \
+    >"$ws/loop/artifacts/tr-no-progress/out/delivery-receipt.json"
   run_tick "$ws" TR_MOCK_BEHAVIOR=noncomplete TR_MOCK_ERROR_CLASS=beta-error
   if [[ "$(state_value "$ws" status)" = delivered ]] \
     && [[ "$(state_value "$ws" terminal_reason)" = '' ]] \

--- a/tests/spawn-step.test.sh
+++ b/tests/spawn-step.test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 ADAPTER="$ROOT/adapters/hermes/spawn_step.sh"
+RUNNER="$ROOT/scripts/task-runner.sh"
 
 pass_count=0
 fail_count=0
@@ -375,6 +376,39 @@ case_forwarded_term_quarantines_partial_output_and_kills_group() {
   fi
 }
 
+case_runner_rejects_relative_spawn_step() {
+  local name=runner-rejects-relative-spawn-step
+  local dir code output
+  dir=$(make_case_dir)
+  set +e
+  output=$(TR_SPAWN_STEP=relative-spawn bash "$RUNNER" "$dir/ws" 2>&1)
+  code=$?
+  set -e
+  if [[ "$code" -eq 2 ]] && grep -Fq 'value=relative-spawn' <<<"$output"; then
+    pass "$name"
+  else
+    fail "$name" "expected exit 2 naming relative-spawn, got rc=$code output=$output"
+  fi
+}
+
+case_runner_rejects_nonexecutable_spawn_step() {
+  local name=runner-rejects-nonexecutable-spawn-step
+  local dir path code output
+  dir=$(make_case_dir)
+  path="$dir/not-executable"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$path"
+  chmod 644 "$path"
+  set +e
+  output=$(TR_SPAWN_STEP="$path" bash "$RUNNER" "$dir/ws" 2>&1)
+  code=$?
+  set -e
+  if [[ "$code" -eq 2 ]] && grep -Fq "value=$path" <<<"$output"; then
+    pass "$name"
+  else
+    fail "$name" "expected exit 2 naming $path, got rc=$code output=$output"
+  fi
+}
+
 case_success
 case_step_cmd_unset
 case_step_cmd_nonexistent
@@ -387,6 +421,8 @@ case_timeout_quarantines_partial_output_and_kills_group
 case_fast_exit_preserves_complete_output_and_reaps_group
 case_ordinary_failure_preserves_complete_output
 case_forwarded_term_quarantines_partial_output_and_kills_group
+case_runner_rejects_relative_spawn_step
+case_runner_rejects_nonexecutable_spawn_step
 
 log "TOTAL pass=$pass_count fail=$fail_count"
 if (( fail_count > 0 )); then

--- a/tests/task-runner.test.sh
+++ b/tests/task-runner.test.sh
@@ -295,6 +295,31 @@ case_trailing_comment_created_parity() {
   fi
 }
 
+case_duplicate_id_scheduler_parser_parity() {
+  local name=duplicate-id-scheduler-parser-parity
+  local ws task
+  ws=$(make_ws)
+
+  write_runner_task "$ws" scheduler-shadow out/delivery-receipt.json true
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success
+
+  write_runner_task "$ws" scheduler-first out/delivery-receipt.json true
+  task="$ws/loop/tasks/queue/scheduler-first.task.md"
+  sed '/^id: scheduler-first$/a\
+id: scheduler-shadow' "$task" >"$task.tmp"
+  mv "$task.tmp" "$task"
+
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success
+  if [[ "$(state_value "$ws" scheduler-first status)" = delivered ]] \
+    && [[ "$(state_value "$ws" scheduler-first attempts_used)" = 1 ]] \
+    && [[ -f "$ws/loop/tasks/delivered/scheduler-first/scheduler-first.task.md" ]] \
+    && [[ ! -e "$task" ]]; then
+    pass "$name"
+  else
+    fail "$name" 'scheduler did not use the same first id value as the runner'
+  fi
+}
+
 attest_verifier_wrapper() {
   local ws=$1
   local wrapper_path=$2
@@ -352,6 +377,18 @@ case_receipt_file_boundary() {
   if [[ "$(state_value "$ws" receipt-parent-symlink status)" != queued ]] \
     || [[ -d "$ws/loop/tasks/delivered/receipt-parent-symlink" ]]; then
     fail "$name" 'resolved receipt path escaped through a parent symlink'
+    return
+  fi
+
+  ws=$(make_ws)
+  write_runner_task "$ws" receipt-out-symlink out/delivery-receipt.json true
+  run_tick "$ws" TR_MOCK_BEHAVIOR=receipt-out-symlink
+  reason="$ws/loop/artifacts/receipt-out-symlink/attempts/001/verify-reason"
+  if [[ "$(state_value "$ws" receipt-out-symlink status)" != queued ]] \
+    || [[ -d "$ws/loop/tasks/delivered/receipt-out-symlink" ]] \
+    || [[ ! -f "$reason" ]] \
+    || ! grep -Fqx 'delivery receipt missing or invalid: out/delivery-receipt.json' "$reason"; then
+    fail "$name" 'artifact out symlink moved the delivery containment root'
     return
   fi
 
@@ -438,10 +475,10 @@ case_receipt_frontmatter_parser_parity() {
 
 case_donecheck_environment_allowlist() {
   local name=donecheck-environment-allowlist
-  local ws log_file unexpected_tr
+  local ws log_file unexpected_tr no_home_log
   ws=$(make_ws)
   write_runner_task "$ws" env-allow out/delivery-receipt.json 'env | sort'
-  TR_SENTINEL_CANARY=x TR_PUSH_CMD=should-not-leak \
+  HOME="$ws/home" TR_SENTINEL_CANARY=x TR_PUSH_CMD=should-not-leak \
     run_tick "$ws" TR_MOCK_BEHAVIOR=success LANG=C LC_ALL=C TZ=UTC
   log_file="$ws/loop/artifacts/env-allow/attempts/001/donecheck.log"
   unexpected_tr=$(grep '^TR_' "$log_file" | grep -v '^TR_DC_CWD=' || true)
@@ -451,7 +488,7 @@ case_donecheck_environment_allowlist() {
     && grep -Fq 'ARTIFACT_DIR=' "$log_file" \
     && grep -Fq 'TR_DC_CWD=' "$log_file" \
     && grep -Fqx 'PATH=/usr/bin:/bin:/usr/sbin:/sbin' "$log_file" \
-    && grep -Fq 'HOME=' "$log_file" \
+    && grep -Fqx "HOME=$ws/home" "$log_file" \
     && grep -Fqx 'LANG=C' "$log_file" \
     && grep -Fqx 'LC_ALL=C' "$log_file" \
     && grep -Fqx 'TZ=UTC' "$log_file" \
@@ -461,9 +498,21 @@ case_donecheck_environment_allowlist() {
     && grep -q '^PWD=' "$log_file" \
     && grep -q '^SHLVL=' "$log_file" \
     && grep -q '^_=' "$log_file"; then
-    pass "$name"
+    :
   else
     fail "$name" "allowlist or shell-created variable contract mismatch: unexpected_tr=$unexpected_tr log=$(cat "$log_file")"
+    return
+  fi
+
+  ws=$(make_ws)
+  write_runner_task "$ws" env-no-home out/delivery-receipt.json 'env | sort'
+  env -u HOME TR_SPAWN_STEP="$MOCK" TR_MOCK_BEHAVIOR=success bash "$RUNNER" "$ws"
+  no_home_log="$ws/loop/artifacts/env-no-home/attempts/001/donecheck.log"
+  if [[ "$(state_value "$ws" env-no-home status)" = delivered ]] \
+    && ! grep -q '^HOME=' "$no_home_log"; then
+    pass "$name"
+  else
+    fail "$name" "unset HOME was supplied to donecheck: log=$(cat "$no_home_log")"
   fi
 }
 
@@ -774,6 +823,31 @@ case_crash_stamp() {
     pass "$name"
   else
     fail "$name" "recovery did not reuse stamped attempt"
+  fi
+}
+
+case_crash_stamp_invalid_receipt_dlq() {
+  local name=crash-stamp-invalid-receipt-dlq
+  local ws task code
+  ws=$(make_ws)
+  write_runner_task "$ws" reap-invalid-receipt out/delivery-receipt.json true
+  set +e
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success TR_CRASH_AFTER=stamp >/dev/null 2>&1
+  code=$?
+  set -e
+  task="$ws/loop/tasks/queue/reap-invalid-receipt.task.md"
+  sed 's|^receipt:.*|receipt: out/../escape|' "$task" >"$task.tmp"
+  mv "$task.tmp" "$task"
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success
+  if [[ "$code" -eq 137 ]] \
+    && [[ "$(state_value "$ws" reap-invalid-receipt status)" = dlq ]] \
+    && [[ "$(state_value "$ws" reap-invalid-receipt terminal_reason)" = missing-receipt ]] \
+    && [[ "$(state_value "$ws" reap-invalid-receipt attempts_used)" = 0 ]] \
+    && [[ -f "$ws/loop/tasks/dlq/reap-invalid-receipt/reap-invalid-receipt.task.md" ]] \
+    && [[ ! -e "$ws/loop/artifacts/reap-invalid-receipt/attempts/001/donecheck.log" ]]; then
+    pass "$name"
+  else
+    fail "$name" 'reap finalize did not DLQ the mutated receipt before charging or verification'
   fi
 }
 
@@ -1203,14 +1277,16 @@ case_attempts_exhaustion() {
 
 case_attempts_exhaustion_reports_actual_failing_donecheck_line() {
   local name=attempts-exhaustion-reports-actual-failing-donecheck-line
-  local ws i report
+  local ws i report failing
   ws=$(make_ws)
   copy_task "$FIX_FAILING_LINE" "$ws" tr-failing-line
   for i in 1 2 3 4; do
     run_tick "$ws" TR_MOCK_BEHAVIOR=success
   done
   report="$ws/loop/tasks/dlq/tr-failing-line/REPORT.md"
+  failing="$ws/loop/artifacts/tr-failing-line/attempts/004/donecheck.failing"
   if [[ "$(state_value "$ws" tr-failing-line status)" = dlq ]] \
+    && grep -Eq '^2: ' "$failing" \
     && grep -F -q 'test -s "$ARTIFACT_DIR/out/missing-receipt.json"' "$report" \
     && ! grep -F -q 'test -s "$ARTIFACT_DIR/out/delivery-receipt.json"' "$report"; then
     pass "$name"
@@ -2123,6 +2199,7 @@ case_corrupt_state_quarantine_continues
 case_quoted_id_intake_runner_agree
 case_invalid_created_sorts_last
 case_trailing_comment_created_parity
+case_duplicate_id_scheduler_parser_parity
 case_happy_path
 case_receipt_file_boundary
 case_missing_receipt_dlq_before_spawn
@@ -2159,6 +2236,7 @@ case_plain_persistent_failure_dlq
 case_crash_verifying_terminal_rederive
 case_crash_spawn
 case_crash_stamp
+case_crash_stamp_invalid_receipt_dlq
 case_crash_stamp_infra_neutral
 case_crash_infra_requeue_recovery
 case_crash_infra_terminal_recovery

--- a/tests/task-runner.test.sh
+++ b/tests/task-runner.test.sh
@@ -46,6 +46,36 @@ copy_task() {
   cp "$src" "$ws/loop/tasks/queue/$id.task.md"
 }
 
+write_runner_task() {
+  local ws=$1
+  local id=$2
+  local receipt_value=$3
+  local donecheck_body=${4:-true}
+  {
+    printf '%s\n' '---'
+    printf 'id: %s\n' "$id"
+    printf '%s\n' 'title: runner boundary fixture'
+    printf '%s\n' 'issued_by: test'
+    printf '%s\n' 'created: 2026-08-12T00:00:00Z'
+    printf '%s\n' 'attempts_budget: 4'
+    printf '%s\n' 'time_budget_min: 30'
+    printf '%s\n' 'escalate_to: test'
+    printf '%s\n' 'verify: mechanical'
+    printf '%s\n' 'parent_id: null'
+    if [[ "$receipt_value" != __missing__ ]]; then
+      printf 'receipt: %s\n' "$receipt_value"
+    fi
+    printf '%s\n\n' '---'
+    printf '%s\n\n' '## Goal' 'Exercise a runner execution boundary.'
+    printf '%s\n' '## Done-when' '```donecheck'
+    printf '%s\n' "$donecheck_body"
+    printf '%s\n\n' '```'
+    printf '%s\n' '## Step plan' '1. Produce the test artifact.' '2. Deliver + capture receipt.' ''
+    printf '%s\n\n' '## Resources' 'none'
+    printf '%s\n' '## Non-goals' 'none'
+  } >"$ws/loop/tasks/queue/$id.task.md"
+}
+
 state_value() {
   local ws=$1
   local id=$2
@@ -286,6 +316,223 @@ case_happy_path() {
     pass "$name"
   else
     fail "$name" "task was not delivered"
+  fi
+}
+
+case_receipt_file_boundary() {
+  local name=receipt-file-boundary
+  local ws reason
+
+  ws=$(make_ws)
+  write_runner_task "$ws" receipt-missing out/delivery-receipt.json true
+  run_tick "$ws" TR_MOCK_BEHAVIOR=claim-valid
+  reason="$ws/loop/artifacts/receipt-missing/attempts/001/verify-reason"
+  if [[ "$(state_value "$ws" receipt-missing status)" = queued ]] \
+    && [[ -f "$reason" ]] \
+    && grep -Fqx 'delivery receipt missing or invalid: out/delivery-receipt.json' "$reason" \
+    && [[ ! -d "$ws/loop/tasks/delivered/receipt-missing" ]]; then
+    :
+  else
+    fail "$name" 'donecheck rc=0 with a missing receipt was delivered or lacked verify-reason'
+    return
+  fi
+
+  ws=$(make_ws)
+  write_runner_task "$ws" receipt-symlink out/delivery-receipt.json true
+  run_tick "$ws" TR_MOCK_BEHAVIOR=receipt-symlink
+  if [[ "$(state_value "$ws" receipt-symlink status)" != queued ]] \
+    || [[ -d "$ws/loop/tasks/delivered/receipt-symlink" ]]; then
+    fail "$name" 'symlink receipt passed the delivery gate'
+    return
+  fi
+
+  ws=$(make_ws)
+  write_runner_task "$ws" receipt-parent-symlink out/link/delivery-receipt.json true
+  run_tick "$ws" TR_MOCK_BEHAVIOR=receipt-parent-symlink
+  if [[ "$(state_value "$ws" receipt-parent-symlink status)" != queued ]] \
+    || [[ -d "$ws/loop/tasks/delivered/receipt-parent-symlink" ]]; then
+    fail "$name" 'resolved receipt path escaped through a parent symlink'
+    return
+  fi
+
+  ws=$(make_ws)
+  write_runner_task "$ws" receipt-directory out/delivery-receipt.json true
+  run_tick "$ws" TR_MOCK_BEHAVIOR=receipt-directory
+  if [[ "$(state_value "$ws" receipt-directory status)" = queued ]] \
+    && [[ ! -d "$ws/loop/tasks/delivered/receipt-directory" ]] \
+    && grep -Fqx 'delivery receipt missing or invalid: out/delivery-receipt.json' \
+      "$ws/loop/artifacts/receipt-directory/attempts/001/verify-reason"; then
+    pass "$name"
+  else
+    fail "$name" 'directory receipt passed the regular-file delivery gate'
+  fi
+}
+
+case_missing_receipt_dlq_before_spawn() {
+  local name=missing-receipt-dlq-before-spawn
+  local ws
+  ws=$(make_ws)
+  write_runner_task "$ws" missing-receipt __missing__ true
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success
+  if [[ "$(state_value "$ws" missing-receipt status)" = dlq ]] \
+    && [[ "$(state_value "$ws" missing-receipt terminal_reason)" = missing-receipt ]] \
+    && [[ -f "$ws/loop/tasks/dlq/missing-receipt/missing-receipt.task.md" ]] \
+    && ! find "$ws/loop/artifacts/missing-receipt/attempts" -mindepth 1 -print | grep -q .; then
+    :
+  else
+    fail "$name" 'missing receipt metadata did not DLQ before a model attempt'
+    return
+  fi
+
+  ws=$(make_ws)
+  write_runner_task "$ws" invalid-receipt out/../escape true
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success
+  if [[ "$(state_value "$ws" invalid-receipt status)" = dlq ]] \
+    && [[ "$(state_value "$ws" invalid-receipt terminal_reason)" = missing-receipt ]] \
+    && ! find "$ws/loop/artifacts/invalid-receipt/attempts" -mindepth 1 -print | grep -q .; then
+    :
+  else
+    fail "$name" 'grammar-invalid receipt metadata did not DLQ before a model attempt'
+    return
+  fi
+
+  ws=$(make_ws)
+  write_runner_task "$ws" recover-missing-receipt out/delivery-receipt.json true
+  set +e
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success TR_CRASH_AFTER=verifying >/dev/null 2>&1
+  set -e
+  sed '/^receipt:/d' "$ws/loop/tasks/queue/recover-missing-receipt.task.md" \
+    >"$ws/loop/tasks/queue/recover-missing-receipt.task.md.tmp"
+  mv "$ws/loop/tasks/queue/recover-missing-receipt.task.md.tmp" \
+    "$ws/loop/tasks/queue/recover-missing-receipt.task.md"
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success
+  if [[ "$(state_value "$ws" recover-missing-receipt status)" = dlq ]] \
+    && [[ "$(state_value "$ws" recover-missing-receipt terminal_reason)" = missing-receipt ]] \
+    && [[ ! -e "$ws/loop/artifacts/recover-missing-receipt/attempts/001/donecheck.log" ]]; then
+    pass "$name"
+  else
+    fail "$name" 'recover_verifying reran donecheck before DLQing missing receipt metadata'
+  fi
+}
+
+case_receipt_frontmatter_parser_parity() {
+  local name=receipt-frontmatter-parser-parity
+  local ws task
+  for receipt_value in '"out/delivery-receipt.json"' 'out/delivery-receipt.json # runner parity'; do
+    ws=$(make_ws)
+    task="$ws/source.task.md"
+    write_runner_task "$ws" receipt-parity "$receipt_value" true
+    mv "$ws/loop/tasks/queue/receipt-parity.task.md" "$task"
+    if ! "$ENQUEUE" "$task" "$ws" >/dev/null 2>&1; then
+      fail "$name" "enqueue rejected receipt value: $receipt_value"
+      return
+    fi
+    run_tick "$ws" TR_MOCK_BEHAVIOR=success
+    if [[ "$(state_value "$ws" receipt-parity status)" != delivered ]]; then
+      fail "$name" "runner disagreed with enqueue for receipt value: $receipt_value"
+      return
+    fi
+  done
+  pass "$name"
+}
+
+case_donecheck_environment_allowlist() {
+  local name=donecheck-environment-allowlist
+  local ws log_file unexpected_tr
+  ws=$(make_ws)
+  write_runner_task "$ws" env-allow out/delivery-receipt.json 'env | sort'
+  TR_SENTINEL_CANARY=x TR_PUSH_CMD=should-not-leak \
+    run_tick "$ws" TR_MOCK_BEHAVIOR=success LANG=C LC_ALL=C TZ=UTC
+  log_file="$ws/loop/artifacts/env-allow/attempts/001/donecheck.log"
+  unexpected_tr=$(grep '^TR_' "$log_file" | grep -v '^TR_DC_CWD=' || true)
+  if [[ "$(state_value "$ws" env-allow status)" = delivered ]] \
+    && grep -Fqx 'TASK_ID=env-allow' "$log_file" \
+    && grep -Fq 'TASK_FILE=' "$log_file" \
+    && grep -Fq 'ARTIFACT_DIR=' "$log_file" \
+    && grep -Fq 'TR_DC_CWD=' "$log_file" \
+    && grep -Fqx 'PATH=/usr/bin:/bin:/usr/sbin:/sbin' "$log_file" \
+    && grep -Fq 'HOME=' "$log_file" \
+    && grep -Fqx 'LANG=C' "$log_file" \
+    && grep -Fqx 'LC_ALL=C' "$log_file" \
+    && grep -Fqx 'TZ=UTC' "$log_file" \
+    && ! grep -q '^TR_SENTINEL_CANARY=' "$log_file" \
+    && ! grep -q '^TR_PUSH_CMD=' "$log_file" \
+    && [[ -z "$unexpected_tr" ]] \
+    && grep -q '^PWD=' "$log_file" \
+    && grep -q '^SHLVL=' "$log_file" \
+    && grep -q '^_=' "$log_file"; then
+    pass "$name"
+  else
+    fail "$name" "allowlist or shell-created variable contract mismatch: unexpected_tr=$unexpected_tr log=$(cat "$log_file")"
+  fi
+}
+
+case_donecheck_uses_pinned_interpreters() {
+  local name=donecheck-uses-pinned-interpreters
+  local ws fake_bash fake_perl bash_marker perl_marker
+  ws=$(make_ws)
+  fake_bash="$ws/fake-bash"
+  fake_perl="$ws/fake-perl"
+  bash_marker="$ws/bash-args"
+  perl_marker="$ws/perl-args"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf 'printf "%%s\\n" "$*" >%q\n' "$bash_marker"
+    printf 'exec %q "$@"\n' "$(command -v bash)"
+  } >"$fake_bash"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf 'printf "%%s\\n" "$*" >%q\n' "$perl_marker"
+    printf 'exec %q "$@"\n' "$(command -v perl)"
+  } >"$fake_perl"
+  chmod +x "$fake_bash" "$fake_perl"
+  printf 'TR_BASH=%s\nTR_PERL=%s\n' "$fake_bash" "$fake_perl" \
+    >"$ws/loop/.tr-interpreters"
+  write_runner_task "$ws" pinned-interpreters out/delivery-receipt.json true
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success
+  if [[ "$(state_value "$ws" pinned-interpreters status)" = delivered ]] \
+    && grep -Fq -- '-euo pipefail' "$bash_marker" \
+    && grep -Fq -- '-MPOSIX=setsid' "$perl_marker"; then
+    pass "$name"
+  else
+    fail "$name" "pinned launch not observed: bash=$(cat "$bash_marker" 2>/dev/null) perl=$(cat "$perl_marker" 2>/dev/null)"
+  fi
+}
+
+case_recover_verifying_receipt_boundary() {
+  local name=recover-verifying-receipt-boundary
+  local ws
+  ws=$(make_ws)
+  write_runner_task "$ws" recover-receipt out/delivery-receipt.json true
+  set +e
+  run_tick "$ws" TR_MOCK_BEHAVIOR=claim-valid TR_CRASH_AFTER=verifying >/dev/null 2>&1
+  set -e
+  run_tick "$ws" TR_MOCK_BEHAVIOR=claim-valid
+  if [[ ! -d "$ws/loop/tasks/delivered/recover-receipt" ]] \
+    && grep -Fqx 'delivery receipt missing or invalid: out/delivery-receipt.json' \
+      "$ws/loop/artifacts/recover-receipt/attempts/001/verify-reason"; then
+    pass "$name"
+  else
+    fail "$name" 'recover_verifying delivered without a valid regular receipt'
+  fi
+}
+
+case_missing_donecheck_never_delivers() {
+  local name=missing-donecheck-never-delivers
+  local ws task
+  ws=$(make_ws)
+  write_runner_task "$ws" missing-donecheck out/delivery-receipt.json true
+  task="$ws/loop/tasks/queue/missing-donecheck.task.md"
+  sed 's/^```donecheck$/```donecheck extra/' "$task" >"$task.tmp"
+  mv "$task.tmp" "$task"
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success
+  if [[ "$(state_value "$ws" missing-donecheck status)" = queued ]] \
+    && [[ ! -d "$ws/loop/tasks/delivered/missing-donecheck" ]] \
+    && grep -Fqx 'missing donecheck block' \
+      "$ws/loop/artifacts/missing-donecheck/attempts/001/verify-reason"; then
+    pass "$name"
+  else
+    fail "$name" 'queue-dropped task without a valid donecheck was delivered'
   fi
 }
 
@@ -1000,6 +1247,7 @@ time_budget_min: 5
 escalate_to: test
 verify: mechanical
 parent_id: null
+receipt: out/delivery-receipt.json
 ---
 
 ## Goal
@@ -1876,6 +2124,13 @@ case_quoted_id_intake_runner_agree
 case_invalid_created_sorts_last
 case_trailing_comment_created_parity
 case_happy_path
+case_receipt_file_boundary
+case_missing_receipt_dlq_before_spawn
+case_receipt_frontmatter_parser_parity
+case_donecheck_environment_allowlist
+case_donecheck_uses_pinned_interpreters
+case_recover_verifying_receipt_boundary
+case_missing_donecheck_never_delivers
 case_success_next_hint_surface
 case_success_next_hint_null_empty_omitted
 case_failed_next_hint_stays_retry_only

--- a/tests/tr-enqueue.test.sh
+++ b/tests/tr-enqueue.test.sh
@@ -43,6 +43,7 @@ write_task() {
   donecheck_extra=$8
   omit_section=$9
   parent_id_value=${10:-null}
+  receipt_value=${11-out/delivery-receipt.json}
 
   {
     printf '%s\n' '---'
@@ -55,6 +56,9 @@ write_task() {
     printf '%s\n' 'escalate_to: sho'
     printf 'verify: %s\n' "$verify"
     printf 'parent_id: %s\n' "$parent_id_value"
+    if [ "$receipt_value" != __missing__ ]; then
+      printf 'receipt: %s\n' "$receipt_value"
+    fi
     printf '%s\n' '---'
     if [ "$omit_section" != "Goal" ]; then
       printf '%s\n\n%s\n\n' '## Goal' 'Test goal.'
@@ -62,7 +66,9 @@ write_task() {
     if [ "$omit_section" != "Done-when" ]; then
       printf '%s\n\n' '## Done-when'
       printf '%s\n' '```donecheck'
-      printf '%s\n' 'test -s "$ARTIFACT_DIR/out/image.png"'
+      if [ "$receipt_assertion" != "empty" ]; then
+        printf '%s\n' 'test -s "$ARTIFACT_DIR/out/image.png"'
+      fi
       if [ "$receipt_assertion" = "yes" ]; then
         printf '%s\n' 'test -s "$ARTIFACT_DIR/out/delivery-receipt.json"'
       fi
@@ -215,6 +221,35 @@ else
   fail_case "copy failure leaves no artifact and retry succeeds" "rc=$rc output=$output"
 fi
 
+task=$TMP_ROOT/staged-snapshot.task.md
+ws=$(new_workspace staged-snapshot)
+write_task "$task" staged-snapshot mechanical 8 30 "$valid_steps" yes "" none
+snapshot_cp_shim=$TMP_ROOT/snapshot-cp-shim
+real_sed=$(command -v sed)
+real_mv=$(command -v mv)
+mkdir -p "$snapshot_cp_shim"
+{
+  printf '%s\n' '#!/bin/sh'
+  printf '%s\n' '"$TR_ENQUEUE_REAL_SED" "s|^receipt:.*|receipt: out/../escape|" "$1" >"$1.changed" || exit $?'
+  printf '%s\n' '"$TR_ENQUEUE_REAL_MV" "$1.changed" "$1" || exit $?'
+  printf '%s\n' 'exec "$TR_ENQUEUE_REAL_CP" "$@"'
+} >"$snapshot_cp_shim/cp"
+chmod +x "$snapshot_cp_shim/cp"
+output=$(PATH="$snapshot_cp_shim:$PATH" \
+  TR_ENQUEUE_REAL_CP="$real_cp" \
+  TR_ENQUEUE_REAL_SED="$real_sed" \
+  TR_ENQUEUE_REAL_MV="$real_mv" \
+  "$SCRIPT" "$task" "$ws" 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ] \
+  && printf '%s\n' "$output" | grep -F -q 'invalid receipt' \
+  && [ ! -e "$ws/loop/tasks/queue/staged-snapshot.task.md" ] \
+  && [ ! -e "$ws/loop/artifacts/staged-snapshot" ]; then
+  pass "validate staged snapshot after copy"
+else
+  fail_case "validate staged snapshot after copy" "rc=$rc output=$output"
+fi
+
 task=$TMP_ROOT/artifact-race.task.md
 ws=$(new_workspace artifact-race)
 write_task "$task" artifact-race mechanical 8 30 "$valid_steps" yes "" none
@@ -308,12 +343,62 @@ run_expect_reject "reject last step without deliver/receipt" "last Step-plan ste
 task=$TMP_ROOT/no-receipt-assertion.task.md
 ws=$(new_workspace no-receipt-assertion)
 write_task "$task" no-receipt-assertion mechanical 8 30 "$valid_steps" no "" none
-run_expect_reject "reject donecheck without receipt assertion" "donecheck has no delivery receipt assertion" "$task" "$ws"
+run_expect_accept "accept donecheck without heuristic receipt assertion" "$task" "$ws" no-receipt-assertion
 
 task=$TMP_ROOT/comment-only-receipt.task.md
 ws=$(new_workspace comment-only-receipt)
 write_task "$task" comment-only-receipt mechanical 8 30 "$valid_steps" no '# test -s "$ARTIFACT_DIR/out/delivery-receipt.json"' none
-run_expect_reject "reject comment-only receipt assertion" "donecheck has no delivery receipt assertion" "$task" "$ws"
+run_expect_accept "accept comments as raw bash" "$task" "$ws" comment-only-receipt
+
+task=$TMP_ROOT/hash-in-quote.task.md
+ws=$(new_workspace hash-in-quote)
+write_task "$task" hash-in-quote mechanical 8 30 "$valid_steps" no 'printf "%s\n" "# retained" >/dev/null' none
+run_expect_accept "raw bash syntax preserves hash inside quotes" "$task" "$ws" hash-in-quote
+
+task=$TMP_ROOT/comment-only-donecheck.task.md
+ws=$(new_workspace comment-only-donecheck)
+write_task "$task" comment-only-donecheck mechanical 8 30 "$valid_steps" empty '   # full-line comment' none
+run_expect_reject "reject blank-or-comment-only donecheck" "missing donecheck block" "$task" "$ws"
+
+for receipt_case in out/x out/a/b.txt; do
+  case_id=$(printf '%s' "$receipt_case" | tr '/.' '--')
+  task=$TMP_ROOT/receipt-$case_id.task.md
+  ws=$(new_workspace receipt-$case_id)
+  write_task "$task" receipt-$case_id mechanical 8 30 "$valid_steps" yes "" none null "$receipt_case"
+  run_expect_accept "accept receipt $receipt_case" "$task" "$ws" receipt-$case_id
+done
+
+task=$TMP_ROOT/missing-receipt.task.md
+ws=$(new_workspace missing-receipt)
+write_task "$task" missing-receipt mechanical 8 30 "$valid_steps" yes "" none null __missing__
+run_expect_reject "reject missing receipt key" "missing required frontmatter key: receipt" "$task" "$ws"
+
+task=$TMP_ROOT/empty-receipt.task.md
+ws=$(new_workspace empty-receipt)
+write_task "$task" empty-receipt mechanical 8 30 "$valid_steps" yes "" none null ""
+run_expect_reject "reject empty receipt" "missing required frontmatter key: receipt" "$task" "$ws"
+
+for receipt_case in out /abs out/../x out/./x out//x state.json 'out/bad name' 'out/a@b'; do
+  case_id=$(printf '%s' "$receipt_case" | tr '/. @' '-----')
+  task=$TMP_ROOT/invalid-receipt-$case_id.task.md
+  ws=$(new_workspace invalid-receipt-$case_id)
+  write_task "$task" invalid-receipt-$case_id mechanical 8 30 "$valid_steps" yes "" none null "$receipt_case"
+  run_expect_reject "reject receipt $receipt_case" "invalid receipt" "$task" "$ws"
+done
+
+task=$TMP_ROOT/quoted-receipt.task.md
+ws=$(new_workspace quoted-receipt)
+write_task "$task" quoted-receipt mechanical 8 30 "$valid_steps" yes "" none
+sed 's|^receipt:.*|receipt: "out/quoted.json"|' "$task" >"$task.tmp"
+mv "$task.tmp" "$task"
+run_expect_accept "accept quoted receipt value" "$task" "$ws" quoted-receipt
+
+task=$TMP_ROOT/commented-receipt.task.md
+ws=$(new_workspace commented-receipt)
+write_task "$task" commented-receipt mechanical 8 30 "$valid_steps" yes "" none
+sed 's|^receipt:.*|receipt: out/commented.json # delivery target|' "$task" >"$task.tmp"
+mv "$task.tmp" "$task"
+run_expect_accept "accept inline-comment receipt value" "$task" "$ws" commented-receipt
 
 task=$TMP_ROOT/bad-verify.task.md
 ws=$(new_workspace bad-verify)
@@ -337,6 +422,34 @@ task=$TMP_ROOT/bad-donecheck.task.md
 ws=$(new_workspace bad-donecheck)
 write_task "$task" bad-donecheck mechanical 8 30 "$valid_steps" yes "if then" none
 run_expect_reject "reject invalid donecheck syntax" "donecheck fails bash -n" "$task" "$ws"
+
+task=$TMP_ROOT/non-utf8.task.md
+ws=$(new_workspace non-utf8)
+write_task "$task" non-utf8 mechanical 8 30 "$valid_steps" yes "" none
+printf '\377' >>"$task"
+run_expect_reject "reject non-UTF-8 task distinctly" "task file is not valid UTF-8" "$task" "$ws"
+
+task=$TMP_ROOT/pinned-bash.task.md
+ws=$(new_workspace pinned-bash)
+write_task "$task" pinned-bash mechanical 8 30 "$valid_steps" yes "" none
+pinned_bash=$ws/fake-bash
+pinned_marker=$ws/bash-args
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf 'printf "%%s\\n" "$*" >%q\n' "$pinned_marker"
+  printf 'exec %q "$@"\n' "$(command -v bash)"
+} >"$pinned_bash"
+chmod +x "$pinned_bash"
+printf 'TR_BASH=%s\nTR_PERL=%s\n' "$pinned_bash" "$(command -v perl)" \
+  >"$ws/loop/.tr-interpreters"
+output=$("$SCRIPT" "$task" "$ws" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ] \
+  && grep -Eq '^-n .*/tr-enqueue-donecheck\.[0-9]+$' "$pinned_marker"; then
+  pass "enqueue syntax check uses pinned Bash"
+else
+  fail_case "enqueue syntax check uses pinned Bash" "rc=$rc args=$(cat "$pinned_marker" 2>/dev/null) output=$output"
+fi
 
 task=$TMP_ROOT/unwritable-artifacts.task.md
 ws=$(new_workspace unwritable-artifacts)

--- a/tests/tr-enqueue.test.sh
+++ b/tests/tr-enqueue.test.sh
@@ -445,10 +445,18 @@ printf 'TR_BASH=%s\nTR_PERL=%s\n' "$pinned_bash" "$(command -v perl)" \
 output=$("$SCRIPT" "$task" "$ws" 2>&1)
 rc=$?
 if [ "$rc" -eq 0 ] \
-  && grep -Eq '^-n .*/tr-enqueue-donecheck\.[0-9]+$' "$pinned_marker"; then
+  && grep -Eq '^-n .*/tr-enqueue-donecheck\.[[:alnum:]]{6}$' "$pinned_marker"; then
   pass "enqueue syntax check uses pinned Bash"
 else
   fail_case "enqueue syntax check uses pinned Bash" "rc=$rc args=$(cat "$pinned_marker" 2>/dev/null) output=$output"
+fi
+
+multiline_receipt=$'out/valid.json\nout/also-valid.json'
+if ! bash -c 'source "$1"; caty_valid_receipt "$2"' \
+  _ "$ROOT/scripts/lib-donecheck.sh" "$multiline_receipt"; then
+  pass "receipt helper rejects multiline values"
+else
+  fail_case "receipt helper rejects multiline values" "multiline value passed standalone grammar validation"
 fi
 
 task=$TMP_ROOT/unwritable-artifacts.task.md


### PR DESCRIPTION
Second child of security Epic #9 (adjudicated order #10 → **#11** → #12 → #13). Implements the frozen CP1 contract: #11 issuecomment-5251304581 (v2) + issuecomment-5251529443 (v3 amendments). The contract was approved at epic checkpoint 1 (#9 issuecomment-5251380656); this PR implements it as written, with one flagged platform guard (below).

## What this PR does

- **A1 — validate the snapshot that runs.** `tr-enqueue` now copies the task into the dot-prefixed queue-side staging file *first* and runs every enqueue gate (frontmatter, sections, donecheck extraction, receipt, `bash -n`, plan checks) against those staged bytes, then atomically renames into place. A staged/route id equality check closes the rename race. The staging name stays invisible to both queue enumerations (python glob and bash globs skip dotfiles).
- **A2 — raw `bash -n`.** `strip_donecheck_comments` deleted; syntax check runs on the raw extracted bytes. Emptiness = every line blank or full-line comment. Tests pin `#` inside quoted strings surviving to validation.
- **A3 / A3-1 / A3-2 — mechanical receipt boundary.** New required frontmatter key `receipt:`; grammar `^out/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$` **plus explicit per-segment rejection of `.`/`..`** (the character class admits both — regex alone is insufficient, and the probe matrix proves `out/../x` is refused). After donecheck rc=0 and before *both* `deliver_task` call sites, the runner asserts the target is a non-symlink, non-empty regular file whose fully resolved path stays under resolved `out/` (closes `test -s <dir>`=TRUE). Receipt-assertion failure = failed verification (verify-reason written, normal gap/budget path). Missing or grammar-invalid receipt metadata at the runner = **DLQ `missing-receipt` before any spawn** (tests assert the attempts dir stays empty), in both `run_one_attempt` and `recover_verifying`. The old grep-for-a-receipt-assertion heuristic is deleted, not repaired.
- **A4 — one extractor.** Both private extractors (awk column-0 vs python `strip()`) deleted; both callers use `scripts/lib-donecheck.sh` (`caty_extract_donecheck`). Pinned grammar: column-0 opener/closer only, LF-normalization, UTF-8 required, full-file scan rejects a second opener anywhere, unclosed fence rejected (deliberate tightening vs today's silent acceptance — flagged for review). Conformance corpus (`tests/donecheck-extract.test.sh`) pins indented-fence-in-heredoc, CRLF, missing final newline, second opener, unclosed, info-string, non-UTF-8, and the documented column-0-fence-in-heredoc textual truncation. Runner-side extraction failure on a queued copy = failed verification with the specific error in `verify-reason` (cannot deliver).
- **A5 / A5-1 / A5-2 — environment and interpreters.** Donecheck launches through `env -i` supplying exactly `TASK_ID`, `TASK_FILE`, `ARTIFACT_DIR`, `TR_DC_CWD`, fixed `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, `HOME`, and `LANG`/`LC_ALL`/`TZ` only when set — closes the inherited `TR_PUSH_CMD` read path. The A5-1 test asserts the four honest properties (parent sentinel + `TR_PUSH_CMD` invisible; supplied set present; no other `TR_*`; shell-created `PWD`/`SHLVL`/`_` enumerated, not asserted absent). One absolute bash + perl recorded in `loop/.tr-interpreters` at workspace init (`install.sh`), self-healing atomically (noclobber + `mv -n`) for pre-existing workspaces, fail-closed on invalid records naming file and value; used by *both* enqueue `bash -n` and the donecheck/spawn launches (fake-interpreter test observes the actual argv). Frontmatter duplicate-key handling unified to first-wins so enqueue (awk) and runner (python) parse the same `receipt` (parity test: quoted value, inline comment).
- **A6 — wrapper ulimits.** Header now sets best-effort CPU (`TR_DONECHECK_TIMEOUT_S`+60), file size 2,097,152 blocks (1 GiB), open files 256, process count 512; `donecheck_header_lines` 3→7 with the failing-line fixture still green. **Flagged platform guard (only deviation):** RLIMIT_NPROC is per-user on macOS, and lowering it below the already-live user process count leaves the wrapper unable to fork (measured). The header therefore applies `-u 512` only when the current per-UID count is observable and <480; otherwise that one limit is skipped. Documented in DESIGN and the header comment.
- **A7 — spawn boundary.** `TR_SPAWN_STEP` must be an absolute path to an executable regular file; violation exits 2 naming the value. PATH-resolved provider configs must migrate (documented).
- **Migration/docs.** All fixtures/templates carry valid `receipt:` and still deliver; docs (en+ja) document the receipt grammar, env allowlist breakage, heredoc column-0 fence prohibition, interpreter record, and absolute spawn path; DESIGN-task-runner.md gains the four accepted residual risks from the contract (runner-user execution by design, post-enqueue mutation undetected, `setsid` descendants escape the timeout kill, `TR_SPAWN_STEP` is operator-level).

## Files changed (declared vs actual)

Declared in the WIP (#11 issuecomment-5258232980): tr-enqueue, task-runner.sh, new lib-donecheck.sh, install.sh, the three named test suites + new corpus test + fixtures, DESIGN-task-runner.md, docs/plugins.md / docs/plugin-convention.md. Actual adds beyond the declaration, accepted on inspection: `scripts/activation-manifest.tsv` (the new sourced library must be registered or `tests/activation-manifest.test.sh` fails — same shape as the #10 acceptance), `templates/TASK.tmpl.md` + `templates/examples/img-pilot.task.md` + `tests/no-progress-stop.test.sh` (the A3 receipt migration reaches every task-shaped file, not only `tests/fixtures/`), and `docs/agent-guide.md` + `docs/reference.md` + `docs/reference.ja.md` (the declaration named the docs pair loosely; reference en/ja is where the runner contract actually lives). `docs/plugins.md` was declared but needed no change (plugin-convention.md carries the plugin-facing rules). Documented rather than waved through.

## Completion record (L1-7)

- Done-when 1: "design note states the trust model, approved at epic checkpoint 1" → **PASS** (CP1 v2/v3 approved 2026-08-11, #9 issuecomment-5251380656; residual risks folded into DESIGN-task-runner.md §7).
- Done-when 2: "comment stripping is quote-aware; tests cover quoted `#`" → **PASS via the approved stronger contract** — CP1 A2 deletes stripping entirely, so validation sees exactly the bytes that run; the quoted-`#` test pins it (`raw bash syntax preserves hash inside quotes`).
- Done-when 3: "the design note's mechanical bounds implemented and tested; out-of-scope documented as residual risk" → **PASS** (A1–A7 + A3-1/A3-2/A5-1/A5-2 all implemented with tests; the four contract residual risks documented).
- Candidate commit: `3a3e845` (base main `7155578`).
- Implementer verification (Codex Sol): `make test` all 23 suites exit 0, `make lint` 49 files, `bash -n` clean, `git diff --check` clean; macOS ulimit probe recorded (`cpu=120 file=2097152 open=256` applied; `-u` guarded as above).
- **Orchestrator verification (independent)**: own full `make test` run rc=0 (suites printing summaries: 391 PASS / 0 FAIL); receipt-grammar probe matrix 25/25 (`out/../x`, `out/./x`, `out//x`, bare `out`, absolute, uppercase, glob chars, `$`-injection all refused; `out/...x` accepted as grammar-legal); extractor edge probe 7/7 (second opener *inside* the block refused, CR-only endings, tab-trailing opener, indented closer = unclosed, comment-only block extracts and is caught by the enqueue emptiness rule); verified both old extractors deleted and only `caty_extract_donecheck` remains; header line count re-derived (7) against the trap arithmetic.
- Intersection with main at PR time: main unchanged since branch base (`7155578`); `git merge-tree --write-tree` clean (rc=0).

Review: 4 heterogeneous seats (Opus 5 / GLM 5.2 / Fable 5 / Grok 4.5) per the owner-approved downgrade while Kimi and Qwen are quota-absent (#9 issuecomment-5251589535); Codex Sol wrote this implementation and is ineligible as a reviewer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
