### PR TITLE
#49: single-source the SECRETS_ENV acceptance rules for wrapper and --check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,8 @@ source "$repo_root/scripts/lib-wrapper-conformance.sh"
 # shellcheck disable=SC1091
 source "$repo_root/scripts/lib-pause.sh"
 # shellcheck disable=SC1091
+source "$repo_root/scripts/lib-secrets-env.sh"
+# shellcheck disable=SC1091
 source "$repo_root/scripts/lib-donecheck.sh"
 legacy_marker_line="# fable-loop bootstrap v1"
 current_marker_line="# caty-agent-harness bootstrap v2"
@@ -562,30 +564,88 @@ check_secrets_env_file() {
   local workspace=$1
   local secrets_file=$2
   local source_file=$3
-  local current_uid
-  local owner_uid
-  local mode
+  local wrapper_rel
+  local shape_reasons shape_reason mode
+  local nul_line
+  local line_number=0 raw_line classify_rc
 
   [[ -n "$secrets_file" ]] || return 0
+  wrapper_rel=$(print_relative "$workspace" "$source_file")
+  if [[ -L "$secrets_file" ]]; then
+    shape_reasons=$(secrets_env_file_shape_reasons "$secrets_file")
+    while IFS= read -r shape_reason; do
+      [[ -n "$shape_reason" ]] || continue
+      printf 'warning: cron wrapper %s SECRETS_ENV %s: %s\n' "$wrapper_rel" "$shape_reason" "$secrets_file" >&2
+    done <<EOF
+$shape_reasons
+EOF
+    return 0
+  fi
   if [[ ! -f "$secrets_file" ]]; then
-    printf 'warning: cron wrapper %s SECRETS_ENV file not found: %s\n' "$(print_relative "$workspace" "$source_file")" "$secrets_file" >&2
+    printf 'warning: cron wrapper %s SECRETS_ENV file not found: %s\n' "$wrapper_rel" "$secrets_file" >&2
     return 0
   fi
 
-  current_uid=$(id -u)
-  owner_uid=$(file_owner_uid "$secrets_file")
-  mode=$(file_mode "$secrets_file")
+  shape_reasons=$(secrets_env_file_shape_reasons "$secrets_file")
+  while IFS= read -r shape_reason; do
+    [[ -n "$shape_reason" ]] || continue
+    case "$shape_reason" in
+      'permissions must be 0600 or 0400; has '*)
+        mode=${shape_reason##* }
+        printf 'warning: cron wrapper %s SECRETS_ENV permissions should be 0600 or 0400: %s has %s\n' "$wrapper_rel" "$secrets_file" "$mode" >&2
+        ;;
+      *)
+        printf 'warning: cron wrapper %s SECRETS_ENV %s: %s\n' "$wrapper_rel" "$shape_reason" "$secrets_file" >&2
+        ;;
+    esac
+  done <<EOF
+$shape_reasons
+EOF
 
-  if [[ "$owner_uid" != "$current_uid" ]]; then
-    printf 'warning: cron wrapper %s SECRETS_ENV owner uid %s does not match current uid %s: %s\n' "$(print_relative "$workspace" "$source_file")" "$owner_uid" "$current_uid" "$secrets_file" >&2
+  if ! nul_line=$(secrets_env_first_nul_line "$secrets_file"); then
+    printf 'warning: cron wrapper %s SECRETS_ENV could not be scanned for embedded NUL bytes: %s\n' "$wrapper_rel" "$secrets_file" >&2
+    return 0
+  fi
+  if [[ -n "$nul_line" ]]; then
+    printf 'warning: cron wrapper %s SECRETS_ENV line %s contains an embedded NUL byte: %s\n' "$wrapper_rel" "$nul_line" "$secrets_file" >&2
+    return 0
   fi
 
-  case "$mode" in
-    400|0400|600|0600) ;;
-    *)
-      printf 'warning: cron wrapper %s SECRETS_ENV permissions should be 0600 or 0400: %s has %s\n' "$(print_relative "$workspace" "$source_file")" "$secrets_file" "$mode" >&2
-      ;;
-  esac
+  if ! exec 8<"$secrets_file"; then
+    printf 'warning: cron wrapper %s SECRETS_ENV file is not readable: %s\n' "$wrapper_rel" "$secrets_file" >&2
+    return 0
+  fi
+  while IFS= read -r -u 8 raw_line || [[ -n "$raw_line" ]]; do
+    line_number=$((line_number + 1))
+    if secrets_env_classify_line "$raw_line"; then
+      classify_rc=0
+    else
+      classify_rc=$?
+    fi
+    case "$classify_rc" in
+      0)
+        if ! (command export "$SECRETS_ENV_KEY=$SECRETS_ENV_VALUE") 2>/dev/null; then
+          printf 'warning: cron wrapper %s SECRETS_ENV line %s cannot export %s (reserved or read-only name): %s\n' \
+            "$wrapper_rel" "$line_number" "$SECRETS_ENV_KEY" "$secrets_file" >&2
+        fi
+        ;;
+      1)
+        ;;
+      2)
+        printf 'warning: cron wrapper %s SECRETS_ENV line %s refuses interpreter-control name %s (rename it, e.g. APP_ENV): %s\n' \
+          "$wrapper_rel" "$line_number" "$SECRETS_ENV_KEY" "$secrets_file" >&2
+        ;;
+      3)
+        printf 'warning: cron wrapper %s SECRETS_ENV line %s is not a KEY=VALUE assignment: %s\n' \
+          "$wrapper_rel" "$line_number" "$secrets_file" >&2
+        ;;
+      *)
+        printf 'warning: cron wrapper %s SECRETS_ENV line %s could not be classified: %s\n' \
+          "$wrapper_rel" "$line_number" "$secrets_file" >&2
+        ;;
+    esac
+  done
+  exec 8<&-
 }
 
 extract_wrapper_secrets_env() {

--- a/scripts/activation-manifest.tsv
+++ b/scripts/activation-manifest.tsv
@@ -20,6 +20,7 @@ scripts/lib-bounded.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-classify.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-donecheck.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-pause.sh	exempt	explicit-function-argument	not-applicable	sourced-library	-	-
+scripts/lib-secrets-env.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-state-fold.sh	exempt	explicit-function-argument	not-applicable	sourced-library	-	-
 scripts/lib-wrapper-conformance.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/loop-init	exempt	--workspace	not-applicable	explicit-initialization-command	-	-

--- a/scripts/lib-secrets-env.sh
+++ b/scripts/lib-secrets-env.sh
@@ -1,0 +1,101 @@
+# shellcheck shell=bash
+# Source-only SECRETS_ENV acceptance rules shared by install.sh and cron wrappers.
+# This library intentionally has no source-time side effects or shell-option changes.
+
+secrets_env_file_shape_reasons() {
+  local secrets_path=$1
+  local current_uid owner_uid mode
+
+  if [[ -L "$secrets_path" ]]; then
+    printf 'must not be a symlink\n'
+    return 0
+  fi
+
+  current_uid=$(id -u)
+  if ! owner_uid=$(stat -c "%u" "$secrets_path" 2>/dev/null || stat -f "%u" "$secrets_path" 2>/dev/null); then
+    printf 'owner uid could not be determined\n'
+  elif [[ "$owner_uid" != "$current_uid" ]]; then
+    printf 'owner uid %s does not match current uid %s\n' "$owner_uid" "$current_uid"
+  fi
+
+  if ! mode=$(stat -c "%a" "$secrets_path" 2>/dev/null || stat -f "%Lp" "$secrets_path" 2>/dev/null); then
+    printf 'permissions could not be determined\n'
+  else
+    case "$mode" in
+      400|0400|600|0600) ;;
+      *)
+        printf 'permissions must be 0600 or 0400; has %s\n' "$mode"
+        ;;
+    esac
+  fi
+}
+
+secrets_env_first_nul_line() {
+  local secrets_path=$1
+
+  LC_ALL=C od -An -v -t u1 "$secrets_path" 2>/dev/null | awk '
+    BEGIN { line_number = 1 }
+    {
+      for (field = 1; field <= NF; field++) {
+        if (!found && $field == 0) {
+          first_match = line_number
+          found = 1
+        }
+        if ($field == 10) {
+          line_number++
+        }
+      }
+    }
+    END {
+      if (found) {
+        print first_match
+      }
+    }
+  '
+}
+
+secrets_env_classify_line() {
+  local raw_line=$1
+  local line value first_char last_char inner_value
+
+  SECRETS_ENV_KEY=
+  SECRETS_ENV_VALUE=
+  line=${raw_line%$'\r'}
+
+  if [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]]; then
+    return 1
+  fi
+  if [[ ! "$line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+    return 3
+  fi
+
+  SECRETS_ENV_KEY=${BASH_REMATCH[1]}
+  value=${BASH_REMATCH[2]}
+  case "$SECRETS_ENV_KEY" in
+    BASH_ENV|ENV|SHELLOPTS|BASHOPTS|IFS|PS4|CDPATH|GLOBIGNORE|PATH|BASH_XTRACEFD|\
+    PAGER|EDITOR|VISUAL|PERL5OPT|PERL5LIB|PERLLIB|PERL5DB|PERL5SHELL|\
+    PYTHONSTARTUP|PYTHONPATH|PYTHONHOME|PYTHONWARNINGS|PYTHONBREAKPOINT|\
+    RUBYOPT|RUBYLIB|NODE_OPTIONS|NODE_PATH|\
+    NODE_REPL_EXTERNAL_MODULE|GIT_SSH|GIT_SSH_COMMAND|GIT_EXTERNAL_DIFF|GIT_PAGER|\
+    GIT_EDITOR|GIT_ASKPASS|SSH_ASKPASS|GIT_PROXY_COMMAND|GIT_CONFIG_GLOBAL|\
+    GIT_CONFIG_SYSTEM|GIT_CONFIG_COUNT|GIT_CONFIG_PARAMETERS|GIT_EXEC_PATH|\
+    GIT_ALTERNATE_OBJECT_DIRECTORIES|LESSOPEN|LESSCLOSE|BASH_FUNC_*|LD_*|DYLD_*)
+      return 2
+      ;;
+  esac
+
+  if (( ${#value} >= 2 )); then
+    first_char=${value:0:1}
+    last_char=${value: -1}
+    if [[ "$first_char" == "$last_char" && ( "$first_char" == "'" || "$first_char" == '"' ) ]]; then
+      inner_value=${value:1:${#value}-2}
+      if [[ "$inner_value" != *"$first_char"* ]]; then
+        value=$inner_value
+      fi
+    fi
+  fi
+  # This global is the sourceable-library result consumed by both callers.
+  # shellcheck disable=SC2034
+  SECRETS_ENV_VALUE=$value
+  return 0
+}

--- a/templates/cron-wrapper.tmpl.sh
+++ b/templates/cron-wrapper.tmpl.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 # uid, and has 0600 or 0400 permissions. No shell code is executed. One matching
 # outer quote layer is stripped only when its inner value has no matching quote,
 # and one trailing CR is removed per line. Interpreter- or loader-control names
-# are refused; the refusal list is a hazard guard, not an exhaustive safety
+# are refused by scripts/lib-secrets-env.sh, which must be installed beside the
+# pause helper. The refusal list is a hazard guard, not an exhaustive safety
 # boundary. Portable Bash 3.2 cannot open with O_NOFOLLOW, so a residual path
 # replacement race remains despite the pre/post-open identity checks.
 
@@ -30,30 +31,24 @@ fail() {
   exit 3
 }
 
-file_owner_uid() {
-  stat -c "%u" "$1" 2>/dev/null || stat -f "%u" "$1"
-}
-
-file_mode() {
-  stat -c "%a" "$1" 2>/dev/null || stat -f "%Lp" "$1"
-}
-
 validate_secrets_env() {
-  local secrets_path=$1 current_uid owner_uid mode
+  local secrets_path=$1 shape_reasons shape_reason mode
 
-  current_uid=$(id -u)
-  owner_uid=$(file_owner_uid "$secrets_path")
-  mode=$(file_mode "$secrets_path")
-
-  if [[ "$owner_uid" != "$current_uid" ]]; then
-    fail "SECRETS_ENV owner uid $owner_uid does not match current uid $current_uid: $secrets_path"
-  fi
-  case "$mode" in
-    400|0400|600|0600) ;;
-    *)
-      fail "SECRETS_ENV permissions must be 0600 or 0400: $secrets_path has $mode"
-      ;;
-  esac
+  shape_reasons=$(secrets_env_file_shape_reasons "$secrets_path")
+  while IFS= read -r shape_reason; do
+    [[ -n "$shape_reason" ]] || continue
+    case "$shape_reason" in
+      'permissions must be 0600 or 0400; has '*)
+        mode=${shape_reason##* }
+        fail "SECRETS_ENV permissions must be 0600 or 0400: $secrets_path has $mode"
+        ;;
+      *)
+        fail "SECRETS_ENV $shape_reason: $secrets_path"
+        ;;
+    esac
+  done <<EOF
+$shape_reasons
+EOF
 }
 
 same_open_file() {
@@ -71,74 +66,37 @@ same_open_file() {
   [[ "$path_identity" == "$fd_identity" ]]
 }
 
-first_nul_line() {
-  local secrets_path=$1
-
-  LC_ALL=C od -An -v -t u1 "$secrets_path" 2>/dev/null | awk '
-    BEGIN { line_number = 1 }
-    {
-      for (field = 1; field <= NF; field++) {
-        if (!found && $field == 0) {
-          first_match = line_number
-          found = 1
-        }
-        if ($field == 10) {
-          line_number++
-        }
-      }
-    }
-    END {
-      if (found) {
-        print first_match
-      }
-    }
-  '
-}
-
 parse_secrets_env() {
   local secrets_path=$1
-  local line_number=0 raw_line line key value first_char last_char inner_value
+  local line_number=0 raw_line classify_rc
 
   while IFS= read -r -u 9 raw_line || [[ -n "$raw_line" ]]; do
     line_number=$((line_number + 1))
-    line=${raw_line%$'\r'}
-
-    if [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]]; then
-      continue
+    if secrets_env_classify_line "$raw_line"; then
+      classify_rc=0
+    else
+      classify_rc=$?
     fi
-    if [[ "$line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
-      key=${BASH_REMATCH[1]}
-      value=${BASH_REMATCH[2]}
-      case "$key" in
-        BASH_ENV|ENV|SHELLOPTS|BASHOPTS|IFS|PS4|CDPATH|GLOBIGNORE|PATH|BASH_XTRACEFD|\
-        PAGER|EDITOR|VISUAL|PERL5OPT|PERL5LIB|PERLLIB|PERL5DB|PERL5SHELL|\
-        PYTHONSTARTUP|PYTHONPATH|PYTHONHOME|PYTHONWARNINGS|PYTHONBREAKPOINT|\
-        RUBYOPT|RUBYLIB|NODE_OPTIONS|NODE_PATH|\
-        NODE_REPL_EXTERNAL_MODULE|GIT_SSH|GIT_SSH_COMMAND|GIT_EXTERNAL_DIFF|GIT_PAGER|\
-        GIT_EDITOR|GIT_ASKPASS|SSH_ASKPASS|GIT_PROXY_COMMAND|GIT_CONFIG_GLOBAL|\
-        GIT_CONFIG_SYSTEM|GIT_CONFIG_COUNT|GIT_CONFIG_PARAMETERS|GIT_EXEC_PATH|\
-        GIT_ALTERNATE_OBJECT_DIRECTORIES|LESSOPEN|LESSCLOSE|BASH_FUNC_*|LD_*|DYLD_*)
-          fail "SECRETS_ENV line $line_number refuses interpreter-control name $key (rename it, e.g. APP_ENV): $secrets_path"
-          ;;
-      esac
-      if (( ${#value} >= 2 )); then
-        first_char=${value:0:1}
-        last_char=${value: -1}
-        if [[ "$first_char" == "$last_char" && ( "$first_char" == "'" || "$first_char" == '"' ) ]]; then
-          inner_value=${value:1:${#value}-2}
-          if [[ "$inner_value" != *"$first_char"* ]]; then
-            value=$inner_value
-          fi
+    case "$classify_rc" in
+      0)
+        # `command` keeps assignment failures catchable across shells and modes
+        # without changing where the variable is set.
+        if ! command export "$SECRETS_ENV_KEY=$SECRETS_ENV_VALUE" 2>/dev/null; then
+          fail "SECRETS_ENV line $line_number cannot export $SECRETS_ENV_KEY (reserved or read-only name): $secrets_path"
         fi
-      fi
-      # `command` keeps assignment failures catchable across shells and modes
-      # without changing where the variable is set.
-      if ! command export "$key=$value" 2>/dev/null; then
-        fail "SECRETS_ENV line $line_number cannot export $key (reserved or read-only name): $secrets_path"
-      fi
-      continue
-    fi
-    fail "SECRETS_ENV line $line_number is not a KEY=VALUE assignment; SECRETS_ENV requires one assignment per line (store multi-line secrets in their own file and put the path in SECRETS_ENV): $secrets_path"
+        ;;
+      1)
+        ;;
+      2)
+        fail "SECRETS_ENV line $line_number refuses interpreter-control name $SECRETS_ENV_KEY (rename it, e.g. APP_ENV): $secrets_path"
+        ;;
+      3)
+        fail "SECRETS_ENV line $line_number is not a KEY=VALUE assignment; SECRETS_ENV requires one assignment per line (store multi-line secrets in their own file and put the path in SECRETS_ENV): $secrets_path"
+        ;;
+      *)
+        fail "SECRETS_ENV line $line_number could not be classified: $secrets_path"
+        ;;
+    esac
   done
 }
 
@@ -214,8 +172,18 @@ if [[ ! -x "$TARGET" ]]; then
 fi
 
 if [[ -n "$SECRETS_ENV" ]]; then
+  secrets_lib="$(dirname "$pause_helper")/lib-secrets-env.sh"
+  if [[ ! -f "$secrets_lib" || ! -r "$secrets_lib" || -L "$secrets_lib" ]] \
+    || ! bash -n "$secrets_lib" >/dev/null 2>&1; then
+    fail "SECRETS_ENV acceptance library is unavailable or invalid: $secrets_lib"
+  fi
+  # shellcheck disable=SC1090
+  if ! source "$secrets_lib" 2>/dev/null; then
+    fail "SECRETS_ENV acceptance library could not be loaded: $secrets_lib"
+  fi
+
   if [[ -L "$SECRETS_ENV" ]]; then
-    fail "SECRETS_ENV must not be a symlink: $SECRETS_ENV"
+    validate_secrets_env "$SECRETS_ENV"
   fi
   if [[ -f "$SECRETS_ENV" ]]; then
     validate_secrets_env "$SECRETS_ENV"
@@ -230,7 +198,7 @@ if [[ -n "$SECRETS_ENV" ]]; then
 
     validate_secrets_env "$SECRETS_ENV"
 
-    if ! nul_line=$(first_nul_line "$SECRETS_ENV"); then
+    if ! nul_line=$(secrets_env_first_nul_line "$SECRETS_ENV"); then
       exec 9<&-
       fail "SECRETS_ENV could not be scanned for embedded NUL bytes: $SECRETS_ENV"
     fi

--- a/tests/secrets-env-rules.test.sh
+++ b/tests/secrets-env-rules.test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+WRAPPER_TEMPLATE=$ROOT/templates/cron-wrapper.tmpl.sh
+TMP_ROOT=${TMPDIR:-/tmp}/secrets-env-rules-test.$$
+PASS_COUNT=0
+FAIL_COUNT=0
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$TMP_ROOT"
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+fail_case() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL %s: %s\n' "$1" "$2"
+}
+
+seed_workspace() {
+  local name=$1
+  local workspace=$TMP_ROOT/ws-$name
+
+  "$ROOT/install.sh" --workspace "$workspace" >/dev/null 2>&1
+  printf '%s\n' '- fixture; 2026-08-12T00:00' >>"$workspace/STATE.md"
+  printf '%s\n' '- 2026-08-12 | task=fixture | verifier=test | verdict=pass | fixture' >>"$workspace/loop/VERIFY.log.md"
+  printf '%s\n' "$workspace"
+}
+
+install_configured_wrapper() {
+  local workspace=$1
+  local secrets_file=$2
+  local wrapper=$workspace/scripts/cron-wrapper.sh
+
+  mkdir -p "$workspace/scripts"
+  awk -v secrets_file="$secrets_file" '
+    NR == 2 { printf "SECRETS_ENV=\"%s\"\n", secrets_file }
+    { print }
+  ' "$WRAPPER_TEMPLATE" >"$wrapper"
+  chmod +x "$wrapper"
+  printf '%s\n' "$wrapper"
+}
+
+assert_prediction() {
+  local name=$1
+  local secrets_file=$2
+  local expected=$3
+  local warning_fragment=$4
+  local workspace wrapper check_rc wrapper_rc
+  local check_warned=0 wrapper_rejected=0
+
+  workspace=$(seed_workspace "$name")
+  wrapper=$(install_configured_wrapper "$workspace" "$secrets_file")
+
+  "$ROOT/install.sh" --check --workspace "$workspace" \
+    >"$TMP_ROOT/$name.check.out" 2>"$TMP_ROOT/$name.check.err"
+  check_rc=$?
+  if grep -Fq 'warning: cron wrapper scripts/cron-wrapper.sh SECRETS_ENV ' "$TMP_ROOT/$name.check.err"; then
+    check_warned=1
+  fi
+
+  TARGET="$TMP_ROOT/recorder" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$workspace" \
+    "$wrapper" >"$TMP_ROOT/$name.wrapper.out" 2>"$TMP_ROOT/$name.wrapper.err"
+  wrapper_rc=$?
+  if [ "$wrapper_rc" -eq 3 ] \
+    && grep -Fq 'cron-wrapper infra error:' "$TMP_ROOT/$name.wrapper.err"; then
+    wrapper_rejected=1
+  fi
+
+  if [ "$expected" = reject ] \
+    && [ "$check_rc" -eq 0 ] && [ "$check_warned" -eq 1 ] \
+    && [ "$wrapper_rejected" -eq 1 ] \
+    && grep -Fq "$warning_fragment" "$TMP_ROOT/$name.check.err"; then
+    pass "$name check warning predicts real wrapper rejection"
+  elif [ "$expected" = accept ] \
+    && [ "$check_rc" -eq 0 ] && [ "$check_warned" -eq 0 ] \
+    && [ "$wrapper_rc" -eq 0 ] && [ "$wrapper_rejected" -eq 0 ]; then
+    pass "$name check silence predicts real wrapper acceptance"
+  else
+    fail_case "$name prediction equivalence" \
+      "check_rc=$check_rc warned=$check_warned wrapper_rc=$wrapper_rc rejected=$wrapper_rejected check_stderr=$(cat "$TMP_ROOT/$name.check.err") wrapper_stderr=$(cat "$TMP_ROOT/$name.wrapper.err")"
+  fi
+}
+
+assert_secrets_lib_failure() {
+  local name=$1
+  local harness_root=$2
+  local expected_message=$3
+  local workspace rc
+
+  workspace=$(seed_workspace "lib-$name")
+  TARGET="$TMP_ROOT/recorder" CATY_HARNESS_ROOT="$harness_root" CATY_WORKSPACE="$workspace" \
+    SECRETS_ENV="$valid_file" "$WRAPPER_TEMPLATE" \
+    >"$TMP_ROOT/lib-$name.out" 2>"$TMP_ROOT/lib-$name.err"
+  rc=$?
+  if [ "$rc" -eq 3 ] \
+    && grep -Fq 'cron-wrapper infra error:' "$TMP_ROOT/lib-$name.err" \
+    && grep -Fq "$expected_message" "$TMP_ROOT/lib-$name.err" \
+    && ! grep -Fq 'status=paused' "$TMP_ROOT/lib-$name.err"; then
+    pass "$name secrets library fails closed through the infra-error contract"
+  else
+    fail_case "$name secrets library fails closed" \
+      "rc=$rc stderr=$(cat "$TMP_ROOT/lib-$name.err")"
+  fi
+}
+
+cat >"$TMP_ROOT/recorder" <<'EOF'
+#!/usr/bin/env bash
+printf 'ran\n'
+EOF
+chmod +x "$TMP_ROOT/recorder"
+
+valid_file=$TMP_ROOT/valid.env
+printf '# neutral fixture\n\n  GOOD="quoted"\r\n' >"$valid_file"
+chmod 600 "$valid_file"
+
+refused_file=$TMP_ROOT/refused.env
+printf 'BASH_ENV=x\n' >"$refused_file"
+chmod 600 "$refused_file"
+
+readonly_name_file=$TMP_ROOT/readonly-name.env
+printf 'UID=1\n' >"$readonly_name_file"
+chmod 600 "$readonly_name_file"
+
+non_assignment_file=$TMP_ROOT/non-assignment.env
+printf 'export GOOD=plain\n' >"$non_assignment_file"
+chmod 600 "$non_assignment_file"
+
+nul_file=$TMP_ROOT/nul.env
+printf 'GOOD=plain\nBROKEN=left\0right\n' >"$nul_file"
+chmod 600 "$nul_file"
+
+bad_mode_file=$TMP_ROOT/bad-mode.env
+printf 'GOOD=plain\n' >"$bad_mode_file"
+chmod 644 "$bad_mode_file"
+
+symlink_source=$TMP_ROOT/symlink-source.env
+symlink_file=$TMP_ROOT/symlink.env
+printf 'GOOD=plain\n' >"$symlink_source"
+chmod 600 "$symlink_source"
+ln -s "$symlink_source" "$symlink_file"
+
+assert_prediction valid "$valid_file" accept ''
+assert_prediction refused-name "$refused_file" reject 'line 1 refuses interpreter-control name BASH_ENV'
+assert_prediction readonly-name "$readonly_name_file" reject 'line 1 cannot export UID (reserved or read-only name)'
+assert_prediction non-assignment "$non_assignment_file" reject 'line 1 is not a KEY=VALUE assignment'
+assert_prediction embedded-nul "$nul_file" reject 'line 2 contains an embedded NUL byte'
+assert_prediction bad-mode "$bad_mode_file" reject 'SECRETS_ENV permissions should be 0600 or 0400'
+assert_prediction symlink "$symlink_file" reject 'SECRETS_ENV must not be a symlink'
+
+dangling_file=$TMP_ROOT/dangling.env
+ln -s "$TMP_ROOT/absent.env" "$dangling_file"
+assert_prediction dangling-symlink "$dangling_file" reject 'SECRETS_ENV must not be a symlink'
+
+fake_root=$TMP_ROOT/harness-without-secrets-lib
+mkdir -p "$fake_root/scripts"
+cp "$ROOT/scripts/lib-pause.sh" "$fake_root/scripts/lib-pause.sh"
+missing_lib_ws=$(seed_workspace missing-lib)
+TARGET="$TMP_ROOT/recorder" CATY_HARNESS_ROOT="$fake_root" CATY_WORKSPACE="$missing_lib_ws" \
+  "$WRAPPER_TEMPLATE" >"$TMP_ROOT/no-secrets-lib.out" 2>"$TMP_ROOT/no-secrets-lib.err"
+no_secrets_lib_rc=$?
+TARGET="$TMP_ROOT/recorder" CATY_HARNESS_ROOT="$fake_root" CATY_WORKSPACE="$missing_lib_ws" \
+  SECRETS_ENV="$valid_file" "$WRAPPER_TEMPLATE" \
+  >"$TMP_ROOT/missing-lib.out" 2>"$TMP_ROOT/missing-lib.err"
+missing_lib_rc=$?
+if [ "$no_secrets_lib_rc" -eq 0 ] && grep -Fxq 'ran' "$TMP_ROOT/no-secrets-lib.out" \
+  && [ "$missing_lib_rc" -eq 3 ] \
+  && grep -Fq 'cron-wrapper infra error: SECRETS_ENV acceptance library is unavailable or invalid:' "$TMP_ROOT/missing-lib.err" \
+  && ! grep -Fq 'status=paused' "$TMP_ROOT/missing-lib.err"; then
+  pass 'secrets library is optional without secrets and fails closed when configured'
+else
+  fail_case 'missing secrets library fails closed' \
+    "no_secrets_rc=$no_secrets_lib_rc secrets_rc=$missing_lib_rc stderr=$(cat "$TMP_ROOT/missing-lib.err")"
+fi
+
+symlink_lib_root=$TMP_ROOT/harness-symlink-secrets-lib
+mkdir -p "$symlink_lib_root/scripts"
+cp "$ROOT/scripts/lib-pause.sh" "$symlink_lib_root/scripts/lib-pause.sh"
+ln -s "$ROOT/scripts/lib-secrets-env.sh" "$symlink_lib_root/scripts/lib-secrets-env.sh"
+assert_secrets_lib_failure symlink "$symlink_lib_root" \
+  'SECRETS_ENV acceptance library is unavailable or invalid:'
+
+unreadable_lib_root=$TMP_ROOT/harness-unreadable-secrets-lib
+mkdir -p "$unreadable_lib_root/scripts"
+cp "$ROOT/scripts/lib-pause.sh" "$unreadable_lib_root/scripts/lib-pause.sh"
+cp "$ROOT/scripts/lib-secrets-env.sh" "$unreadable_lib_root/scripts/lib-secrets-env.sh"
+chmod 000 "$unreadable_lib_root/scripts/lib-secrets-env.sh"
+if [ -r "$unreadable_lib_root/scripts/lib-secrets-env.sh" ]; then
+  pass 'unreadable secrets library check skipped because this user can read mode 000 files'
+else
+  assert_secrets_lib_failure unreadable "$unreadable_lib_root" \
+    'SECRETS_ENV acceptance library is unavailable or invalid:'
+fi
+
+invalid_lib_root=$TMP_ROOT/harness-invalid-secrets-lib
+mkdir -p "$invalid_lib_root/scripts"
+cp "$ROOT/scripts/lib-pause.sh" "$invalid_lib_root/scripts/lib-pause.sh"
+printf 'this is not valid shell syntax (\n' >"$invalid_lib_root/scripts/lib-secrets-env.sh"
+assert_secrets_lib_failure syntax-invalid "$invalid_lib_root" \
+  'SECRETS_ENV acceptance library is unavailable or invalid:'
+
+source_failure_lib_root=$TMP_ROOT/harness-source-failure-secrets-lib
+mkdir -p "$source_failure_lib_root/scripts"
+cp "$ROOT/scripts/lib-pause.sh" "$source_failure_lib_root/scripts/lib-pause.sh"
+printf 'return 1\n' >"$source_failure_lib_root/scripts/lib-secrets-env.sh"
+assert_secrets_lib_failure source-failure "$source_failure_lib_root" \
+  'SECRETS_ENV acceptance library could not be loaded:'
+
+refusal_locations=$(grep -Fl 'BASH_ENV|ENV|SHELLOPTS' \
+  "$ROOT/scripts/lib-secrets-env.sh" "$ROOT/templates/cron-wrapper.tmpl.sh" "$ROOT/install.sh" || true)
+assignment_locations=$(grep -Fl '([A-Za-z_][A-Za-z0-9_]*)=(.*)' \
+  "$ROOT/scripts/lib-secrets-env.sh" "$ROOT/templates/cron-wrapper.tmpl.sh" "$ROOT/install.sh" || true)
+if [ "$refusal_locations" = "$ROOT/scripts/lib-secrets-env.sh" ] \
+  && [ "$assignment_locations" = "$ROOT/scripts/lib-secrets-env.sh" ]; then
+  pass 'refusal list and assignment grammar have one production source'
+else
+  fail_case 'single-source anti-drift guard' \
+    "refusal_locations=$refusal_locations assignment_locations=$assignment_locations"
+fi
+
+printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
Closes #49 (follow-up to #10 / PR #48, Opus seat finding M5 second half). Fixes the operability gap where `install.sh --check` reports green on a SECRETS_ENV file the cron wrapper will reject at 03:00 — and removes the structural drift that produced it.

## What this PR does

- **One production source for the acceptance rules.** New `scripts/lib-secrets-env.sh` holds, moved verbatim from the wrapper template: the interpreter/loader-control refusal list, the one-assignment-per-line grammar (indentation allowed, one trailing CR trimmed, one outer quote layer stripped only when the inner value has no matching quote), the embedded-NUL scanner, and the file-shape rules (symlink refusal, owner uid, 0600/0400 mode). Bash 3.2-safe, source-only, no side effects, BSD stat fallbacks preserved.
- **Wrapper template consumes the library.** `templates/cron-wrapper.tmpl.sh` deletes its inline copies and resolves the library beside the already-resolved pause helper (`CATY_HARNESS_ROOT` or the TARGET-relative fallback), **only inside the `SECRETS_ENV` branch** — installs without secrets never depend on it. Library missing / symlink / unreadable / `bash -n` failure / source failure → `cron-wrapper infra error:` + exit 3, never the pause path's silent exit 0. All runtime orchestration stays wrapper-side: fd-9 open, pre/post `same_open_file` identity checks, `fail()` mapping, `command export`. Every wrapper error string is byte-identical to before (the strings pinned in `tests/deadman-probe.test.sh` still pass untouched). The `v1` template marker is unchanged.
- **`--check` now predicts the wrapper.** `check_secrets_env_file` applies the same rules through the same library to a configured secrets file: shape reasons, NUL scan, per-line grammar/name classification, plus a subshell exportability probe (`(command export KEY=VALUE)`) that predicts the wrapper's reserved/read-only-name rejection without polluting install.sh's environment. Each finding is one `warning: cron wrapper <rel> SECRETS_ENV ...` advisory row on stderr. Exit-code contract, stdout machine rows, frozen `warning: `/`missing ` prefixes, and the pinned permissions wording are unchanged. Warnings carry key names and line numbers only — never values.
- **Tests.** New `tests/secrets-env-rules.test.sh` (14 cases): prediction equivalence executed against the **real template** over shared fixtures (valid file / refused name / non-assignment / embedded NUL / bad mode / symlink / dangling symlink / readonly name `UID`) asserting wrapper-rejects ⟺ check-warns and wrapper-accepts ⟺ check-silent; the four library fail-closed paths (missing, symlink, syntax-invalid, source-failure) plus the no-secrets-configured path proving the library is optional there; and an anti-drift grep pinning that the refusal list and assignment grammar exist **only** in `scripts/lib-secrets-env.sh` — the drift #49 names cannot silently re-form.

## Files changed (declared vs actual)

Declared in the WIP (#49 issuecomment-5261532313): install.sh, templates/cron-wrapper.tmpl.sh, scripts/lib-secrets-env.sh (new), tests/check-tickprobe.test.sh, possibly tests/cron-wrapper*.test.sh. Actual: install.sh, templates/cron-wrapper.tmpl.sh, scripts/lib-secrets-env.sh (new), **tests/secrets-env-rules.test.sh (new)** — the equivalence matrix got its own focused suite instead of growing check-tickprobe (same idiom: PASS/FAIL counters, TMP_ROOT, cleanup trap); check-tickprobe needed no edits because its pinned `WARN_SECRETS` wording survives verbatim. Within the declared surface; no adapter, runner, or CI files touched (#51's territory untouched).

## Completion record (L1-7)

- Done-when 1: "--check applies the wrapper's acceptance rules (symlink, grammar, NUL, refusal list) as warning-prefixed advisories without changing the exit-code contract" → **PASS** (plus the readonly-export class found on inspection; exit code and streams pinned by the existing regression test, untouched).
- Done-when 2: "the rule set lives in one place shared by wrapper and install.sh so the two cannot drift" → **PASS** (`scripts/lib-secrets-env.sh` is the only file matching the refusal-list and grammar literals; enforced by the anti-drift grep test, so a future copy fails the suite).
- Done-when 3: "a file the wrapper rejects makes --check say so; a file the wrapper accepts stays clean; frozen prefixes and stdout machine rows unchanged" → **PASS** (equivalence matrix runs the real template; stream-split regression in check-tickprobe green).
- Candidate commit: `d4c0626` (base main `3441b8e`).
- Implementer: Codex Sol (initial + delta r1: readonly-export prediction gap). Orchestrator (Alpha) independent verification: full suite 24/24 files 0 FAIL run twice (post-initial, post-delta); `bash -n` + `shellcheck -x` clean on all four files; diff precision-read confirming wrapper error strings byte-identical and `set -e`-safe rc capture at every classify call site.
- Intersection with main at PR time: main unchanged since branch base (`3441b8e`); no open PRs; #51 (task-runner/tr-enqueue lane) shares no files with this diff.

Review: 2 heterogeneous seats per `loom-seats` (size M, no risk areas): Kimi K3 + GLM 5.2. Codex Sol wrote the implementation and is ineligible as a reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
