### PR TITLE
#12: verify the release before family-updater checks it out (CP2)

### DIFF
--- a/docs/updater-rollout.md
+++ b/docs/updater-rollout.md
@@ -46,31 +46,57 @@ read-only deploy credential; the updater never pushes.
 
 ## Persistent state
 
-Each clone basename has an independent monotonic pin:
+Each physical clone path has an independent monotonic pin. The readable clone
+basename is suffixed with a stable short hash of its resolved physical path, so
+two clones named alike do not share state:
 
 ```text
-$HOME/.claude/state/updater-pin/<repo-name>.json
+$HOME/.claude/state/updater-pin/<repo-name>-<path-hash>.json
 ```
 
 It records the highest successfully installed version and its full commit OID.
-An existing machine without a pin seeds it from pre-fetch `HEAD` only when that
-commit is at a strict semver tag. Otherwise the updater fails closed and names
-`scripts/updater-bootstrap`. Unreadable or malformed pins also fail closed.
+An existing machine without a pin takes the version name only from the most
+recent `ok` entry for this repository in the machine-written
+`$HOME/.claude/state/installed-versions.log`, and accepts it only when that name
+still points at pre-fetch `HEAD`. The floor commit is always that recorded
+pre-fetch OID. Without consistent ledger evidence the updater fails closed and
+names `scripts/updater-bootstrap`. Unreadable or malformed pins also fail
+closed. A `--dry-run` computes this floor in memory but writes no pin, dedupe or
+ledger state and sends no heartbeat or hot-inbox report.
 
-Rejected or moved names are recorded once at:
+Moved names, report dedupe, and exact install-failure identities are recorded in
+the append-only state log at:
 
 ```text
-$HOME/.claude/state/updater-ineligible/<repo-name>.log
+$HOME/.claude/state/updater-ineligible/<repo-name>-<path-hash>.log
 ```
 
-Those names remain excluded, but one bad upstream name does not wedge later
-legitimate updates or produce an hourly alert storm.
+A moved name remains excluded. A cryptographic or floor verification failure is
+retried on later ticks so signer rotation or another out-of-band repair can
+recover it; its report is deduplicated until that name passes verification.
+Structurally valid remote records with non-semver tag names are skipped with a
+local stdout note. They never become candidates and produce no report or
+persistent record. Skipped names do not enter duplicate detection, so a repeated
+non-semver record is skipped again. Duplicate strict-semver names and unparsable
+remote records still stop the run and report once per offending name. An
+`install.sh --check` failure excludes only the exact tag-name/commit-OID pair
+after rollback, preventing hourly checkout and report churn.
 
 ## Release signing and key rotation
 
 Every update target must be a strict semver annotated tag signed by a pinned SSH
 key. Legacy lightweight or unsigned releases are rollback identities only and
 can never be selected as update targets.
+
+The gate binds a verified tag to its exact name and a pinned signing key; it
+does **not** bind that tag to a repository. Each repository therefore must have
+its own signing key and its own `allowed_signers` file. Sharing a key across
+repositories lets a release signed for one repository pass the gate and be
+installed by another repository.
+
+A tag name rejected as moved is permanently excluded on that machine. Publish
+the corrected release under a higher version; never re-push it under the same
+name.
 
 Rotate signing keys with overlap:
 

--- a/docs/updater-rollout.md
+++ b/docs/updater-rollout.md
@@ -1,118 +1,114 @@
-# Task Packet — family-updater rollout
+# Family updater rollout
 
-> Historical design record. Issue numbers cited in this document refer to the pre-publication private trackers, not to issues in this repository.
+The updater follows released tags only after verifying the exact tag object it
+will use. SSH tag signatures are the security control. The stable-ring soak is
+only rollout pacing: a signer can backdate `GIT_COMMITTER_DATE`, so tag age must
+never be treated as proof of authenticity.
 
-From: Alpha · SoT: pre-publication private tracker Issue #36
-For: Claude Code, OpenClaw, and Hermes family agents
+## First installation: mechanical bootstrap gate
 
-## Claude Code
+Do not execute the clone's cron wrapper or recurring updater before bootstrap.
+The owner must deliver two values out of band:
 
-### Why (read first)
+1. an SSH `allowed_signers` file, normally
+   `$HOME/.claude/state/updater-allowed-signers`; and
+2. the exact initial release name, such as `v1.3.0`.
 
-Claude Code needs the harness clone to follow released tags without giving the
-updater any write authority. The updater fetches tags, checks out the selected
-release in detached HEAD, runs `install.sh --check`, and rolls back if the check
-fails.
+The signer file must be non-empty, readable, and outside the clone. Never copy
+it from the repository, auto-create it, or fall back to Git configuration. Run
+an out-of-band copy of the bootstrap command (or compare its bytes with a trusted
+copy before execution). The trusted directory must contain both
+`updater-bootstrap` and its sibling `lib-updater-verify.sh`:
 
-### What to do
+```sh
+/trusted/updater-bootstrap \
+  --repo-dir "$HOME/claude-workspace/caty-agent-harness" \
+  --allowed-signers "$HOME/.claude/state/updater-allowed-signers" \
+  --initial-tag v1.3.0 \
+  --cron-wrapper-dest "$HOME/.local/bin/caty-family-updater-cron"
+```
 
-1. Prepare a stable harness clone with a read-only deploy key or fine-grained PAT.
-   Do not use a token with write access.
-2. Copy `templates/updater-cron.tmpl.sh` into a cron-owned scripts location.
-3. Install a cron line like:
-   ```cron
-   12 * * * * REPO_DIR="$HOME/claude-workspace/caty-agent-harness" WORKSPACE="$HOME/claude-workspace" AGENT="claude-code" RING="stable" SOAK_HOURS="24" FMA_SCRIPTS_DIR="$HOME/claude-workspace/family-memory-architecture/scripts" "$HOME/claude-workspace/caty-agent-harness/templates/updater-cron.tmpl.sh" >>"$HOME/claude-workspace/updater-cron.log" 2>&1
-   ```
+Bootstrap verifies exactly the owner-named tag; it does not select a newer tag.
+It captures the tag-object and commit OIDs once, verifies the captured tag object
+with the forced out-of-repo signer pin, binds the `tag` header exactly to the
+owner-named ref, checks out the captured commit OID, asserts `HEAD`, records the
+per-repository floor, and only then installs the cron wrapper. A rebound tag is
+refused.
 
-### Constraints
+After bootstrap, configure the copied wrapper. Example:
 
-- The credential on the clone is read-only. The updater never pushes.
-- Keep Claude Code on `stable` unless Alpha assigns a canary duty.
-- The cron wrapper must point at an absolute `REPO_DIR`.
+```cron
+12 * * * * REPO_DIR="$HOME/claude-workspace/caty-agent-harness" WORKSPACE="$HOME/claude-workspace" AGENT="claude-code" RING="stable" SOAK_HOURS="24" FMA_SCRIPTS_DIR="$HOME/claude-workspace/family-memory-architecture/scripts" CATY_UPDATER_ALLOWED_SIGNERS="$HOME/.claude/state/updater-allowed-signers" "$HOME/.local/bin/caty-family-updater-cron" >>"$HOME/claude-workspace/updater-cron.log" 2>&1
+```
 
-### Done when
+Use `RING=canary SOAK_HOURS=0` only for the assigned canary. Give every clone a
+read-only deploy credential; the updater never pushes.
 
-- [ ] Cron is installed and points at the intended clone and workspace.
-- [ ] `scripts/family-updater --repo-dir <clone> --workspace <ws> --ring stable`
-      succeeds once manually.
-- [ ] Heartbeats appear as `job-heartbeat updater-claude-code`.
-- [ ] Local ledger entries appear for real updates and failures in
-      `~/.claude/state/installed-versions.log`; no-op already-current runs do
-      not add a line.
+## Persistent state
 
-## OpenClaw / Claire
+Each clone basename has an independent monotonic pin:
 
-### Why (read first)
+```text
+$HOME/.claude/state/updater-pin/<repo-name>.json
+```
 
-Claire is the family canary. She should receive the newest valid release tag first
-so failures are caught before stable agents update.
+It records the highest successfully installed version and its full commit OID.
+An existing machine without a pin seeds it from pre-fetch `HEAD` only when that
+commit is at a strict semver tag. Otherwise the updater fails closed and names
+`scripts/updater-bootstrap`. Unreadable or malformed pins also fail closed.
 
-> Status: Claire installed as canary on 2026-07-09 (v1.1.0, RING=canary SOAK_HOURS=0,
-> hourly cron, heartbeat `updater-claire.json` ok, 34/34 tests green on host).
-> v1.1.1 is the first tag distributed via the rail itself.
+Rejected or moved names are recorded once at:
 
-> Path correction (install learning, pre-publication private tracker #40): the cron line below shows
-> `WORKSPACE="/path/to/claire-home/.openclaw-claire/workspace"`, but Claire's real workspace
-> is `/path/to/openclaw-home/.openclaw/workspace-claire`. Verify the live workspace path on
-> the host before installing; do not copy packet paths blindly.
+```text
+$HOME/.claude/state/updater-ineligible/<repo-name>.log
+```
 
-### What to do
+Those names remain excluded, but one bad upstream name does not wedge later
+legitimate updates or produce an hourly alert storm.
 
-1. Prepare Claire's harness clone with a read-only deploy key or fine-grained PAT.
-2. Use the updater cron wrapper with Claire on canary:
-   ```cron
-   17 * * * * REPO_DIR="/path/to/clones/caty-agent-harness" WORKSPACE="/path/to/claire-home/.openclaw-claire/workspace" AGENT="claire" RING="canary" SOAK_HOURS="0" FMA_SCRIPTS_DIR="/path/to/fma/scripts" "/path/to/clones/caty-agent-harness/templates/updater-cron.tmpl.sh" >>"/path/to/claire-home/.openclaw-claire/workspace/loop/updater-cron.log" 2>&1
-   ```
+## Release signing and key rotation
 
-### Constraints
+Every update target must be a strict semver annotated tag signed by a pinned SSH
+key. Legacy lightweight or unsigned releases are rollback identities only and
+can never be selected as update targets.
 
-- Claire is canary; do not reuse this ring assignment for other OpenClaw profiles
-  unless Alpha explicitly says so.
-- Keep the harness credential read-only.
-- Failure reports must be caution-only hot-inbox posts from the updater.
+Rotate signing keys with overlap:
 
-### Done when
+1. distribute the new public key in `allowed_signers` while retaining the old;
+2. verify adoption on every updater host;
+3. sign a release with the new key and verify fleet acceptance; then
+4. retire the old key from every host.
 
-- [ ] Claire reports `job-heartbeat updater-claire` after a no-op or successful update.
-- [ ] A failed canary check produces exactly one hot-inbox caution post.
-- [ ] The ledger records real updates and failures under
-      `~/.claude/state/installed-versions.log`; no-op already-current runs do
-      not add a line.
+Never switch the release signer before the overlap has been verified.
 
-## Hermes
+## Fetch behavior and atomicity
 
-### Why (read first)
+Branches are fetched with tags suppressed. Tags are enumerated with
+`git ls-remote --refs --tags`, compared by direct ref OID, and only absent names
+are fetched in one `git fetch --atomic --no-tags` call. A moved name is never
+forced over the local ref. `--atomic` guarantees atomic **ref updates**: a failed
+batch installs no new tag refs. It does not roll back downloaded objects;
+unreachable objects are ordinary `git gc` housekeeping and confer no trust.
 
-Hermes should follow stable release tags after the soak window so the profile gets
-the same harness fixes without being first to absorb release risk.
+## Residual bootstrap risks
 
-### What to do
+A fresh clone has no prior direct OID, so it cannot detect that an existing tag
+name was moved before the clone was created. The owner-named bootstrap removes
+automatic selection, while signature verification prevents substituted content
+and exact header name binding prevents an old genuine tag object being rebound
+under a new version name.
 
-1. Prepare the Hermes harness clone with a read-only deploy key or fine-grained PAT.
-2. Install a stable cron line:
-   ```cron
-   22 * * * * REPO_DIR="$HOME/caty-agent-harness" WORKSPACE="$HOME/.hermes/profiles/default/workspace" AGENT="hermes" RING="stable" SOAK_HOURS="24" FMA_SCRIPTS_DIR="$HOME/claude-workspace/family-memory-architecture/scripts" "$HOME/caty-agent-harness/templates/updater-cron.tmpl.sh" >>"$HOME/.hermes/profiles/default/workspace/loop/updater-cron.log" 2>&1
-   ```
+If an attacker controls both the remote and the owner channel that supplies the
+initial tag name, the owner can still be induced to name an older genuine signed
+release. That owner-channel compromise is out of scope for this mechanism and
+must be addressed by protecting the out-of-band channel.
 
-### Constraints
+## Operational checks
 
-- Use `stable` unless Hermes is explicitly assigned a canary role.
-- Do not give the updater write access to the remote.
-- Keep `WORKSPACE` aligned with the active Hermes profile.
-
-### Done when
-
-- [ ] Manual updater run passes for the target Hermes workspace.
-- [ ] Heartbeats appear as `job-heartbeat updater-hermes`.
-- [ ] Failures, if any, land in hot-inbox as caution posts and the clone rolls back.
-- [ ] The local ledger records real updates and failures; no-op
-      already-current runs do not add a line.
-
-## Deployment inventory example
-
-The live deployment inventory is maintained privately by the operator. Use this
-minimal placeholder pattern and confirm every value on the target host before installing.
-
-| Agent | Host | Trigger | Deploy clone | Credential |
-| --- | --- | --- | --- | --- |
-| `<agent>` | `<host>` | `<cron-or-launchd schedule>` | `/path/to/caty-agent-harness` | `<host>-updater-ro` |
+- Git 2.34 or newer with SSH signature verification is mandatory.
+- A missing, empty, unreadable, or repository-local `allowed_signers` file stops
+  the run.
+- Successful real updates and failures append to
+  `~/.claude/state/installed-versions.log`; no-op current runs do not.
+- A failed install check rolls back to the exact pre-update full commit OID,
+  asserts that identity, and only then runs the rollback install check.

--- a/scripts/activation-manifest.tsv
+++ b/scripts/activation-manifest.tsv
@@ -16,6 +16,8 @@ templates/cron-wrapper.tmpl.sh	guarded	--workspace-or-positional	exit-0-status	s
 templates/updater-cron.tmpl.sh	exempt	none	not-applicable	harness-updater-wrapper-not-member-workspace	-	-
 scripts/attest-wrapper	exempt	none	not-applicable	setup-time-wrapper-attestation	-	-
 scripts/family-updater	exempt	none	not-applicable	harness-clone-updater-not-member-workspace	-	-
+scripts/updater-bootstrap	exempt	none	not-applicable	out-of-band-updater-trust-bootstrap	-	-
+scripts/lib-updater-verify.sh	exempt	none	not-applicable	sourced-updater-verification-library	-	-
 scripts/lib-bounded.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-classify.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-donecheck.sh	exempt	none	not-applicable	sourced-library	-	-

--- a/scripts/family-updater
+++ b/scripts/family-updater
@@ -17,6 +17,7 @@ lock_acquired=0
 lock_dir=
 pin_path=
 ineligible_path=
+startup_failure_path=
 preupdate_head=
 UPDATER_ROLLBACK_COMPLETED=0
 
@@ -167,6 +168,41 @@ report_failure() {
   append_ledger "$tag" fail
 }
 
+report_startup_failure() {
+  local name=$1
+  local reason=$2
+  local rc
+
+  printf 'family-updater error: %s\n' "$reason" >&2
+  [[ "$dry_run" -eq 0 ]] || return 0
+  if updater_mark_verification_failure "$startup_failure_path" "$name" "$reason"; then
+    send_heartbeat fail "$reason"
+    post_failure_report "$name" "" "$reason"
+    append_ledger "$name" fail
+    return 0
+  else
+    rc=$?
+  fi
+  [[ "$rc" -eq 1 ]] && return 0
+  report_failure "$name" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+  return 1
+}
+
+clear_startup_failure() {
+  local name=$1
+  local rc
+
+  [[ "$dry_run" -eq 0 ]] || return 0
+  if updater_clear_verification_failure "$startup_failure_path" "$name"; then
+    return 0
+  else
+    rc=$?
+  fi
+  [[ "$rc" -eq 1 ]] && return 0
+  report_failure "state-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+  return 1
+}
+
 # Callback used by updater_sync_remote_tags. Persistence is handled by the
 # shared library before this is called, so repeated ticks do not report again.
 updater_report_ineligible() {
@@ -180,7 +216,10 @@ record_candidate_verification_failure() {
   local reason=$2
   local rc
 
-  [[ "$dry_run" -eq 0 ]] || return 0
+  if [[ "$dry_run" -eq 1 ]]; then
+    printf 'family-updater error: %s\n' "$reason" >&2
+    return 0
+  fi
   if updater_mark_verification_failure "$ineligible_path" "$tag" "$reason"; then
     updater_report_ineligible "$tag" "$reason"
     return 0
@@ -336,24 +375,45 @@ if [[ ! "$preupdate_head" =~ ^[0-9a-f]{40}$ ]]; then
   exit 1
 fi
 
-if ! updater_check_capabilities "$repo_dir"; then
-  report_failure "capability-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
-  exit 1
-fi
-if ! updater_validate_allowed_signers "$repo_dir" "$allowed_signers"; then
-  report_failure "signers-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
-  exit 1
-fi
-
 pin_path=$(updater_default_pin_path "$repo_dir")
 ineligible_path=$(updater_default_ineligible_path "$repo_dir")
-if [[ -L "$ineligible_path" || ( -e "$ineligible_path" && ! -f "$ineligible_path" ) ]]; then
-  reason="updater ineligible log is not a regular file: $ineligible_path"
+startup_failure_path=$(updater_default_startup_failure_path "$repo_dir")
+if [[ -L "$startup_failure_path" \
+  || ( -e "$startup_failure_path" && ! -f "$startup_failure_path" ) \
+  || ( -f "$startup_failure_path" && ( ! -r "$startup_failure_path" || ! -w "$startup_failure_path" ) ) ]]; then
+  reason="updater startup failure log is not a readable, writable regular file: $startup_failure_path"
   report_failure "state-failed" "$reason" "" "$reason"
   exit 1
 fi
+
+if ! updater_check_capabilities "$repo_dir"; then
+  report_startup_failure "capability-failed" "$UPDATER_VERIFY_REASON"
+  exit 1
+fi
+if ! clear_startup_failure "capability-failed"; then
+  exit 1
+fi
+if ! updater_validate_allowed_signers "$repo_dir" "$allowed_signers"; then
+  report_startup_failure "signers-failed" "$UPDATER_VERIFY_REASON"
+  exit 1
+fi
+if ! clear_startup_failure "signers-failed"; then
+  exit 1
+fi
+
+if [[ -L "$ineligible_path" || ( -e "$ineligible_path" && ! -f "$ineligible_path" ) ]]; then
+  reason="updater ineligible log is not a regular file: $ineligible_path"
+  report_startup_failure "state-failed" "$reason"
+  exit 1
+fi
+if ! clear_startup_failure "state-failed"; then
+  exit 1
+fi
 if ! updater_load_or_seed_floor "$repo_dir" "$pin_path" "$preupdate_head" "$(ledger_path)" "$((1 - dry_run))"; then
-  report_failure "pin-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+  report_startup_failure "pin-failed" "$UPDATER_VERIFY_REASON"
+  exit 1
+fi
+if ! clear_startup_failure "pin-failed"; then
   exit 1
 fi
 

--- a/scripts/family-updater
+++ b/scripts/family-updater
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck source=scripts/lib-updater-verify.sh
+source "$SCRIPT_DIR/lib-updater-verify.sh"
+
 repo_dir=
 workspace=$PWD
 agent=${USER:-unknown}
@@ -8,23 +12,28 @@ ring=stable
 soak_hours=24
 dry_run=0
 fma_scripts_dir=${FMA_SCRIPTS_DIR:-}
+allowed_signers=${CATY_UPDATER_ALLOWED_SIGNERS:-$HOME/.claude/state/updater-allowed-signers}
 lock_acquired=0
 lock_dir=
+pin_path=
+ineligible_path=
+preupdate_head=
 
 usage() {
   cat <<'USAGE'
 Usage:
   scripts/family-updater --repo-dir <path> [--workspace <dir>] [--agent <name>]
                          [--ring canary|stable] [--soak-hours N] [--dry-run]
-                         [--fma-scripts-dir <dir>]
+                         [--allowed-signers <path>] [--fma-scripts-dir <dir>]
 
 Flags:
   --repo-dir <path>       Local caty-agent-harness clone to update. Required.
   --workspace <dir>       Workspace passed to install.sh --check.
   --agent <name>          Reporting agent name. Defaults to $USER.
-  --ring canary|stable    Canary takes the newest semver tag. Stable waits for soak.
+  --ring canary|stable    Canary takes the newest eligible tag. Stable adds soak.
   --soak-hours N          Stable tag minimum age in hours. Defaults to 24.
-  --dry-run               Print the planned update without fetching or changing files.
+  --dry-run               Verify and fetch refs, but do not checkout or run install.sh.
+  --allowed-signers <p>   Out-of-repo SSH allowed_signers file. Flag overrides env.
   --fma-scripts-dir <dir> Directory containing job-heartbeat and hot-inbox-post.
                            When omitted, reporting is disabled with a warning.
   -h, --help              Show this help.
@@ -54,7 +63,6 @@ trap 'cleanup_lock' EXIT HUP INT TERM
 
 is_live_pid() {
   local pid=$1
-
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
   kill -0 "$pid" 2>/dev/null
 }
@@ -75,75 +83,8 @@ acquire_lock() {
     fi
     rm -rf "$lock_dir"
   done
-
   lock_acquired=1
   printf '%s\n' "$$" >"$pid_file"
-}
-
-semver_tags() {
-  local tag_output
-
-  if ! tag_output=$(git -C "$repo_dir" tag --sort=-v:refname); then
-    return 1
-  fi
-  printf '%s\n' "$tag_output" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true
-}
-
-tag_epoch() {
-  local tag=$1
-  local epoch
-
-  epoch=$(git -C "$repo_dir" for-each-ref --format='%(taggerdate:unix)' "refs/tags/$tag")
-  if [[ -z "$epoch" ]]; then
-    epoch=$(git -C "$repo_dir" log -1 --format=%ct "$tag^{}" 2>/dev/null || true)
-  fi
-  printf '%s\n' "$epoch"
-}
-
-select_target_tag() {
-  local tags=$1
-  local now_epoch=$2
-  local min_age_seconds=$((soak_hours * 3600))
-  local tag
-  local epoch
-  local age
-
-  [[ -n "$tags" ]] || return 0
-
-  if [[ "$ring" == "canary" ]]; then
-    printf '%s\n' "$tags" | head -n 1
-    return 0
-  fi
-
-  while IFS= read -r tag; do
-    [[ -n "$tag" ]] || continue
-    epoch=$(tag_epoch "$tag")
-    [[ "$epoch" =~ ^[0-9]+$ ]] || continue
-    age=$((now_epoch - epoch))
-    if (( age >= min_age_seconds )); then
-      printf '%s\n' "$tag"
-      return 0
-    fi
-  done <<EOF
-$tags
-EOF
-}
-
-current_points_at_tag() {
-  local tag=$1
-
-  git -C "$repo_dir" tag --points-at HEAD | grep -Fxq "$tag"
-}
-
-rollback_ref() {
-  local tag
-
-  tag=$(git -C "$repo_dir" describe --tags --exact-match 2>/dev/null || true)
-  if [[ -n "$tag" ]]; then
-    printf '%s\n' "$tag"
-  else
-    git -C "$repo_dir" rev-parse --short HEAD
-  fi
 }
 
 ledger_path() {
@@ -153,12 +94,10 @@ ledger_path() {
 append_ledger() {
   local tag=$1
   local status=$2
-  local path
-  local repo_name
-  local timestamp
+  local path repo_name timestamp
 
   path=$(ledger_path)
-  repo_name=$(basename "$(cd "$repo_dir" && pwd)")
+  repo_name=$(updater_repo_name "$repo_dir")
   timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
   mkdir -p "$(dirname "$path")"
   printf '%s %s %s %s %s\n' "$timestamp" "$agent" "$repo_name" "$tag" "$status" >>"$path"
@@ -171,10 +110,10 @@ warn_missing_reporter() {
 send_heartbeat() {
   local status=$1
   local reason=$2
+  local reporter
 
   [[ -n "$fma_scripts_dir" ]] || return 0
-  local reporter="$fma_scripts_dir/job-heartbeat"
-
+  reporter="$fma_scripts_dir/job-heartbeat"
   if [[ ! -x "$reporter" ]]; then
     warn_missing_reporter "$reporter"
     return 0
@@ -188,22 +127,18 @@ post_failure_report() {
   local tag=$1
   local rollback=$2
   local summary=$3
+  local reporter repo_name report_summary=$summary
 
   [[ -n "$fma_scripts_dir" ]] || return 0
-  local reporter="$fma_scripts_dir/hot-inbox-post"
-  local repo_name
-  local report_summary=$summary
-
+  reporter="$fma_scripts_dir/hot-inbox-post"
   if [[ ! -x "$reporter" ]]; then
     warn_missing_reporter "$reporter"
     return 0
   fi
-
   if [[ -n "$rollback" && "$summary" != *"rollback to $rollback ALSO failed"* ]]; then
     report_summary="$summary; rolled back to $rollback"
   fi
-
-  repo_name=$(basename "$(cd "$repo_dir" && pwd)")
+  repo_name=$(updater_repo_name "$repo_dir")
   if ! "$reporter" \
     --kind caution \
     --title "updater failed: $agent $repo_name $tag" \
@@ -221,9 +156,46 @@ report_failure() {
   local rollback=$3
   local summary=$4
 
+  printf 'family-updater error: %s\n' "$summary" >&2
   send_heartbeat fail "$reason"
   post_failure_report "$tag" "$rollback" "$summary"
   append_ledger "$tag" fail
+}
+
+# Callback used by updater_sync_remote_tags. Persistence is handled by the
+# shared library before this is called, so repeated ticks do not report again.
+updater_report_ineligible() {
+  local tag=$1
+  local reason=$2
+  report_failure "$tag" "$reason" "" "$reason"
+}
+
+record_candidate_verification_failure() {
+  local tag=$1
+  local reason=$2
+  local rc
+
+  if updater_mark_verification_failure "$ineligible_path" "$tag" "$reason"; then
+    updater_report_ineligible "$tag" "$reason"
+    return 0
+  else
+    rc=$?
+  fi
+  [[ "$rc" -eq 1 ]] && return 0
+  return 1
+}
+
+clear_candidate_verification_failure() {
+  local tag=$1
+  local rc
+
+  if updater_clear_verification_failure "$ineligible_path" "$tag"; then
+    return 0
+  else
+    rc=$?
+  fi
+  [[ "$rc" -eq 1 ]] && return 0
+  return 1
 }
 
 run_install_check() {
@@ -244,19 +216,38 @@ first_line_or_default() {
   local text=$1
   local fallback=$2
   local line
-
   line=$(printf '%s\n' "$text" | sed -n '1p')
-  if [[ -n "$line" ]]; then
-    printf '%s\n' "$line"
-  else
-    printf '%s\n' "$fallback"
-  fi
+  printf '%s\n' "${line:-$fallback}"
 }
 
 compact_summary() {
-  local text=$1
+  printf '%s' "$1" | tr '\n' ' ' | cut -c1-200
+}
 
-  printf '%s' "$text" | tr '\n' ' ' | cut -c1-200
+rollback_after_install_failure() {
+  local target_tag=$1
+  local error_head=$2
+  local summary=$3
+  local rollback_output rollback_head actual_head
+
+  if ! git -C "$repo_dir" checkout --detach "$preupdate_head" >/dev/null; then
+    report_failure "$target_tag" "$error_head" "" "$summary; rollback checkout to $preupdate_head FAILED"
+    return 1
+  fi
+  actual_head=$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null || true)
+  if [[ "$actual_head" != "$preupdate_head" ]]; then
+    report_failure "$target_tag" "$error_head" "" "$summary; rollback identity mismatch: expected $preupdate_head found ${actual_head:-unreadable}; rollback install.sh was not executed"
+    return 1
+  fi
+
+  rollback_output=
+  if ! run_install_check rollback_output; then
+    rollback_head=$(first_line_or_default "$rollback_output" "rollback install check failed")
+    printf 'warning: rollback check did not pass: %s\n' "$rollback_head" >&2
+    summary="$summary; rollback to $preupdate_head ALSO failed its check"
+  fi
+  report_failure "$target_tag" "$error_head" "$preupdate_head" "$summary"
+  return 1
 }
 
 while (($# > 0)); do
@@ -290,6 +281,11 @@ while (($# > 0)); do
       dry_run=1
       shift
       ;;
+    --allowed-signers)
+      (($# >= 2)) || die_usage
+      allowed_signers=$2
+      shift 2
+      ;;
     --fma-scripts-dir)
       (($# >= 2)) || die_usage
       fma_scripts_dir=$2
@@ -299,9 +295,7 @@ while (($# > 0)); do
       usage
       exit 0
       ;;
-    *)
-      die_usage
-      ;;
+    *) die_usage ;;
   esac
 done
 
@@ -310,57 +304,145 @@ if [[ -z "$fma_scripts_dir" ]]; then
 fi
 
 [[ -n "$repo_dir" ]] || die_usage
-[[ "$ring" == "canary" || "$ring" == "stable" ]] || die "invalid ring: $ring"
+[[ "$ring" == canary || "$ring" == stable ]] || die "invalid ring: $ring"
 [[ "$soak_hours" =~ ^[0-9]+$ ]] || die "invalid soak-hours: $soak_hours"
 [[ -d "$repo_dir" ]] || die "repo dir not found: $repo_dir"
 
 acquire_lock "$repo_dir/.family-updater.lock"
-
-if ! git -C "$repo_dir" rev-parse --git-dir >/dev/null; then
-  reason="repo is not a git repository"
-  send_heartbeat fail "$reason" || true
+if ! git -C "$repo_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  report_failure "startup-failed" "repo is not a git repository" "" "repo is not a git repository"
   exit 1
 fi
 [[ -x "$repo_dir/install.sh" ]] || die "install.sh is not executable: $repo_dir/install.sh"
 
-if [[ "$dry_run" -eq 0 ]]; then
-  if ! git -C "$repo_dir" fetch --tags --prune origin; then
-    report_failure "fetch-failed" "git fetch failed" "" "git fetch failed"
-    exit 1
-  fi
-else
-  printf 'dry-run: would fetch tags from origin\n'
-fi
-
-if ! tags=$(semver_tags); then
-  reason="git tag listing failed"
-  report_failure "tag-list-failed" "$reason" "" "$reason"
+preupdate_head=$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null || true)
+if [[ ! "$preupdate_head" =~ ^[0-9a-f]{40}$ ]]; then
+  report_failure "startup-failed" "cannot record pre-update HEAD full commit OID" "" "cannot record pre-update HEAD full commit OID"
   exit 1
 fi
-if [[ -z "$tags" ]]; then
-  printf 'family-updater: no eligible semver tags found; already up to date\n'
-  exit 0
+
+if ! updater_check_capabilities "$repo_dir"; then
+  report_failure "capability-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+  exit 1
+fi
+if ! updater_validate_allowed_signers "$repo_dir" "$allowed_signers"; then
+  report_failure "signers-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+  exit 1
 fi
 
-target_tag=$(select_target_tag "$tags" "$(date -u '+%s')")
+pin_path=$(updater_default_pin_path "$repo_dir")
+ineligible_path=$(updater_default_ineligible_path "$repo_dir")
+if [[ -L "$ineligible_path" || ( -e "$ineligible_path" && ! -f "$ineligible_path" ) ]]; then
+  reason="updater ineligible log is not a regular file: $ineligible_path"
+  report_failure "state-failed" "$reason" "" "$reason"
+  exit 1
+fi
+if ! updater_load_or_seed_floor "$repo_dir" "$pin_path" "$preupdate_head"; then
+  report_failure "pin-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+  exit 1
+fi
+
+if ! updater_sync_remote_tags "$repo_dir" "$ineligible_path"; then
+  report_failure "fetch-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+  exit 1
+fi
+
+remote_names=
+while IFS=$'\t' read -r remote_name remote_oid; do
+  [[ -n "$remote_name" ]] || continue
+  remote_names=${remote_names:+$remote_names$'\n'}$remote_name
+done <<<"$UPDATER_REMOTE_TAGS"
+sorted_names=$(updater_sort_semvers_desc "$remote_names")
+
+target_tag=
+target_tag_oid=
+target_commit=
+verified_seen=0
+now_epoch=$(date -u '+%s')
+min_age_seconds=$((soak_hours * 3600))
+
+while IFS= read -r candidate; do
+  [[ -n "$candidate" ]] || continue
+  if updater_is_moved_tag_ineligible "$ineligible_path" "$candidate"; then
+    continue
+  fi
+
+  # B-ALG step 1 uses the direct OID enumerated from the remote. Lightweight
+  # refs are rejected before capture; capture repeats the type assertion.
+  candidate_oid=$(updater_remote_oid_for "$UPDATER_REMOTE_TAGS" "$candidate" || true)
+  candidate_type=$(git -C "$repo_dir" cat-file -t "$candidate_oid" 2>/dev/null || true)
+  if [[ "$candidate_type" != tag ]]; then
+    reason="tag is lightweight or not annotated: $candidate"
+    if ! record_candidate_verification_failure "$candidate" "$reason"; then
+      report_failure "$candidate" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+      exit 1
+    fi
+    continue
+  fi
+
+  # B-ALG steps 2-4: capture once, verify T with forced config, parse only T's
+  # header block, and bind its embedded tag name exactly to the candidate name.
+  if ! updater_capture_verify_and_bind "$repo_dir" "$candidate" "$allowed_signers"; then
+    reason=$UPDATER_VERIFY_REASON
+    if ! record_candidate_verification_failure "$candidate" "$reason"; then
+      report_failure "$candidate" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+      exit 1
+    fi
+    continue
+  fi
+
+  # B-ALG step 5: numeric monotonic floor, including equal-version identity.
+  if ! updater_check_floor "$candidate" "$UPDATER_CAPTURED_COMMIT"; then
+    reason=$UPDATER_VERIFY_REASON
+    if ! record_candidate_verification_failure "$candidate" "$reason"; then
+      report_failure "$candidate" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+      exit 1
+    fi
+    continue
+  fi
+  if ! clear_candidate_verification_failure "$candidate"; then
+    report_failure "$candidate" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+    exit 1
+  fi
+  verified_seen=1
+
+  # Soak is applied only after cryptographic eligibility. It is rollout pacing,
+  # not a security control: a signer can backdate the tagger timestamp.
+  if [[ "$ring" == stable ]] && (( now_epoch - UPDATER_CAPTURED_EPOCH < min_age_seconds )); then
+    continue
+  fi
+
+  target_tag=$UPDATER_CAPTURED_TAG
+  target_tag_oid=$UPDATER_CAPTURED_TAG_OID
+  target_commit=$UPDATER_CAPTURED_COMMIT
+  break
+done <<<"$sorted_names"
+
 if [[ -z "$target_tag" ]]; then
-  printf 'family-updater: no %s tag old enough for %s hour soak; already up to date\n' "$ring" "$soak_hours"
-  exit 0
+  if [[ "$verified_seen" -eq 1 ]]; then
+    printf 'family-updater: no stable tag old enough for %s hour soak; already up to date\n' "$soak_hours"
+    exit 0
+  fi
+  if [[ -z "$remote_names" ]]; then
+    printf 'family-updater: remote has no eligible semver tags; already up to date\n'
+    exit 0
+  fi
+  printf 'family-updater: no remote tag passed the verification and floor gate\n' >&2
+  exit 1
 fi
 
-if current_points_at_tag "$target_tag"; then
+current_head=$(git -C "$repo_dir" rev-parse HEAD)
+if [[ "$current_head" == "$target_commit" ]]; then
   if [[ "$dry_run" -eq 1 ]]; then
-    printf 'dry-run: already at %s, nothing to do\n' "$target_tag"
+    printf 'dry-run: verified already-current %s (%s), nothing to do\n' "$target_tag" "$target_commit"
     exit 0
   fi
   send_heartbeat ok "$target_tag"
   exit 0
 fi
 
-rollback=$(rollback_ref)
-
 if [[ "$dry_run" -eq 1 ]]; then
-  printf 'dry-run: would update %s from %s to %s\n' "$repo_dir" "$rollback" "$target_tag"
+  printf 'dry-run: verified update %s from %s to %s (%s); no checkout or install executed\n' "$repo_dir" "$preupdate_head" "$target_tag" "$target_commit"
   exit 0
 fi
 
@@ -370,14 +452,21 @@ if [[ -n "$(git -C "$repo_dir" status --porcelain -- . ':!.family-updater.lock')
   exit 1
 fi
 
-if ! git -C "$repo_dir" checkout --detach "$target_tag" >/dev/null; then
-  reason="checkout of $target_tag failed"
-  report_failure "$target_tag" "$reason" "" "$reason"
+# B-ALG step 6. The selected name is never resolved again; checkout and the
+# post-checkout assertion use only the commit OID captured before verification.
+if ! updater_checkout_captured_commit "$repo_dir" "$target_commit"; then
+  report_failure "$target_tag" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON; install.sh was not executed"
   exit 1
 fi
 
+# B-ALG step 7: repo code executes only after every trust and identity check.
 check_output=
 if run_install_check check_output; then
+  if ! updater_write_pin "$pin_path" "$target_tag" "$target_commit"; then
+    pin_error=$UPDATER_VERIFY_REASON
+    rollback_after_install_failure "$target_tag" "$pin_error" "$pin_error"
+    exit 1
+  fi
   send_heartbeat ok "$target_tag"
   append_ledger "$target_tag" ok
   exit 0
@@ -388,17 +477,5 @@ fi
 error_head=$(first_line_or_default "$check_output" "install check failed with exit $check_rc")
 summary=$(compact_summary "$check_output")
 [[ -n "$summary" ]] || summary=$error_head
-
-if ! git -C "$repo_dir" checkout --detach "$rollback" >/dev/null; then
-  report_failure "$target_tag" "$error_head" "" "$summary; rollback checkout to $rollback FAILED"
-  exit 1
-fi
-rollback_output=
-if ! run_install_check rollback_output; then
-  rollback_head=$(first_line_or_default "$rollback_output" "rollback install check failed")
-  printf 'warning: rollback check did not pass: %s\n' "$rollback_head" >&2
-  summary="$summary; rollback to $rollback ALSO failed its check"
-fi
-
-report_failure "$target_tag" "$error_head" "$rollback" "$summary"
+rollback_after_install_failure "$target_tag" "$error_head" "$summary"
 exit 1

--- a/scripts/family-updater
+++ b/scripts/family-updater
@@ -18,6 +18,7 @@ lock_dir=
 pin_path=
 ineligible_path=
 preupdate_head=
+UPDATER_ROLLBACK_COMPLETED=0
 
 usage() {
   cat <<'USAGE'
@@ -32,7 +33,8 @@ Flags:
   --agent <name>          Reporting agent name. Defaults to $USER.
   --ring canary|stable    Canary takes the newest eligible tag. Stable adds soak.
   --soak-hours N          Stable tag minimum age in hours. Defaults to 24.
-  --dry-run               Verify and fetch refs, but do not checkout or run install.sh.
+  --dry-run               Verify and fetch refs, but do not checkout, install,
+                          write updater state, or send heartbeat/hot-inbox reports.
   --allowed-signers <p>   Out-of-repo SSH allowed_signers file. Flag overrides env.
   --fma-scripts-dir <dir> Directory containing job-heartbeat and hot-inbox-post.
                            When omitted, reporting is disabled with a warning.
@@ -96,6 +98,7 @@ append_ledger() {
   local status=$2
   local path repo_name timestamp
 
+  [[ "$dry_run" -eq 0 ]] || return 0
   path=$(ledger_path)
   repo_name=$(updater_repo_name "$repo_dir")
   timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -112,6 +115,7 @@ send_heartbeat() {
   local reason=$2
   local reporter
 
+  [[ "$dry_run" -eq 0 ]] || return 0
   [[ -n "$fma_scripts_dir" ]] || return 0
   reporter="$fma_scripts_dir/job-heartbeat"
   if [[ ! -x "$reporter" ]]; then
@@ -129,6 +133,7 @@ post_failure_report() {
   local summary=$3
   local reporter repo_name report_summary=$summary
 
+  [[ "$dry_run" -eq 0 ]] || return 0
   [[ -n "$fma_scripts_dir" ]] || return 0
   reporter="$fma_scripts_dir/hot-inbox-post"
   if [[ ! -x "$reporter" ]]; then
@@ -175,6 +180,7 @@ record_candidate_verification_failure() {
   local reason=$2
   local rc
 
+  [[ "$dry_run" -eq 0 ]] || return 0
   if updater_mark_verification_failure "$ineligible_path" "$tag" "$reason"; then
     updater_report_ineligible "$tag" "$reason"
     return 0
@@ -189,6 +195,7 @@ clear_candidate_verification_failure() {
   local tag=$1
   local rc
 
+  [[ "$dry_run" -eq 0 ]] || return 0
   if updater_clear_verification_failure "$ineligible_path" "$tag"; then
     return 0
   else
@@ -196,6 +203,12 @@ clear_candidate_verification_failure() {
   fi
   [[ "$rc" -eq 1 ]] && return 0
   return 1
+}
+
+candidate_was_moved_this_tick() {
+  local tag=$1
+
+  printf '%s\n' "$UPDATER_MOVED_TAGS" | grep -Fxq "$tag"
 }
 
 run_install_check() {
@@ -230,6 +243,7 @@ rollback_after_install_failure() {
   local summary=$3
   local rollback_output rollback_head actual_head
 
+  UPDATER_ROLLBACK_COMPLETED=0
   if ! git -C "$repo_dir" checkout --detach "$preupdate_head" >/dev/null; then
     report_failure "$target_tag" "$error_head" "" "$summary; rollback checkout to $preupdate_head FAILED"
     return 1
@@ -246,6 +260,7 @@ rollback_after_install_failure() {
     printf 'warning: rollback check did not pass: %s\n' "$rollback_head" >&2
     summary="$summary; rollback to $preupdate_head ALSO failed its check"
   fi
+  UPDATER_ROLLBACK_COMPLETED=1
   report_failure "$target_tag" "$error_head" "$preupdate_head" "$summary"
   return 1
 }
@@ -337,13 +352,15 @@ if [[ -L "$ineligible_path" || ( -e "$ineligible_path" && ! -f "$ineligible_path
   report_failure "state-failed" "$reason" "" "$reason"
   exit 1
 fi
-if ! updater_load_or_seed_floor "$repo_dir" "$pin_path" "$preupdate_head"; then
+if ! updater_load_or_seed_floor "$repo_dir" "$pin_path" "$preupdate_head" "$(ledger_path)" "$((1 - dry_run))"; then
   report_failure "pin-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
   exit 1
 fi
 
-if ! updater_sync_remote_tags "$repo_dir" "$ineligible_path"; then
-  report_failure "fetch-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+if ! updater_sync_remote_tags "$repo_dir" "$ineligible_path" "$dry_run"; then
+  if [[ "$UPDATER_SYNC_FAILURE_HANDLED" -eq 0 ]]; then
+    report_failure "fetch-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+  fi
   exit 1
 fi
 
@@ -355,7 +372,6 @@ done <<<"$UPDATER_REMOTE_TAGS"
 sorted_names=$(updater_sort_semvers_desc "$remote_names")
 
 target_tag=
-target_tag_oid=
 target_commit=
 verified_seen=0
 now_epoch=$(date -u '+%s')
@@ -363,7 +379,8 @@ min_age_seconds=$((soak_hours * 3600))
 
 while IFS= read -r candidate; do
   [[ -n "$candidate" ]] || continue
-  if updater_is_moved_tag_ineligible "$ineligible_path" "$candidate"; then
+  if updater_is_moved_tag_ineligible "$ineligible_path" "$candidate" \
+    || candidate_was_moved_this_tick "$candidate"; then
     continue
   fi
 
@@ -400,6 +417,9 @@ while IFS= read -r candidate; do
     fi
     continue
   fi
+  if updater_has_install_failure "$ineligible_path" "$candidate" "$UPDATER_CAPTURED_COMMIT"; then
+    continue
+  fi
   if ! clear_candidate_verification_failure "$candidate"; then
     report_failure "$candidate" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
     exit 1
@@ -413,7 +433,6 @@ while IFS= read -r candidate; do
   fi
 
   target_tag=$UPDATER_CAPTURED_TAG
-  target_tag_oid=$UPDATER_CAPTURED_TAG_OID
   target_commit=$UPDATER_CAPTURED_COMMIT
   break
 done <<<"$sorted_names"
@@ -477,5 +496,16 @@ fi
 error_head=$(first_line_or_default "$check_output" "install check failed with exit $check_rc")
 summary=$(compact_summary "$check_output")
 [[ -n "$summary" ]] || summary=$error_head
-rollback_after_install_failure "$target_tag" "$error_head" "$summary"
-exit 1
+rollback_rc=0
+rollback_after_install_failure "$target_tag" "$error_head" "$summary" || rollback_rc=$?
+if [[ "$UPDATER_ROLLBACK_COMPLETED" -eq 1 ]]; then
+  if updater_mark_install_failure "$ineligible_path" "$target_tag" "$target_commit"; then
+    :
+  else
+    mark_rc=$?
+    if [[ "$mark_rc" -eq 2 ]]; then
+      printf 'family-updater error: %s\n' "$UPDATER_VERIFY_REASON" >&2
+    fi
+  fi
+fi
+exit "${rollback_rc:-1}"

--- a/scripts/lib-updater-verify.sh
+++ b/scripts/lib-updater-verify.sh
@@ -1,0 +1,534 @@
+#!/usr/bin/env bash
+
+# Shared trust gate for family-updater and updater-bootstrap. Callers provide
+# reporting; this file owns the ordered object, name, floor, and checkout checks.
+
+UPDATER_VERIFY_REASON=
+UPDATER_CAPTURED_TAG=
+UPDATER_CAPTURED_TAG_OID=
+UPDATER_CAPTURED_COMMIT=
+UPDATER_CAPTURED_EPOCH=
+UPDATER_FLOOR_VERSION=
+UPDATER_FLOOR_COMMIT=
+UPDATER_REMOTE_TAGS=
+
+updater_is_semver() {
+  [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+updater_semver_components() {
+  local value=${1#v}
+  local output_var=$2
+  local major=${value%%.*}
+  local rest=${value#*.}
+  local minor=${rest%%.*}
+  local patch=${rest#*.}
+
+  while [[ ${#major} -gt 1 && ${major#0} != "$major" ]]; do major=${major#0}; done
+  while [[ ${#minor} -gt 1 && ${minor#0} != "$minor" ]]; do minor=${minor#0}; done
+  while [[ ${#patch} -gt 1 && ${patch#0} != "$patch" ]]; do patch=${patch#0}; done
+  printf -v "$output_var" '%s %s %s' "$major" "$minor" "$patch"
+}
+
+updater_numeric_component_compare() {
+  local left=$1
+  local right=$2
+
+  if (( ${#left} > ${#right} )); then
+    printf '1\n'
+  elif (( ${#left} < ${#right} )); then
+    printf '%s\n' '-1'
+  elif [[ "$left" == "$right" ]]; then
+    printf '0\n'
+  elif [[ "$left" > "$right" ]]; then
+    printf '1\n'
+  else
+    printf '%s\n' '-1'
+  fi
+}
+
+updater_semver_compare() {
+  local left_parts right_parts
+  local left_component right_component comparison
+  local index
+  local -a left right
+
+  updater_semver_components "$1" left_parts
+  updater_semver_components "$2" right_parts
+  read -r -a left <<<"$left_parts"
+  read -r -a right <<<"$right_parts"
+  for index in 0 1 2; do
+    left_component=${left[$index]}
+    right_component=${right[$index]}
+    comparison=$(updater_numeric_component_compare "$left_component" "$right_component")
+    if [[ "$comparison" != 0 ]]; then
+      printf '%s\n' "$comparison"
+      return 0
+    fi
+  done
+  printf '0\n'
+}
+
+updater_sort_semvers_desc() {
+  local values=$1
+  local value swap
+  local i
+  local -a sorted
+
+  sorted=()
+  while IFS= read -r value; do
+    [[ -n "$value" ]] || continue
+    sorted+=("$value")
+    i=$((${#sorted[@]} - 1))
+    while (( i > 0 )) && [[ $(updater_semver_compare "${sorted[$i]}" "${sorted[$((i - 1))]}") -gt 0 ]]; do
+      swap=${sorted[$((i - 1))]}
+      sorted[$((i - 1))]=${sorted[$i]}
+      sorted[$i]=$swap
+      i=$((i - 1))
+    done
+  done <<<"$values"
+  if (( ${#sorted[@]} > 0 )); then
+    printf '%s\n' "${sorted[@]}"
+  fi
+}
+
+updater_repo_name() {
+  basename "$(cd "$1" && pwd -P)"
+}
+
+updater_default_pin_path() {
+  printf '%s/.claude/state/updater-pin/%s.json\n' "$HOME" "$(updater_repo_name "$1")"
+}
+
+updater_default_ineligible_path() {
+  printf '%s/.claude/state/updater-ineligible/%s.log\n' "$HOME" "$(updater_repo_name "$1")"
+}
+
+updater_path_is_outside_repo() {
+  local repo_real signers_dir signers_real
+
+  repo_real=$(cd "$1" && pwd -P) || return 1
+  signers_dir=$(dirname "$2")
+  signers_real=$(cd "$signers_dir" 2>/dev/null && pwd -P) || return 1
+  signers_real="$signers_real/$(basename "$2")"
+  [[ "$signers_real" != "$repo_real" && "$signers_real" != "$repo_real/"* ]]
+}
+
+updater_check_capabilities() {
+  local repo=$1
+  local version_text major minor probe_output ssh_probe
+
+  version_text=$(git --version 2>/dev/null) || {
+    UPDATER_VERIFY_REASON="git capability check failed: git --version is unavailable"
+    return 1
+  }
+  if [[ ! "$version_text" =~ ([0-9]+)\.([0-9]+) ]]; then
+    UPDATER_VERIFY_REASON="git capability check failed: cannot parse version: $version_text"
+    return 1
+  fi
+  major=${BASH_REMATCH[1]}
+  minor=${BASH_REMATCH[2]}
+  if (( major < 2 || (major == 2 && minor < 34) )); then
+    UPDATER_VERIFY_REASON="git 2.34 or newer is required for SSH signature verification (found $major.$minor)"
+    return 1
+  fi
+
+  if ! command -v ssh-keygen >/dev/null 2>&1; then
+    UPDATER_VERIFY_REASON="SSH signature verification is unavailable: ssh-keygen is not installed"
+    return 1
+  fi
+  ssh_probe=$(ssh-keygen -Y 2>&1 || true)
+  if printf '%s\n' "$ssh_probe" | grep -Eiq 'unknown option.*Y|illegal option.*Y'; then
+    UPDATER_VERIFY_REASON="SSH signature verification is unavailable: ssh-keygen lacks -Y signature support"
+    return 1
+  fi
+
+  probe_output=$(git -C "$repo" -c gpg.format=ssh verify-tag 0000000000000000000000000000000000000000 2>&1 || true)
+  if printf '%s\n' "$probe_output" | grep -Eiq 'unsupported .*gpg\.format|unknown .*gpg\.format|invalid value.*ssh'; then
+    UPDATER_VERIFY_REASON="SSH signature verification is unavailable in this git installation"
+    return 1
+  fi
+}
+
+updater_validate_allowed_signers() {
+  local repo=$1
+  local path=$2
+
+  if [[ ! -f "$path" || ! -r "$path" || ! -s "$path" ]]; then
+    UPDATER_VERIFY_REASON="allowed_signers file is absent, unreadable, or empty: $path"
+    return 1
+  fi
+  if [[ -L "$path" ]]; then
+    UPDATER_VERIFY_REASON="allowed_signers must not be a symlink: $path"
+    return 1
+  fi
+  if ! updater_path_is_outside_repo "$repo" "$path"; then
+    UPDATER_VERIFY_REASON="allowed_signers must live outside the repository: $path"
+    return 1
+  fi
+}
+
+updater_prepare_private_dir() {
+  local dir=$1
+
+  if ! mkdir -p "$dir" || ! chmod 700 "$dir"; then
+    UPDATER_VERIFY_REASON="cannot prepare updater state directory: $dir"
+    return 1
+  fi
+}
+
+updater_write_pin() {
+  local path=$1
+  local version=$2
+  local commit=$3
+  local dir tmp timestamp
+
+  dir=$(dirname "$path")
+  updater_prepare_private_dir "$dir" || return 1
+  tmp=$(mktemp "$dir/.updater-pin.tmp.XXXXXX") || {
+    UPDATER_VERIFY_REASON="cannot create atomic pin temporary file beside: $path"
+    return 1
+  }
+  chmod 600 "$tmp" || {
+    rm -f "$tmp"
+    UPDATER_VERIFY_REASON="cannot set mode 0600 on pin temporary file: $tmp"
+    return 1
+  }
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  if ! printf '{"version":"%s","commit":"%s","updated_at":"%s"}\n' "$version" "$commit" "$timestamp" >"$tmp"; then
+    rm -f "$tmp"
+    UPDATER_VERIFY_REASON="cannot write pin temporary file for: $path"
+    return 1
+  fi
+  if ! mv -f "$tmp" "$path" || ! chmod 600 "$path"; then
+    rm -f "$tmp"
+    UPDATER_VERIFY_REASON="cannot atomically replace pin file: $path"
+    return 1
+  fi
+}
+
+updater_read_pin() {
+  local path=$1
+  local line line_count version commit timestamp
+  local pin_regex='^\{"version":"(v[0-9]+\.[0-9]+\.[0-9]+)","commit":"([0-9a-f]{40})","updated_at":"([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)"\}$'
+
+  if [[ -L "$path" || ! -f "$path" || ! -r "$path" ]]; then
+    UPDATER_VERIFY_REASON="updater pin file is unreadable: $path"
+    return 1
+  fi
+  IFS= read -r line <"$path" || {
+    UPDATER_VERIFY_REASON="updater pin file is unparsable or malformed: $path"
+    return 1
+  }
+  line_count=$(wc -l <"$path" | tr -d '[:space:]')
+  if [[ "$line_count" != 1 || ! "$line" =~ $pin_regex ]]; then
+    UPDATER_VERIFY_REASON="updater pin file is unparsable or malformed: $path"
+    return 1
+  fi
+  version=${BASH_REMATCH[1]}
+  commit=${BASH_REMATCH[2]}
+  timestamp=${BASH_REMATCH[3]}
+  if [[ ! "$timestamp" =~ ^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$ ]]; then
+    UPDATER_VERIFY_REASON="updater pin file is unparsable or malformed: $path"
+    return 1
+  fi
+  UPDATER_FLOOR_VERSION=$version
+  UPDATER_FLOOR_COMMIT=$commit
+}
+
+updater_load_or_seed_floor() {
+  local repo=$1
+  local path=$2
+  local prefetch_head=$3
+  local tags tag sorted
+
+  if [[ -e "$path" || -L "$path" ]]; then
+    updater_read_pin "$path"
+    return $?
+  fi
+
+  tags=$(git -C "$repo" tag --points-at "$prefetch_head" 2>/dev/null || true)
+  sorted=$(updater_sort_semvers_desc "$(printf '%s\n' "$tags" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)")
+  tag=$(printf '%s\n' "$sorted" | sed -n '1p')
+  if [[ -z "$tag" ]]; then
+    UPDATER_VERIFY_REASON="updater pin is absent and pre-fetch HEAD is not at a semver tag; bootstrap with scripts/updater-bootstrap: $path"
+    return 1
+  fi
+  updater_write_pin "$path" "$tag" "$prefetch_head" || return 1
+  UPDATER_FLOOR_VERSION=$tag
+  UPDATER_FLOOR_COMMIT=$prefetch_head
+}
+
+updater_is_moved_tag_ineligible() {
+  local path=$1
+  local name=$2
+
+  [[ -f "$path" ]] && awk -v name="$name" \
+    '$1 == name && $3 == "moved-tag" {found=1; exit} END {exit found ? 0 : 1}' "$path"
+}
+
+# Moved-tag records are the only persistent selection exclusion. Verification
+# failures in this same append-only log are report-dedupe state and are retried.
+updater_mark_ineligible() {
+  local path=$1
+  local name=$2
+  local reason=$3
+  local dir timestamp
+
+  if updater_is_moved_tag_ineligible "$path" "$name"; then
+    return 1
+  fi
+  dir=$(dirname "$path")
+  updater_prepare_private_dir "$dir" || return 2
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  if ! printf '%s %s %s\n' "$name" "$timestamp" "$reason" >>"$path" || ! chmod 600 "$path"; then
+    UPDATER_VERIFY_REASON="cannot append updater ineligible record: $path"
+    return 2
+  fi
+  return 0
+}
+
+updater_has_verification_failure() {
+  local path=$1
+  local name=$2
+
+  [[ -f "$path" ]] && awk -v name="$name" '
+    $1 == name {
+      if ($3 == "moved-tag") next
+      if ($3 == "verification-failure-cleared") active=0
+      else active=1
+    }
+    END {exit active ? 0 : 1}
+  ' "$path"
+}
+
+# Returns 0 when a new record was appended, 1 when an active record already
+# deduplicates this name, and 2 on a state-file failure.
+updater_mark_verification_failure() {
+  local path=$1
+  local name=$2
+  local reason=$3
+  local dir timestamp
+
+  if updater_has_verification_failure "$path" "$name"; then
+    return 1
+  fi
+  dir=$(dirname "$path")
+  updater_prepare_private_dir "$dir" || return 2
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  if ! printf '%s %s verification-failure %s\n' "$name" "$timestamp" "$reason" >>"$path" \
+    || ! chmod 600 "$path"; then
+    UPDATER_VERIFY_REASON="cannot append updater verification-failure record: $path"
+    return 2
+  fi
+  return 0
+}
+
+# Clearing is represented by another record so the state file remains
+# append-only. Returns 0 when appended, 1 when there was nothing active to
+# clear, and 2 on a state-file failure.
+updater_clear_verification_failure() {
+  local path=$1
+  local name=$2
+  local dir timestamp
+
+  if ! updater_has_verification_failure "$path" "$name"; then
+    return 1
+  fi
+  dir=$(dirname "$path")
+  updater_prepare_private_dir "$dir" || return 2
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  if ! printf '%s %s verification-failure-cleared\n' "$name" "$timestamp" >>"$path" \
+    || ! chmod 600 "$path"; then
+    UPDATER_VERIFY_REASON="cannot append updater verification-failure clear record: $path"
+    return 2
+  fi
+  return 0
+}
+
+updater_remote_oid_for() {
+  local records=$1
+  local wanted=$2
+  local name oid
+
+  while IFS=$'\t' read -r name oid; do
+    if [[ "$name" == "$wanted" ]]; then
+      printf '%s\n' "$oid"
+      return 0
+    fi
+  done <<<"$records"
+  return 1
+}
+
+# Fetches branches without tags, validates the remote tag listing, identifies
+# moved names, then installs all absent tag refs in one atomic ref-update batch.
+# A failed atomic fetch can leave unreachable objects, but it installs no new
+# refs/tags; object-store cleanup is git gc housekeeping, not a trust property.
+updater_sync_remote_tags() {
+  local repo=$1
+  local ineligible_path=$2
+  local output line oid ref name extra local_oid mark_rc
+  local names= records= candidates=
+  local -a refspecs
+
+  if ! git -C "$repo" fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'; then
+    UPDATER_VERIFY_REASON="branch fetch failed"
+    return 1
+  fi
+  if ! output=$(git -C "$repo" ls-remote --refs --tags origin); then
+    UPDATER_VERIFY_REASON="git ls-remote --refs --tags origin failed"
+    return 1
+  fi
+
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    oid= ref= extra=
+    IFS=$'\t' read -r oid ref extra <<<"$line"
+    if [[ -n "$extra" || ! "$oid" =~ ^[0-9a-f]{40}$ || "$ref" != refs/tags/* || "$ref" == *'^{}' ]]; then
+      UPDATER_VERIFY_REASON="unparsable remote tag record: $line"
+      return 1
+    fi
+    name=${ref#refs/tags/}
+    if ! updater_is_semver "$name"; then
+      UPDATER_VERIFY_REASON="remote tag name is not strict semver: $name"
+      return 1
+    fi
+    if printf '%s\n' "$names" | grep -Fxq "$name"; then
+      UPDATER_VERIFY_REASON="duplicate remote tag name: $name"
+      return 1
+    fi
+    names=${names:+$names$'\n'}$name
+    records=${records:+$records$'\n'}$name$'\t'$oid
+  done <<<"$output"
+
+  while IFS=$'\t' read -r name oid; do
+    [[ -n "$name" ]] || continue
+    if local_oid=$(git -C "$repo" show-ref --verify --hash "refs/tags/$name" 2>/dev/null); then
+      if [[ "$local_oid" != "$oid" ]]; then
+        updater_mark_ineligible "$ineligible_path" "$name" "moved-tag" || mark_rc=$?
+        mark_rc=${mark_rc:-0}
+        if [[ "$mark_rc" -eq 0 ]]; then
+          updater_report_ineligible "$name" "moved tag: local $local_oid differs from remote $oid"
+        elif [[ "$mark_rc" -eq 2 ]]; then
+          return 1
+        fi
+        mark_rc=
+      fi
+    else
+      candidates=${candidates:+$candidates$'\n'}$name
+    fi
+  done <<<"$records"
+
+  refspecs=()
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    refspecs+=("refs/tags/$name:refs/tags/$name")
+  done <<<"$candidates"
+  if (( ${#refspecs[@]} > 0 )); then
+    if ! git -C "$repo" fetch --atomic --no-tags origin "${refspecs[@]}"; then
+      UPDATER_VERIFY_REASON="atomic candidate tag fetch failed; no new tag refs were installed"
+      return 1
+    fi
+  fi
+
+  UPDATER_REMOTE_TAGS=$records
+}
+
+updater_header_from_object() {
+  local object=$1
+  local output_var=$2
+  local line header_value=
+
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || break
+    header_value=${header_value:+$header_value$'\n'}$line
+  done <<<"$object"
+  printf -v "$output_var" '%s' "$header_value"
+}
+
+# B-ALG steps 2-4. The ref is resolved exactly once here. Every later object
+# operation uses the captured tag-object OID or peeled commit OID.
+updater_capture_verify_and_bind() {
+  local repo=$1
+  local name=$2
+  local allowed_signers=$3
+  local tag_oid type commit object header line embedded= epoch= tag_count=0
+
+  if ! tag_oid=$(git -C "$repo" rev-parse --verify "refs/tags/$name"); then
+    UPDATER_VERIFY_REASON="cannot capture tag ref: $name"
+    return 1
+  fi
+  type=$(git -C "$repo" cat-file -t "$tag_oid" 2>/dev/null || true)
+  if [[ "$type" != tag ]]; then
+    UPDATER_VERIFY_REASON="tag is lightweight or not annotated: $name"
+    return 1
+  fi
+  if ! commit=$(git -C "$repo" rev-parse --verify "$tag_oid^{commit}"); then
+    UPDATER_VERIFY_REASON="annotated tag does not peel to a commit: $name"
+    return 1
+  fi
+  if ! git -C "$repo" -c gpg.format=ssh -c gpg.ssh.allowedSignersFile="$allowed_signers" verify-tag "$tag_oid" >/dev/null 2>&1; then
+    UPDATER_VERIFY_REASON="SSH signature verification failed: $name"
+    return 1
+  fi
+  if ! object=$(git -C "$repo" cat-file tag "$tag_oid"); then
+    UPDATER_VERIFY_REASON="cannot read verified tag object: $name"
+    return 1
+  fi
+  updater_header_from_object "$object" header
+  while IFS= read -r line; do
+    if [[ "$line" == 'tag '* ]]; then
+      embedded=${line#tag }
+      tag_count=$((tag_count + 1))
+    elif [[ "$line" =~ ^tagger\ .*\ ([0-9]+)\ [+-][0-9]{4}$ ]]; then
+      epoch=${BASH_REMATCH[1]}
+    fi
+  done <<<"$header"
+  if [[ "$tag_count" -ne 1 || "$embedded" != "$name" ]]; then
+    UPDATER_VERIFY_REASON="verified tag object name does not exactly match ref $name (embedded: ${embedded:-missing})"
+    return 1
+  fi
+  if [[ ! "$epoch" =~ ^[0-9]+$ ]]; then
+    UPDATER_VERIFY_REASON="verified tag has no usable tagger timestamp: $name"
+    return 1
+  fi
+
+  UPDATER_CAPTURED_TAG=$name
+  UPDATER_CAPTURED_TAG_OID=$tag_oid
+  UPDATER_CAPTURED_COMMIT=$commit
+  UPDATER_CAPTURED_EPOCH=$epoch
+}
+
+# B-ALG step 5. Equality binds the version to the recorded commit identity.
+updater_check_floor() {
+  local name=$1
+  local commit=$2
+  local comparison
+
+  comparison=$(updater_semver_compare "$name" "$UPDATER_FLOOR_VERSION")
+  if [[ "$comparison" -lt 0 ]]; then
+    UPDATER_VERIFY_REASON="tag $name is below installed floor $UPDATER_FLOOR_VERSION"
+    return 1
+  fi
+  if [[ "$comparison" -eq 0 && "$commit" != "$UPDATER_FLOOR_COMMIT" ]]; then
+    UPDATER_VERIFY_REASON="tag $name equals floor version but commit differs from recorded OID"
+    return 1
+  fi
+}
+
+# B-ALG step 6. Checkout and the identity assertion both use the captured OID.
+updater_checkout_captured_commit() {
+  local repo=$1
+  local commit=$2
+  local head
+
+  if ! git -C "$repo" checkout --detach "$commit" >/dev/null; then
+    UPDATER_VERIFY_REASON="checkout of captured commit $commit failed"
+    return 1
+  fi
+  head=$(git -C "$repo" rev-parse HEAD 2>/dev/null || true)
+  if [[ "$head" != "$commit" ]]; then
+    UPDATER_VERIFY_REASON="checkout identity mismatch: expected $commit, found ${head:-unreadable}"
+    return 1
+  fi
+}

--- a/scripts/lib-updater-verify.sh
+++ b/scripts/lib-updater-verify.sh
@@ -115,6 +115,10 @@ updater_default_ineligible_path() {
   printf '%s/.claude/state/updater-ineligible/%s.log\n' "$HOME" "$(updater_repo_state_key "$1")"
 }
 
+updater_default_startup_failure_path() {
+  printf '%s/.claude/state/updater-startup-failures/%s.log\n' "$HOME" "$(updater_repo_state_key "$1")"
+}
+
 updater_path_is_outside_repo() {
   local repo_real signers_dir signers_real
 

--- a/scripts/lib-updater-verify.sh
+++ b/scripts/lib-updater-verify.sh
@@ -11,6 +11,8 @@ UPDATER_CAPTURED_EPOCH=
 UPDATER_FLOOR_VERSION=
 UPDATER_FLOOR_COMMIT=
 UPDATER_REMOTE_TAGS=
+UPDATER_MOVED_TAGS=
+UPDATER_SYNC_FAILURE_HANDLED=0
 
 updater_is_semver() {
   [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
@@ -96,12 +98,21 @@ updater_repo_name() {
   basename "$(cd "$1" && pwd -P)"
 }
 
+updater_repo_state_key() {
+  local repo_real repo_name path_hash
+
+  repo_real=$(cd "$1" && pwd -P) || return 1
+  repo_name=$(basename "$repo_real")
+  path_hash=$(printf '%s' "$repo_real" | git hash-object --stdin) || return 1
+  printf '%s-%s\n' "$repo_name" "${path_hash:0:12}"
+}
+
 updater_default_pin_path() {
-  printf '%s/.claude/state/updater-pin/%s.json\n' "$HOME" "$(updater_repo_name "$1")"
+  printf '%s/.claude/state/updater-pin/%s.json\n' "$HOME" "$(updater_repo_state_key "$1")"
 }
 
 updater_default_ineligible_path() {
-  printf '%s/.claude/state/updater-ineligible/%s.log\n' "$HOME" "$(updater_repo_name "$1")"
+  printf '%s/.claude/state/updater-ineligible/%s.log\n' "$HOME" "$(updater_repo_state_key "$1")"
 }
 
 updater_path_is_outside_repo() {
@@ -240,21 +251,34 @@ updater_load_or_seed_floor() {
   local repo=$1
   local path=$2
   local prefetch_head=$3
-  local tags tag sorted
+  local ledger=$4
+  local persist_seed=${5:-1}
+  local repo_name tag recorded_commit
 
   if [[ -e "$path" || -L "$path" ]]; then
     updater_read_pin "$path"
     return $?
   fi
 
-  tags=$(git -C "$repo" tag --points-at "$prefetch_head" 2>/dev/null || true)
-  sorted=$(updater_sort_semvers_desc "$(printf '%s\n' "$tags" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)")
-  tag=$(printf '%s\n' "$sorted" | sed -n '1p')
-  if [[ -z "$tag" ]]; then
-    UPDATER_VERIFY_REASON="updater pin is absent and pre-fetch HEAD is not at a semver tag; bootstrap with scripts/updater-bootstrap: $path"
+  repo_name=$(updater_repo_name "$repo")
+  tag=$(awk -v repo="$repo_name" '
+    NF == 5 && $3 == repo && $5 == "ok" {tag=$4}
+    END {if (tag != "") print tag}
+  ' "$ledger" 2>/dev/null || true)
+  if [[ -z "$tag" ]] || ! updater_is_semver "$tag"; then
+    UPDATER_VERIFY_REASON="updater pin is absent and the install ledger has no usable ok entry for this repository; bootstrap with scripts/updater-bootstrap: $path"
     return 1
   fi
-  updater_write_pin "$path" "$tag" "$prefetch_head" || return 1
+
+  recorded_commit=$(git -C "$repo" rev-parse --verify "refs/tags/$tag^{commit}" 2>/dev/null || true)
+  if [[ "$recorded_commit" != "$prefetch_head" ]]; then
+    UPDATER_VERIFY_REASON="updater pin is absent and the install ledger tag does not point at pre-fetch HEAD; bootstrap with scripts/updater-bootstrap: $path"
+    return 1
+  fi
+
+  if [[ "$persist_seed" -eq 1 ]]; then
+    updater_write_pin "$path" "$tag" "$prefetch_head" || return 1
+  fi
   UPDATER_FLOOR_VERSION=$tag
   UPDATER_FLOOR_COMMIT=$prefetch_head
 }
@@ -294,9 +318,8 @@ updater_has_verification_failure() {
 
   [[ -f "$path" ]] && awk -v name="$name" '
     $1 == name {
-      if ($3 == "moved-tag") next
-      if ($3 == "verification-failure-cleared") active=0
-      else active=1
+      if ($3 == "verification-failure") active=1
+      else if ($3 == "verification-failure-cleared") active=0
     }
     END {exit active ? 0 : 1}
   ' "$path"
@@ -346,6 +369,38 @@ updater_clear_verification_failure() {
   return 0
 }
 
+updater_has_install_failure() {
+  local path=$1
+  local name=$2
+  local commit=$3
+
+  [[ -f "$path" ]] && awk -v name="$name" -v commit="$commit" \
+    '$1 == name && $3 == "install-failure" && $4 == commit {found=1; exit}
+     END {exit found ? 0 : 1}' "$path"
+}
+
+# Install failures are selection exclusions for one exact release identity.
+# A different commit OID is a different pair and is not suppressed here.
+updater_mark_install_failure() {
+  local path=$1
+  local name=$2
+  local commit=$3
+  local dir timestamp
+
+  if updater_has_install_failure "$path" "$name" "$commit"; then
+    return 1
+  fi
+  dir=$(dirname "$path")
+  updater_prepare_private_dir "$dir" || return 2
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  if ! printf '%s %s install-failure %s\n' "$name" "$timestamp" "$commit" >>"$path" \
+    || ! chmod 600 "$path"; then
+    UPDATER_VERIFY_REASON="cannot append updater install-failure record: $path"
+    return 2
+  fi
+  return 0
+}
+
 updater_remote_oid_for() {
   local records=$1
   local wanted=$2
@@ -360,6 +415,51 @@ updater_remote_oid_for() {
   return 1
 }
 
+updater_remote_record_name() {
+  local line=$1
+  local ref=$2
+  local name hash
+
+  if [[ "$ref" == refs/tags/* ]]; then
+    name=${ref#refs/tags/}
+  fi
+  if [[ -n "${name:-}" && "$name" != *[[:space:]]* ]]; then
+    printf '%s\n' "$name"
+    return 0
+  fi
+  hash=$(printf '%s' "$line" | git hash-object --stdin) || return 1
+  printf 'remote-record-%s\n' "${hash:0:12}"
+}
+
+# Record and report a remote-listing failure once per offending name. Returns
+# nonzero so the caller preserves the contract's fail-closed stop.
+updater_fail_remote_listing() {
+  local path=$1
+  local name=$2
+  local reason=$3
+  local dry_run=$4
+  local mark_rc
+
+  UPDATER_VERIFY_REASON=$reason
+  if [[ "$dry_run" -eq 1 ]]; then
+    return 1
+  fi
+  if ! declare -F updater_report_ineligible >/dev/null 2>&1; then
+    UPDATER_VERIFY_REASON="updater reporting callback is unavailable for: $reason"
+    return 1
+  fi
+  if updater_mark_verification_failure "$path" "$name" "$reason"; then
+    updater_report_ineligible "$name" "$reason"
+    UPDATER_SYNC_FAILURE_HANDLED=1
+  else
+    mark_rc=$?
+    if [[ "$mark_rc" -eq 1 ]]; then
+      UPDATER_SYNC_FAILURE_HANDLED=1
+    fi
+  fi
+  return 1
+}
+
 # Fetches branches without tags, validates the remote tag listing, identifies
 # moved names, then installs all absent tag refs in one atomic ref-update batch.
 # A failed atomic fetch can leave unreachable objects, but it installs no new
@@ -367,9 +467,13 @@ updater_remote_oid_for() {
 updater_sync_remote_tags() {
   local repo=$1
   local ineligible_path=$2
-  local output line oid ref name extra local_oid mark_rc
+  local dry_run=${3:-0}
+  local output line oid ref name extra local_oid mark_rc reason record_name
   local names= records= candidates=
   local -a refspecs
+
+  UPDATER_MOVED_TAGS=
+  UPDATER_SYNC_FAILURE_HANDLED=0
 
   if ! git -C "$repo" fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'; then
     UPDATER_VERIFY_REASON="branch fetch failed"
@@ -385,16 +489,19 @@ updater_sync_remote_tags() {
     oid= ref= extra=
     IFS=$'\t' read -r oid ref extra <<<"$line"
     if [[ -n "$extra" || ! "$oid" =~ ^[0-9a-f]{40}$ || "$ref" != refs/tags/* || "$ref" == *'^{}' ]]; then
-      UPDATER_VERIFY_REASON="unparsable remote tag record: $line"
+      reason="unparsable remote tag record: $line"
+      record_name=$(updater_remote_record_name "$line" "$ref") || record_name=remote-record-unavailable
+      updater_fail_remote_listing "$ineligible_path" "$record_name" "$reason" "$dry_run"
       return 1
     fi
     name=${ref#refs/tags/}
     if ! updater_is_semver "$name"; then
-      UPDATER_VERIFY_REASON="remote tag name is not strict semver: $name"
-      return 1
+      printf 'family-updater: skipping non-semver remote tag name: %s\n' "$name"
+      continue
     fi
     if printf '%s\n' "$names" | grep -Fxq "$name"; then
-      UPDATER_VERIFY_REASON="duplicate remote tag name: $name"
+      reason="duplicate remote tag name: $name"
+      updater_fail_remote_listing "$ineligible_path" "$name" "$reason" "$dry_run"
       return 1
     fi
     names=${names:+$names$'\n'}$name
@@ -405,6 +512,14 @@ updater_sync_remote_tags() {
     [[ -n "$name" ]] || continue
     if local_oid=$(git -C "$repo" show-ref --verify --hash "refs/tags/$name" 2>/dev/null); then
       if [[ "$local_oid" != "$oid" ]]; then
+        UPDATER_MOVED_TAGS=${UPDATER_MOVED_TAGS:+$UPDATER_MOVED_TAGS$'\n'}$name
+        if [[ "$dry_run" -eq 1 ]]; then
+          continue
+        fi
+        if ! declare -F updater_report_ineligible >/dev/null 2>&1; then
+          UPDATER_VERIFY_REASON="updater reporting callback is unavailable for moved tag: $name"
+          return 1
+        fi
         updater_mark_ineligible "$ineligible_path" "$name" "moved-tag" || mark_rc=$?
         mark_rc=${mark_rc:-0}
         if [[ "$mark_rc" -eq 0 ]]; then

--- a/scripts/updater-bootstrap
+++ b/scripts/updater-bootstrap
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck source=scripts/lib-updater-verify.sh
+source "$SCRIPT_DIR/lib-updater-verify.sh"
+
+repo_dir=
+initial_tag=
+allowed_signers=${CATY_UPDATER_ALLOWED_SIGNERS:-$HOME/.claude/state/updater-allowed-signers}
+cron_wrapper_dest=
+pin_already_matches=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/updater-bootstrap --repo-dir <clone> --initial-tag <vX.Y.Z>
+                            [--allowed-signers <out-of-repo-path>]
+                            [--cron-wrapper-dest <absolute-path>]
+
+The owner supplies the exact initial tag and allowed_signers out of band. This
+command verifies that one named tag only, checks it out by captured commit OID,
+records the per-repository floor, and only then may copy the cron wrapper.
+USAGE
+}
+
+fail() {
+  printf 'updater-bootstrap error: %s\n' "$1" >&2
+  exit 1
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --repo-dir)
+      (($# >= 2)) || { usage >&2; exit 2; }
+      repo_dir=$2
+      shift 2
+      ;;
+    --initial-tag)
+      (($# >= 2)) || { usage >&2; exit 2; }
+      initial_tag=$2
+      shift 2
+      ;;
+    --allowed-signers)
+      (($# >= 2)) || { usage >&2; exit 2; }
+      allowed_signers=$2
+      shift 2
+      ;;
+    --cron-wrapper-dest)
+      (($# >= 2)) || { usage >&2; exit 2; }
+      cron_wrapper_dest=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n "$repo_dir" && -n "$initial_tag" ]] || { usage >&2; exit 2; }
+[[ -d "$repo_dir" ]] || fail "repo dir not found: $repo_dir"
+updater_is_semver "$initial_tag" || fail "initial tag is not strict semver: $initial_tag"
+if [[ -n "$cron_wrapper_dest" && "$cron_wrapper_dest" != /* ]]; then
+  fail "cron wrapper destination must be absolute: $cron_wrapper_dest"
+fi
+if ! git -C "$repo_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  fail "repo is not a git repository: $repo_dir"
+fi
+if ! updater_check_capabilities "$repo_dir"; then
+  fail "$UPDATER_VERIFY_REASON"
+fi
+if ! updater_validate_allowed_signers "$repo_dir" "$allowed_signers"; then
+  fail "$UPDATER_VERIFY_REASON"
+fi
+
+pin_path=$(updater_default_pin_path "$repo_dir")
+
+# B-BOOT uses the same B-ALG steps 2-4 as the recurring updater and operates on
+# exactly the owner-named ref. It performs no remote enumeration or selection.
+if ! updater_capture_verify_and_bind "$repo_dir" "$initial_tag" "$allowed_signers"; then
+  fail "$UPDATER_VERIFY_REASON"
+fi
+
+# A prior attempt may have written the verified floor and then failed while
+# installing the cron wrapper. Only that exact version/commit identity may be
+# resumed; every other pre-existing pin remains a hard refusal.
+if [[ -e "$pin_path" || -L "$pin_path" ]]; then
+  if ! updater_read_pin "$pin_path" \
+    || [[ "$UPDATER_FLOOR_VERSION" != "$initial_tag" \
+      || "$UPDATER_FLOOR_COMMIT" != "$UPDATER_CAPTURED_COMMIT" ]]; then
+    fail "updater pin already exists; bootstrap will not replace it: $pin_path"
+  fi
+  pin_already_matches=1
+fi
+
+# The bootstrap floor is the verified initial identity itself. Running the same
+# equality rule makes a same-version/different-content seed impossible.
+UPDATER_FLOOR_VERSION=$initial_tag
+UPDATER_FLOOR_COMMIT=$UPDATER_CAPTURED_COMMIT
+if ! updater_check_floor "$initial_tag" "$UPDATER_CAPTURED_COMMIT"; then
+  fail "$UPDATER_VERIFY_REASON"
+fi
+
+# B-ALG step 6: checkout and assert only the captured commit OID, never the ref.
+if ! updater_checkout_captured_commit "$repo_dir" "$UPDATER_CAPTURED_COMMIT"; then
+  fail "$UPDATER_VERIFY_REASON"
+fi
+
+# The floor is made durable only after the named tag passed the full mechanical
+# gate. Repo code is not enabled and the cron wrapper is not installed earlier.
+if [[ "$pin_already_matches" -eq 0 ]]; then
+  if ! updater_write_pin "$pin_path" "$initial_tag" "$UPDATER_CAPTURED_COMMIT"; then
+    fail "$UPDATER_VERIFY_REASON"
+  fi
+fi
+
+if [[ -n "$cron_wrapper_dest" ]]; then
+  wrapper_source="$repo_dir/templates/updater-cron.tmpl.sh"
+  [[ -f "$wrapper_source" ]] || fail "verified release has no updater cron template: $wrapper_source"
+  wrapper_dir=$(dirname "$cron_wrapper_dest")
+  mkdir -p "$wrapper_dir" || fail "cannot create cron wrapper directory: $wrapper_dir"
+  tmp_wrapper=$(mktemp "$wrapper_dir/.updater-cron.tmp.XXXXXX") || fail "cannot create cron wrapper temporary file"
+  if ! cp "$wrapper_source" "$tmp_wrapper" || ! chmod 700 "$tmp_wrapper" || ! mv -f "$tmp_wrapper" "$cron_wrapper_dest"; then
+    rm -f "$tmp_wrapper"
+    fail "cannot atomically install cron wrapper: $cron_wrapper_dest"
+  fi
+fi
+
+printf 'updater-bootstrap: verified and installed %s at commit %s\n' "$initial_tag" "$UPDATER_CAPTURED_COMMIT"
+if [[ "$pin_already_matches" -eq 1 ]]; then
+  printf 'updater-bootstrap: confirmed existing floor %s\n' "$pin_path"
+else
+  printf 'updater-bootstrap: initialized floor %s\n' "$pin_path"
+fi
+if [[ -n "$cron_wrapper_dest" ]]; then
+  printf 'updater-bootstrap: installed cron wrapper %s\n' "$cron_wrapper_dest"
+fi

--- a/scripts/updater-bootstrap
+++ b/scripts/updater-bootstrap
@@ -87,8 +87,8 @@ if ! updater_capture_verify_and_bind "$repo_dir" "$initial_tag" "$allowed_signer
 fi
 
 # A prior attempt may have written the verified floor and then failed while
-# installing the cron wrapper. Only that exact version/commit identity may be
-# resumed; every other pre-existing pin remains a hard refusal.
+# installing the cron wrapper. The pre-existing pin identity check below allows
+# only that exact version/commit to resume and refuses every other pin.
 if [[ -e "$pin_path" || -L "$pin_path" ]]; then
   if ! updater_read_pin "$pin_path" \
     || [[ "$UPDATER_FLOOR_VERSION" != "$initial_tag" \
@@ -96,14 +96,6 @@ if [[ -e "$pin_path" || -L "$pin_path" ]]; then
     fail "updater pin already exists; bootstrap will not replace it: $pin_path"
   fi
   pin_already_matches=1
-fi
-
-# The bootstrap floor is the verified initial identity itself. Running the same
-# equality rule makes a same-version/different-content seed impossible.
-UPDATER_FLOOR_VERSION=$initial_tag
-UPDATER_FLOOR_COMMIT=$UPDATER_CAPTURED_COMMIT
-if ! updater_check_floor "$initial_tag" "$UPDATER_CAPTURED_COMMIT"; then
-  fail "$UPDATER_VERIFY_REASON"
 fi
 
 # B-ALG step 6: checkout and assert only the captured commit OID, never the ref.

--- a/templates/updater-cron.tmpl.sh
+++ b/templates/updater-cron.tmpl.sh
@@ -36,8 +36,11 @@ if [[ ! -x "$REPO_DIR/scripts/family-updater" ]]; then
   fail "family-updater is not executable: $REPO_DIR/scripts/family-updater"
 fi
 
-repo_name=$(basename "$(cd "$REPO_DIR" && pwd -P)")
-pin_path="$HOME/.claude/state/updater-pin/$repo_name.json"
+repo_real=$(cd "$REPO_DIR" && pwd -P)
+repo_name=$(basename "$repo_real")
+repo_hash=$(printf '%s' "$repo_real" | git hash-object --stdin) || fail "cannot hash physical REPO_DIR path"
+repo_state_key="$repo_name-${repo_hash:0:12}"
+pin_path="$HOME/.claude/state/updater-pin/$repo_state_key.json"
 if [[ ! -r "$pin_path" ]]; then
   fail "verified updater pin is missing; run scripts/updater-bootstrap before enabling this wrapper: $pin_path"
 fi

--- a/templates/updater-cron.tmpl.sh
+++ b/templates/updater-cron.tmpl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Caty Agent Harness updater cron wrapper template v1
+# Caty Agent Harness updater cron wrapper template v2
 #
 # Copy this file next to a checked-out harness clone, set REPO_DIR to the
 # absolute clone path, and run it from cron. It validates wrapper-level
@@ -20,6 +20,7 @@ WORKSPACE=${WORKSPACE:-$PWD}
 AGENT=${AGENT:-${USER:-unknown}}
 RING=${RING:-stable}
 SOAK_HOURS=${SOAK_HOURS:-24}
+ALLOWED_SIGNERS=${CATY_UPDATER_ALLOWED_SIGNERS:-$HOME/.claude/state/updater-allowed-signers}
 
 if [[ -z "${FMA_SCRIPTS_DIR:-}" ]]; then
   fail "FMA_SCRIPTS_DIR is not set; set it to the reporter directory (for example, /path/to/family-memory-architecture/scripts)"
@@ -35,10 +36,20 @@ if [[ ! -x "$REPO_DIR/scripts/family-updater" ]]; then
   fail "family-updater is not executable: $REPO_DIR/scripts/family-updater"
 fi
 
+repo_name=$(basename "$(cd "$REPO_DIR" && pwd -P)")
+pin_path="$HOME/.claude/state/updater-pin/$repo_name.json"
+if [[ ! -r "$pin_path" ]]; then
+  fail "verified updater pin is missing; run scripts/updater-bootstrap before enabling this wrapper: $pin_path"
+fi
+if [[ ! -r "$ALLOWED_SIGNERS" || ! -s "$ALLOWED_SIGNERS" ]]; then
+  fail "allowed_signers file is absent, unreadable, or empty: $ALLOWED_SIGNERS"
+fi
+
 exec "$REPO_DIR/scripts/family-updater" \
   --repo-dir "$REPO_DIR" \
   --workspace "$WORKSPACE" \
   --agent "$AGENT" \
   --ring "$RING" \
   --soak-hours "$SOAK_HOURS" \
+  --allowed-signers "$ALLOWED_SIGNERS" \
   --fma-scripts-dir "$FMA_SCRIPTS_DIR"

--- a/tests/family-updater.test.sh
+++ b/tests/family-updater.test.sh
@@ -139,6 +139,7 @@ repo_state_key() {
 pin_path() { printf '%s/.claude/state/updater-pin/%s.json\n' "$HOME_DIR" "$(repo_state_key)"; }
 ineligible_path() { printf '%s/.claude/state/updater-ineligible/%s.log\n' "$HOME_DIR" "$(repo_state_key)"; }
 ledger_path() { printf '%s/.claude/state/installed-versions.log\n' "$HOME_DIR"; }
+startup_failure_path() { printf '%s/.claude/state/updater-startup-failures/%s.log\n' "$HOME_DIR" "$(repo_state_key)"; }
 
 append_ok_ledger() {
   local tag=$1
@@ -165,6 +166,76 @@ run_updater() {
       --soak-hours 0 --allowed-signers "$ALLOWED" --fma-scripts-dir "$FMA" "$@" 2>&1
   fi
 }
+
+new_fixture delta4-startup-pin-dedupe
+tag_release signed v1.0.0 "$BASE_COMMIT"
+push_tag v1.0.0
+fetch_local_tag v1.0.0
+startup_output=
+startup_rcs=
+for tick in 1 2 3; do
+  output=$(run_updater); rc=$?
+  startup_output=${startup_output:+$startup_output$'\n'}$output
+  startup_rcs="$startup_rcs $rc"
+done
+first_reports=$(grep -Fc 'updater failed: claire repo pin-failed' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+first_fail_heartbeats=$(grep -Fc 'job-heartbeat updater-claire fail ' "$LOGS/heartbeats.log" 2>/dev/null || true)
+first_errors=$(printf '%s\n' "$startup_output" | grep -Fc 'family-updater error: updater pin is absent and the install ledger has no usable ok entry' || true)
+first_fail_ledger=$(grep -Fc ' pin-failed fail' "$(ledger_path)" 2>/dev/null || true)
+
+write_pin v1.0.0 "$BASE_COMMIT"
+recovery_output=$(run_updater); recovery_rc=$?
+rm -f "$(pin_path)"
+recurrence_output=$(run_updater); recurrence_rc=$?
+total_reports=$(grep -Fc 'updater failed: claire repo pin-failed' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+total_fail_heartbeats=$(grep -Fc 'job-heartbeat updater-claire fail ' "$LOGS/heartbeats.log" 2>/dev/null || true)
+total_errors=$(printf '%s\n%s\n' "$startup_output" "$recurrence_output" | grep -Fc 'family-updater error: updater pin is absent and the install ledger has no usable ok entry' || true)
+total_fail_ledger=$(grep -Fc ' pin-failed fail' "$(ledger_path)" 2>/dev/null || true)
+failure_records=$(grep -Fc 'pin-failed ' "$(startup_failure_path)" 2>/dev/null || true)
+clear_records=$(grep -F 'pin-failed ' "$(startup_failure_path)" 2>/dev/null | grep -Fc ' verification-failure-cleared' || true)
+if [[ "$startup_rcs" == ' 1 1 1' && "$first_reports" -eq 1 \
+  && "$first_fail_heartbeats" -eq 1 && "$first_errors" -eq 3 \
+  && "$first_fail_ledger" -eq 1 && "$recovery_rc" -eq 0 \
+  && "$recurrence_rc" -eq 1 && "$total_reports" -eq 2 \
+  && "$total_fail_heartbeats" -eq 2 && "$total_errors" -eq 4 \
+  && "$total_fail_ledger" -eq 2 && "$failure_records" -eq 3 \
+  && "$clear_records" -eq 1 ]]; then
+  pass "startup pin failure reports once across three ticks, clears on recovery, and reports on recurrence"
+else
+  fail_case "startup pin failure reports once across three ticks, clears on recovery, and reports on recurrence" \
+    "rcs=[$startup_rcs]/$recovery_rc/$recurrence_rc reports=$first_reports/$total_reports heartbeats=$first_fail_heartbeats/$total_fail_heartbeats errors=$first_errors/$total_errors ledger=$first_fail_ledger/$total_fail_ledger records=$failure_records clears=$clear_records recovery=$recovery_output"
+fi
+
+new_fixture delta4-dry-run-diagnostic
+commit_release installed pass
+installed_commit=$RELEASE_COMMIT
+tag_release signed v1.0.0 "$installed_commit"
+push_tag v1.0.0
+fetch_local_tag v1.0.0
+git -C "$REPO" checkout -q --detach "$installed_commit"
+append_ok_ledger v1.0.0
+ledger_before=$(cksum "$(ledger_path)")
+commit_release rejected pass
+tag_release unsigned v1.1.0 "$RELEASE_COMMIT"
+push_tag v1.1.0
+output=$(run_updater --dry-run); rc=$?
+ledger_after=$(cksum "$(ledger_path)")
+if [[ "$rc" -eq 0 && "$ledger_before" == "$ledger_after" \
+  && ! -e "$(pin_path)" && ! -e "$(ineligible_path)" \
+  && ! -e "$(startup_failure_path)" && ! -e "$LOGS/heartbeats.log" \
+  && ! -e "$LOGS/hot-inbox.log" ]] \
+  && printf '%s\n' "$output" | grep -Fq 'family-updater error: SSH signature verification failed: v1.1.0'; then
+  pass "dry-run prints candidate rejection while writing and reporting nothing"
+else
+  fail_case "dry-run prints candidate rejection while writing and reporting nothing" \
+    "rc=$rc pin=$(test -e "$(pin_path)" && echo yes || echo no) ineligible=$(test -e "$(ineligible_path)" && echo yes || echo no) startup=$(test -e "$(startup_failure_path)" && echo yes || echo no) output=$output"
+fi
+
+if [[ "${DELTA4_FOCUSED:-0}" == 1 ]]; then
+  printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+  [[ "$FAIL_COUNT" -eq 0 ]]
+  exit $?
+fi
 
 make_candidate() {
   local kind=$1
@@ -1090,22 +1161,104 @@ fi
 new_fixture capability-old-git
 write_pin v0.0.0 "$BASE_COMMIT"
 before=$(git -C "$REPO" rev-parse HEAD)
-output=$(PATH="$FAKEBIN:$PATH" REAL_GIT="$REAL_GIT" FAKE_OLD_GIT=1 run_updater); rc=$?
+capability_output=
+capability_rcs=
+for tick in 1 2 3; do
+  output=$(PATH="$FAKEBIN:$PATH" REAL_GIT="$REAL_GIT" FAKE_OLD_GIT=1 run_updater); rc=$?
+  capability_output=${capability_output:+$capability_output$'\n'}$output
+  capability_rcs="$capability_rcs $rc"
+done
+first_reports=$(grep -Fc 'updater failed: claire repo capability-failed' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+first_fail_heartbeats=$(grep -Fc 'job-heartbeat updater-claire fail ' "$LOGS/heartbeats.log" 2>/dev/null || true)
+first_errors=$(printf '%s\n' "$capability_output" | grep -Fc 'family-updater error: git 2.34 or newer is required' || true)
+recovery_output=$(run_updater); recovery_rc=$?
+recurrence_output=$(PATH="$FAKEBIN:$PATH" REAL_GIT="$REAL_GIT" FAKE_OLD_GIT=1 run_updater); recurrence_rc=$?
 after=$(git -C "$REPO" rev-parse HEAD)
-if [[ "$rc" -ne 0 && "$before" == "$after" ]] && printf '%s\n' "$output" | grep -Fq 'git 2.34 or newer is required'; then
-  pass "simulated old git fails closed with capability message"
+total_reports=$(grep -Fc 'updater failed: claire repo capability-failed' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+total_fail_heartbeats=$(grep -Fc 'job-heartbeat updater-claire fail ' "$LOGS/heartbeats.log" 2>/dev/null || true)
+clear_records=$(grep -F 'capability-failed ' "$(startup_failure_path)" 2>/dev/null | grep -Fc ' verification-failure-cleared' || true)
+if [[ "$capability_rcs" == ' 1 1 1' && "$recovery_rc" -eq 0 && "$recurrence_rc" -eq 1 \
+  && "$before" == "$after" && "$first_reports" -eq 1 && "$total_reports" -eq 2 \
+  && "$first_fail_heartbeats" -eq 1 && "$total_fail_heartbeats" -eq 2 \
+  && "$first_errors" -eq 3 && "$clear_records" -eq 1 ]]; then
+  pass "capability failure reports once, stays visible each tick, clears, and can report again"
 else
-  fail_case "simulated old git fails closed with capability message" "rc=$rc output=$output"
+  fail_case "capability failure reports once, stays visible each tick, clears, and can report again" \
+    "rcs=[$capability_rcs]/$recovery_rc/$recurrence_rc reports=$first_reports/$total_reports heartbeats=$first_fail_heartbeats/$total_fail_heartbeats errors=$first_errors clears=$clear_records output=$recurrence_output"
 fi
 
 new_fixture missing-signers
 write_pin v0.0.0 "$BASE_COMMIT"
 missing=$BASE/does-not-exist
-output=$(HOME="$HOME_DIR" "$UPDATER" --repo-dir "$REPO" --workspace "$WS" --agent claire --ring canary --allowed-signers "$missing" --fma-scripts-dir "$FMA" 2>&1); rc=$?
-if [[ "$rc" -ne 0 ]] && printf '%s\n' "$output" | grep -Fq "allowed_signers file is absent, unreadable, or empty: $missing"; then
-  pass "missing allowed_signers fails closed and names the file"
+signers_output=
+signers_rcs=
+for tick in 1 2 3; do
+  output=$(HOME="$HOME_DIR" "$UPDATER" --repo-dir "$REPO" --workspace "$WS" --agent claire --ring canary --allowed-signers "$missing" --fma-scripts-dir "$FMA" 2>&1); rc=$?
+  signers_output=${signers_output:+$signers_output$'\n'}$output
+  signers_rcs="$signers_rcs $rc"
+done
+first_reports=$(grep -Fc 'updater failed: claire repo signers-failed' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+first_fail_heartbeats=$(grep -Fc 'job-heartbeat updater-claire fail ' "$LOGS/heartbeats.log" 2>/dev/null || true)
+first_errors=$(printf '%s\n' "$signers_output" | grep -Fc "family-updater error: allowed_signers file is absent, unreadable, or empty: $missing" || true)
+recovery_output=$(run_updater); recovery_rc=$?
+recurrence_output=$(HOME="$HOME_DIR" "$UPDATER" --repo-dir "$REPO" --workspace "$WS" --agent claire --ring canary --allowed-signers "$missing" --fma-scripts-dir "$FMA" 2>&1); recurrence_rc=$?
+total_reports=$(grep -Fc 'updater failed: claire repo signers-failed' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+total_fail_heartbeats=$(grep -Fc 'job-heartbeat updater-claire fail ' "$LOGS/heartbeats.log" 2>/dev/null || true)
+clear_records=$(grep -F 'signers-failed ' "$(startup_failure_path)" 2>/dev/null | grep -Fc ' verification-failure-cleared' || true)
+if [[ "$signers_rcs" == ' 1 1 1' && "$recovery_rc" -eq 0 && "$recurrence_rc" -eq 1 \
+  && "$first_reports" -eq 1 && "$total_reports" -eq 2 \
+  && "$first_fail_heartbeats" -eq 1 && "$total_fail_heartbeats" -eq 2 \
+  && "$first_errors" -eq 3 && "$clear_records" -eq 1 ]]; then
+  pass "signer failure reports once, stays visible each tick, clears, and can report again"
 else
-  fail_case "missing allowed_signers fails closed and names the file" "rc=$rc output=$output"
+  fail_case "signer failure reports once, stays visible each tick, clears, and can report again" \
+    "rcs=[$signers_rcs]/$recovery_rc/$recurrence_rc reports=$first_reports/$total_reports heartbeats=$first_fail_heartbeats/$total_fail_heartbeats errors=$first_errors clears=$clear_records output=$recurrence_output"
+fi
+
+new_fixture invalid-ineligible-state
+write_pin v0.0.0 "$BASE_COMMIT"
+invalid_state=$(ineligible_path)
+mkdir -p "$(dirname "$invalid_state")" "$invalid_state"
+state_output=
+state_rcs=
+for tick in 1 2 3; do
+  output=$(run_updater); rc=$?
+  state_output=${state_output:+$state_output$'\n'}$output
+  state_rcs="$state_rcs $rc"
+done
+first_reports=$(grep -Fc 'updater failed: claire repo state-failed' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+first_fail_heartbeats=$(grep -Fc 'job-heartbeat updater-claire fail ' "$LOGS/heartbeats.log" 2>/dev/null || true)
+first_errors=$(printf '%s\n' "$state_output" | grep -Fc "family-updater error: updater ineligible log is not a regular file: $invalid_state" || true)
+rmdir "$invalid_state"
+recovery_output=$(run_updater); recovery_rc=$?
+mkdir "$invalid_state"
+recurrence_output=$(run_updater); recurrence_rc=$?
+total_reports=$(grep -Fc 'updater failed: claire repo state-failed' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+total_fail_heartbeats=$(grep -Fc 'job-heartbeat updater-claire fail ' "$LOGS/heartbeats.log" 2>/dev/null || true)
+clear_records=$(grep -F 'state-failed ' "$(startup_failure_path)" 2>/dev/null | grep -Fc ' verification-failure-cleared' || true)
+if [[ "$state_rcs" == ' 1 1 1' && "$recovery_rc" -eq 0 && "$recurrence_rc" -eq 1 \
+  && "$first_reports" -eq 1 && "$total_reports" -eq 2 \
+  && "$first_fail_heartbeats" -eq 1 && "$total_fail_heartbeats" -eq 2 \
+  && "$first_errors" -eq 3 && "$clear_records" -eq 1 ]]; then
+  pass "state failure reports once, stays visible each tick, clears, and can report again"
+else
+  fail_case "state failure reports once, stays visible each tick, clears, and can report again" \
+    "rcs=[$state_rcs]/$recovery_rc/$recurrence_rc reports=$first_reports/$total_reports heartbeats=$first_fail_heartbeats/$total_fail_heartbeats errors=$first_errors clears=$clear_records output=$recurrence_output"
+fi
+
+new_fixture startup-dedupe-state-invalid
+write_pin v0.0.0 "$BASE_COMMIT"
+dedupe_path=$(startup_failure_path)
+mkdir -p "$(dirname "$dedupe_path")"
+ln -s "$BASE/dedupe-target" "$dedupe_path"
+before=$(git -C "$REPO" rev-parse HEAD)
+output=$(run_updater); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$SENTINEL" ]] \
+  && printf '%s\n' "$output" | grep -Fq "updater startup failure log is not a readable, writable regular file: $dedupe_path"; then
+  pass "invalid startup dedupe state fails closed before update work"
+else
+  fail_case "invalid startup dedupe state fails closed before update work" "rc=$rc output=$output"
 fi
 
 new_fixture repo-local-signers

--- a/tests/family-updater.test.sh
+++ b/tests/family-updater.test.sh
@@ -2,451 +2,724 @@
 set -u
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+UPDATER=${UPDATER_UNDER_TEST:-$ROOT/scripts/family-updater}
+BOOTSTRAP=${BOOTSTRAP_UNDER_TEST:-$ROOT/scripts/updater-bootstrap}
 TMP_ROOT=${TMPDIR:-/tmp}/family-updater-test.$$
+REAL_GIT=$(command -v git)
 PASS_COUNT=0
 FAIL_COUNT=0
 
-cleanup() {
-  rm -rf "$TMP_ROOT"
-}
+cleanup() { rm -rf "$TMP_ROOT"; }
 trap cleanup EXIT HUP INT TERM
-
 mkdir -p "$TMP_ROOT"
 
-pass() {
-  PASS_COUNT=$((PASS_COUNT + 1))
-  printf 'PASS %s\n' "$1"
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf 'PASS %s\n' "$1"; }
+fail_case() { FAIL_COUNT=$((FAIL_COUNT + 1)); printf 'FAIL %s: %s\n' "$1" "$2"; }
+
+assert_true() {
+  local name=$1
+  shift
+  if "$@"; then pass "$name"; else fail_case "$name" "assertion failed: $*"; fi
 }
 
-fail_case() {
-  FAIL_COUNT=$((FAIL_COUNT + 1))
-  printf 'FAIL %s: %s\n' "$1" "$2"
+assert_contains() {
+  local name=$1 file=$2 text=$3
+  if [[ -f "$file" ]] && grep -Fq "$text" "$file"; then
+    pass "$name"
+  else
+    fail_case "$name" "missing '$text' in $file"
+  fi
 }
 
 write_fake_install() {
-  src=$1
-  result=$2
-
-  cat >"$src/install.sh" <<'EOF'
+  local src=$1 result=$2
+  cat >"$src/install.sh" <<'INSTALL'
 #!/usr/bin/env bash
 set -euo pipefail
-
-usage() {
-  printf 'Usage: install.sh --check --workspace <dir>\n'
-}
-
-workspace=$PWD
-check_mode=0
-
-while (($# > 0)); do
-  case "$1" in
-    --check)
-      check_mode=1
-      shift
-      ;;
-    --workspace)
-      (($# >= 2)) || { usage >&2; exit 2; }
-      workspace=$2
-      shift 2
-      ;;
-    *)
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-[[ "$check_mode" -eq 1 ]] || { usage >&2; exit 2; }
-if [[ -f "$(dirname "$0")/.fixture-install-fails" ]]; then
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if [[ -n "${UPDATER_INSTALL_SENTINEL:-}" ]]; then
+  printf '%s\n' "$(sed -n '1p' "$repo_dir/VERSION.fixture")" >>"$UPDATER_INSTALL_SENTINEL"
+fi
+if [[ -f "$repo_dir/.fixture-install-fails" ]]; then
   printf 'fixture install check failed\n'
   exit 1
 fi
-printf 'check: workspace %s\n' "$workspace"
 printf 'ok: fixture install check passed\n'
-EOF
+INSTALL
   chmod +x "$src/install.sh"
-  if [ "$result" = "fail" ]; then
+  if [[ "$result" == fail ]]; then
     printf 'fail\n' >"$src/.fixture-install-fails"
   else
     rm -f "$src/.fixture-install-fails"
   fi
 }
 
-commit_tag() {
-  src=$1
-  tag=$2
-  date_value=$3
-  result=$4
+new_fixture() {
+  local name=$1
+  name=${name// /-}
+  BASE=$TMP_ROOT/$name
+  ORIGIN=$BASE/origin.git
+  SRC=$BASE/src
+  REPO=$BASE/repo
+  HOME_DIR=$BASE/home
+  FMA=$BASE/fma
+  LOGS=$BASE/logs
+  WS=$BASE/ws
+  KEY=$BASE/key
+  OTHER_KEY=$BASE/other-key
+  ALLOWED=$HOME_DIR/.claude/state/updater-allowed-signers
+  SENTINEL=$BASE/install-sentinel.log
 
-  write_fake_install "$src" "$result"
-  printf '%s %s\n' "$tag" "$result" >"$src/VERSION.fixture"
-  git -C "$src" add -A >/dev/null 2>&1
-  GIT_AUTHOR_DATE="$date_value" GIT_COMMITTER_DATE="$date_value" \
-    git -C "$src" commit -m "$tag" >/dev/null
-  GIT_COMMITTER_DATE="$date_value" git -C "$src" tag -a "$tag" -m "$tag"
-}
+  mkdir -p "$BASE" "$HOME_DIR/.claude/state" "$FMA" "$LOGS" "$WS"
+  ssh-keygen -q -t ed25519 -N '' -f "$KEY"
+  ssh-keygen -q -t ed25519 -N '' -f "$OTHER_KEY"
+  printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$KEY.pub")" >"$ALLOWED"
 
-make_fma_shims() {
-  fma_dir=$1
-  log_dir=$2
+  git init -q --bare "$ORIGIN"
+  git init -q "$SRC"
+  git -C "$SRC" config user.name Fixture
+  git -C "$SRC" config user.email fixture@example.invalid
+  git -C "$SRC" config gpg.format ssh
+  git -C "$SRC" config user.signingkey "$KEY"
+  write_fake_install "$SRC" pass
+  printf 'base\n' >"$SRC/VERSION.fixture"
+  git -C "$SRC" add -A
+  GIT_AUTHOR_DATE=2020-01-01T00:00:00Z GIT_COMMITTER_DATE=2020-01-01T00:00:00Z \
+    git -C "$SRC" commit -qm base
+  BASE_COMMIT=$(git -C "$SRC" rev-parse HEAD)
+  BRANCH=$(git -C "$SRC" rev-parse --abbrev-ref HEAD)
+  git -C "$SRC" remote add origin "$ORIGIN"
+  git -C "$SRC" push -q origin "$BRANCH"
+  git clone -q --no-tags "$ORIGIN" "$REPO"
+  git -C "$REPO" checkout -q --detach "$BASE_COMMIT"
 
-  mkdir -p "$fma_dir" "$log_dir"
-  cat >"$fma_dir/job-heartbeat" <<EOF
+  cat >"$FMA/job-heartbeat" <<EOF
 #!/usr/bin/env bash
-printf '%s\n' "job-heartbeat \$*" >>"$log_dir/heartbeats.log"
+printf '%s\n' "job-heartbeat \$*" >>"$LOGS/heartbeats.log"
 EOF
-  cat >"$fma_dir/hot-inbox-post" <<EOF
+  cat >"$FMA/hot-inbox-post" <<EOF
 #!/usr/bin/env bash
-printf '%s\n' "hot-inbox-post \$*" >>"$log_dir/hot-inbox.log"
+printf '%s\n' "hot-inbox-post \$*" >>"$LOGS/hot-inbox.log"
 EOF
-  chmod +x "$fma_dir/job-heartbeat" "$fma_dir/hot-inbox-post"
+  chmod +x "$FMA/job-heartbeat" "$FMA/hot-inbox-post"
 }
 
-make_fixture() {
-  name=$1
-  target_result=$2
-  checkout_tag=$3
-  v10_date=${4:-2020-01-01T00:00:00Z}
-  v11_date=${5:-2020-01-02T00:00:00Z}
-  v12_date=${6:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}
-  v10_result=${7:-pass}
-  v11_result=${8:-pass}
-  base=$TMP_ROOT/$name
-  origin=$base/origin.git
-  src=$base/src
-  repo=$base/repo
-  ws=$base/ws
-  home=$base/home
-  fma=$base/fma
-  logs=$base/fma-logs
-
-  mkdir -p "$base" "$ws" "$home"
-  git init -q --bare "$origin"
-  git init -q "$src"
-  git -C "$src" config user.name "Fixture"
-  git -C "$src" config user.email "fixture@example.invalid"
-
-  commit_tag "$src" v1.0.0 "$v10_date" "$v10_result"
-  commit_tag "$src" v1.1.0 "$v11_date" "$v11_result"
-  commit_tag "$src" v1.2.0 "$v12_date" "$target_result"
-  git -C "$src" remote add origin "$origin"
-  branch=$(git -C "$src" rev-parse --abbrev-ref HEAD)
-  git -C "$src" push -q --tags origin "$branch"
-
-  git clone -q "$origin" "$repo" >/dev/null 2>&1
-  git -C "$repo" checkout --detach "$checkout_tag" >/dev/null 2>&1
-  make_fma_shims "$fma" "$logs"
-  printf '%s\n' "$base"
+commit_release() {
+  local label=$1 result=${2:-pass}
+  write_fake_install "$SRC" "$result"
+  mkdir -p "$SRC/templates"
+  cat >"$SRC/templates/updater-cron.tmpl.sh" <<'CRON_WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'fixture updater cron wrapper\n'
+CRON_WRAPPER
+  printf '%s\n' "$label" >"$SRC/VERSION.fixture"
+  git -C "$SRC" add -A
+  GIT_AUTHOR_DATE=2020-02-01T00:00:00Z GIT_COMMITTER_DATE=2020-02-01T00:00:00Z \
+    git -C "$SRC" commit -qm "$label"
+  RELEASE_COMMIT=$(git -C "$SRC" rev-parse HEAD)
 }
 
-repo_for() {
-  printf '%s\n' "$1/repo"
+tag_release() {
+  local kind=$1 name=$2 commit=$3
+  case "$kind" in
+    signed)
+      git -C "$SRC" config user.signingkey "$KEY"
+      GIT_COMMITTER_DATE=2020-02-01T00:00:00Z git -C "$SRC" tag -s "$name" "$commit" -m "$name"
+      ;;
+    unpinned)
+      git -C "$SRC" config user.signingkey "$OTHER_KEY"
+      GIT_COMMITTER_DATE=2020-02-01T00:00:00Z git -C "$SRC" tag -s "$name" "$commit" -m "$name"
+      git -C "$SRC" config user.signingkey "$KEY"
+      ;;
+    unsigned)
+      GIT_COMMITTER_DATE=2020-02-01T00:00:00Z git -C "$SRC" tag -a "$name" "$commit" -m "$name"
+      ;;
+    lightweight)
+      git -C "$SRC" tag "$name" "$commit"
+      ;;
+  esac
 }
 
-src_for() {
-  printf '%s\n' "$1/src"
-}
+push_tag() { git -C "$SRC" push -q "$ORIGIN" "refs/tags/$1:refs/tags/$1"; }
+force_push_tag() { git -C "$SRC" push -q --force "$ORIGIN" "refs/tags/$1:refs/tags/$1"; }
+fetch_local_tag() { git -C "$REPO" fetch -q --no-tags "$ORIGIN" "refs/tags/$1:refs/tags/$1"; }
 
-home_for() {
-  printf '%s\n' "$1/home"
-}
+pin_path() { printf '%s/.claude/state/updater-pin/%s.json\n' "$HOME_DIR" "$(basename "$REPO")"; }
+ineligible_path() { printf '%s/.claude/state/updater-ineligible/%s.log\n' "$HOME_DIR" "$(basename "$REPO")"; }
 
-fma_for() {
-  printf '%s\n' "$1/fma"
-}
-
-logs_for() {
-  printf '%s\n' "$1/fma-logs"
-}
-
-ws_for() {
-  printf '%s\n' "$1/ws"
-}
-
-ledger_for() {
-  printf '%s\n' "$1/home/.claude/state/installed-versions.log"
-}
-
-current_tag() {
-  git -C "$1" describe --tags --exact-match 2>/dev/null
+write_pin() {
+  local version=$1 commit=$2 path
+  path=$(pin_path)
+  mkdir -p "$(dirname "$path")"
+  chmod 700 "$(dirname "$path")"
+  printf '{"version":"%s","commit":"%s","updated_at":"2020-01-01T00:00:00Z"}\n' "$version" "$commit" >"$path"
+  chmod 600 "$path"
 }
 
 run_updater() {
-  base=$1
-  ring=$2
-  soak=$3
-  shift 3
-  HOME=$(home_for "$base") "$ROOT/scripts/family-updater" \
-    --repo-dir "$(repo_for "$base")" \
-    --workspace "$(ws_for "$base")" \
-    --agent claire \
-    --ring "$ring" \
-    --soak-hours "$soak" \
-    --fma-scripts-dir "$(fma_for "$base")" \
-    "$@" 2>&1
-}
-
-assert_file_contains() {
-  name=$1
-  file=$2
-  expected=$3
-
-  if [ -f "$file" ] && grep -Fq "$expected" "$file"; then
-    pass "$name"
+  if [[ "${BASELINE_FOCUSED:-0}" == 1 ]]; then
+    HOME="$HOME_DIR" UPDATER_INSTALL_SENTINEL="$SENTINEL" "$UPDATER" \
+      --repo-dir "$REPO" --workspace "$WS" --agent claire --ring canary \
+      --soak-hours 0 --fma-scripts-dir "$FMA" "$@" 2>&1
   else
-    fail_case "$name" "missing '$expected' in $file"
+    HOME="$HOME_DIR" UPDATER_INSTALL_SENTINEL="$SENTINEL" "$UPDATER" \
+      --repo-dir "$REPO" --workspace "$WS" --agent claire --ring canary \
+      --soak-hours 0 --allowed-signers "$ALLOWED" --fma-scripts-dir "$FMA" "$@" 2>&1
   fi
 }
 
-base=$(make_fixture normal pass v1.0.0)
-output=$(run_updater "$base" canary 24)
-rc=$?
-if [ "$rc" -eq 0 ] && [ "$(current_tag "$(repo_for "$base")")" = "v1.2.0" ]; then
-  pass "normal update moves to newest canary tag"
-else
-  fail_case "normal update moves to newest canary tag" "rc=$rc output=$output"
-fi
-assert_file_contains "normal update sends ok heartbeat" "$(logs_for "$base")/heartbeats.log" "job-heartbeat updater-claire ok --reason v1.2.0"
-assert_file_contains "normal update appends ok ledger" "$(ledger_for "$base")" "claire repo v1.2.0 ok"
+make_candidate() {
+  local kind=$1
+  commit_release candidate pass
+  CANDIDATE_COMMIT=$RELEASE_COMMIT
+  CANDIDATE_TAG=v1.1.0
+  if [[ "$kind" == rebound ]]; then
+    tag_release signed v1.1.0 "$CANDIDATE_COMMIT"
+    local genuine_oid
+    genuine_oid=$(git -C "$SRC" rev-parse refs/tags/v1.1.0)
+    CANDIDATE_TAG=v9.9.9
+    git -C "$SRC" update-ref "refs/tags/$CANDIDATE_TAG" "$genuine_oid"
+  else
+    if [[ "$kind" == valid || "$kind" == below ]]; then
+      tag_release signed "$CANDIDATE_TAG" "$CANDIDATE_COMMIT"
+    else
+      tag_release "$kind" "$CANDIDATE_TAG" "$CANDIDATE_COMMIT"
+    fi
+  fi
+  push_tag "$CANDIDATE_TAG"
+}
 
-base=$(make_fixture semver-filter pass v1.0.0)
-src=$(src_for "$base")
-commit_tag "$src" v1.3.0-rc1 "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" pass
-commit_tag "$src" latest "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" pass
-commit_tag "$src" 1.4.0 "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" pass
-git -C "$src" push -q --tags origin "$(git -C "$src" rev-parse --abbrev-ref HEAD)"
-output=$(run_updater "$base" canary 24)
-rc=$?
-if [ "$rc" -eq 0 ] && [ "$(current_tag "$(repo_for "$base")")" = "v1.2.0" ]; then
-  pass "canary ignores prerelease and non-semver tags"
-else
-  fail_case "canary ignores prerelease and non-semver tags" "rc=$rc output=$output"
-fi
+run_side_path_variant() {
+  local kind=$1 mode=$2 expected=$3 label=$4
+  local before after output rc floor_commit
 
-base=$(make_fixture stable-skip pass v1.0.0)
-output=$(run_updater "$base" stable 1)
-rc=$?
-if [ "$rc" -eq 0 ] && [ "$(current_tag "$(repo_for "$base")")" = "v1.1.0" ]; then
-  pass "stable ring skips too-fresh tag"
-else
-  fail_case "stable ring skips too-fresh tag" "rc=$rc output=$output"
-fi
-output=$(run_updater "$base" canary 1)
-rc=$?
-if [ "$rc" -eq 0 ] && [ "$(current_tag "$(repo_for "$base")")" = "v1.2.0" ]; then
-  pass "canary takes too-fresh tag"
-else
-  fail_case "canary takes too-fresh tag" "rc=$rc output=$output"
-fi
+  new_fixture "$label"
+  floor_commit=$BASE_COMMIT
+  if [[ "$kind" == equal-different ]]; then
+    commit_release floor-identity pass
+    floor_commit=$RELEASE_COMMIT
+    commit_release candidate pass
+    CANDIDATE_COMMIT=$RELEASE_COMMIT
+    CANDIDATE_TAG=v1.1.0
+    tag_release signed "$CANDIDATE_TAG" "$CANDIDATE_COMMIT"
+    push_tag "$CANDIDATE_TAG"
+  else
+    make_candidate "$kind"
+  fi
 
-base=$(make_fixture canary-soak-ignored pass v1.0.0)
-output=$(run_updater "$base" canary 999)
-rc=$?
-if [ "$rc" -eq 0 ] && [ "$(current_tag "$(repo_for "$base")")" = "v1.2.0" ]; then
-  pass "canary ignores soak hours"
-else
-  fail_case "canary ignores soak hours" "rc=$rc output=$output"
-fi
+  case "$kind" in
+    below) write_pin v2.0.0 "$BASE_COMMIT" ;;
+    equal-different) write_pin v1.1.0 "$floor_commit" ;;
+    valid)
+      if [[ "$mode" == current ]]; then write_pin "$CANDIDATE_TAG" "$CANDIDATE_COMMIT"; else write_pin v0.0.0 "$BASE_COMMIT"; fi
+      ;;
+    *) write_pin v0.0.0 "$BASE_COMMIT" ;;
+  esac
 
-now=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-base=$(make_fixture stable-no-old-tags pass v1.0.0 "$now" "$now" "$now")
-before_head=$(git -C "$(repo_for "$base")" rev-parse HEAD)
-output=$(run_updater "$base" stable 1)
-rc=$?
-after_head=$(git -C "$(repo_for "$base")" rev-parse HEAD)
-if [ "$rc" -eq 0 ] \
-  && [ "$before_head" = "$after_head" ] \
-  && printf '%s\n' "$output" | grep -Fq "family-updater: no stable tag old enough for 1 hour soak; already up to date"; then
-  pass "stable exits zero when no tag satisfies soak"
-else
-  fail_case "stable exits zero when no tag satisfies soak" "rc=$rc output=$output"
-fi
-if [ ! -f "$(logs_for "$base")/hot-inbox.log" ]; then
-  pass "stable soak skip does not post hot-inbox"
-else
-  fail_case "stable soak skip does not post hot-inbox" "unexpected hot-inbox log"
-fi
+  if [[ "$mode" == current ]]; then
+    fetch_local_tag "$CANDIDATE_TAG"
+    git -C "$REPO" checkout -q --detach "$CANDIDATE_COMMIT"
+  fi
+  before=$(git -C "$REPO" rev-parse HEAD)
+  if [[ "$mode" == dry ]]; then
+    output=$(run_updater --dry-run); rc=$?
+  else
+    output=$(run_updater); rc=$?
+  fi
+  after=$(git -C "$REPO" rev-parse HEAD)
 
-base=$(make_fixture rollback fail v1.1.0)
-output=$(run_updater "$base" canary 24)
-rc=$?
-if [ "$rc" -ne 0 ] && [ "$(current_tag "$(repo_for "$base")")" = "v1.1.0" ]; then
-  pass "check failure rolls back to previous tag"
-else
-  fail_case "check failure rolls back to previous tag" "rc=$rc output=$output"
-fi
-assert_file_contains "failure sends fail heartbeat" "$(logs_for "$base")/heartbeats.log" "job-heartbeat updater-claire fail --reason fixture install check failed"
-if [ -f "$(logs_for "$base")/hot-inbox.log" ] && [ "$(wc -l <"$(logs_for "$base")/hot-inbox.log")" -eq 1 ]; then
-  pass "failure posts exactly one hot-inbox caution"
-else
-  fail_case "failure posts exactly one hot-inbox caution" "hot-inbox log missing or wrong line count"
-fi
-assert_file_contains "failure appends fail ledger" "$(ledger_for "$base")" "claire repo v1.2.0 fail"
+  if [[ "$expected" == accept ]]; then
+    if [[ "$rc" -eq 0 && "$before" == "$after" && ! -e "$SENTINEL" ]]; then
+      pass "$label"
+    else
+      fail_case "$label" "rc=$rc before=$before after=$after output=$output"
+    fi
+  else
+    if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$SENTINEL" ]]; then
+      pass "$label"
+    else
+      fail_case "$label" "rc=$rc before=$before after=$after sentinel=$(test -e "$SENTINEL" && echo yes || echo no) output=$output"
+    fi
+  fi
+}
 
-now=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-base=$(make_fixture rollback-also-fails fail v1.1.0 "2020-01-01T00:00:00Z" "2020-01-02T00:00:00Z" "$now" pass fail)
-output=$(run_updater "$base" canary 24)
-rc=$?
-if [ "$rc" -ne 0 ] && [ "$(current_tag "$(repo_for "$base")")" = "v1.1.0" ]; then
-  pass "rollback also fails stays on rollback tag"
-else
-  fail_case "rollback also fails stays on rollback tag" "rc=$rc output=$output"
-fi
-assert_file_contains "rollback also fails is visible in hot-inbox" "$(logs_for "$base")/hot-inbox.log" "rollback to v1.1.0 ALSO failed its check"
-if [ -f "$(logs_for "$base")/hot-inbox.log" ] && [ "$(wc -l <"$(logs_for "$base")/hot-inbox.log")" -eq 1 ]; then
-  pass "rollback also fails posts exactly one hot-inbox caution"
-else
-  fail_case "rollback also fails posts exactly one hot-inbox caution" "hot-inbox log missing or wrong line count"
-fi
+if [[ "${BASELINE_FOCUSED:-0}" == 1 ]]; then
+  # These are the same security assertions used below. They intentionally fail
+  # against dfbc094 and provide destructive before/after evidence for #12.
+  run_side_path_variant rebound current reject "pre-fix probe: rebound-name must be rejected"
+  run_side_path_variant below current reject "pre-fix probe: below-floor tag must be rejected"
 
-base=$(make_fixture already pass v1.2.0)
-output=$(run_updater "$base" canary 24)
-rc=$?
-if [ "$rc" -eq 0 ]; then
-  pass "already up to date exits zero"
-else
-  fail_case "already up to date exits zero" "rc=$rc output=$output"
-fi
-assert_file_contains "already up to date sends ok heartbeat" "$(logs_for "$base")/heartbeats.log" "job-heartbeat updater-claire ok --reason v1.2.0"
-if [ ! -f "$(logs_for "$base")/hot-inbox.log" ]; then
-  pass "already up to date does not post hot-inbox"
-else
-  fail_case "already up to date does not post hot-inbox" "unexpected hot-inbox log"
-fi
-# No-op runs intentionally skip the ledger so repeated cron heartbeats do not
-# duplicate installed-version entries.
-if [ ! -f "$(ledger_for "$base")" ]; then
-  pass "already up to date skips ledger"
-else
-  fail_case "already up to date skips ledger" "unexpected ledger entry"
-fi
+  new_fixture pre-fix-moved
+  commit_release old-moved pass
+  old_commit=$RELEASE_COMMIT
+  tag_release signed v1.1.0 "$old_commit"
+  push_tag v1.1.0
+  fetch_local_tag v1.1.0
+  git -C "$SRC" tag -d v1.1.0 >/dev/null
+  commit_release moved pass
+  tag_release signed v1.1.0 "$RELEASE_COMMIT"
+  force_push_tag v1.1.0
+  commit_release legitimate pass
+  legitimate_commit=$RELEASE_COMMIT
+  tag_release signed v1.2.0 "$legitimate_commit"
+  push_tag v1.2.0
+  write_pin v1.0.0 "$BASE_COMMIT"
+  output=$(run_updater); rc=$?
+  if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$legitimate_commit" ]]; then
+    pass "pre-fix probe: moved tag must not wedge legitimate newer update"
+  else
+    fail_case "pre-fix probe: moved tag must not wedge legitimate newer update" "rc=$rc head=$(git -C "$REPO" rev-parse HEAD) output=$output"
+  fi
 
-base=$(make_fixture already-dry-run pass v1.2.0)
-output=$(run_updater "$base" canary 24 --dry-run)
-rc=$?
-if [ "$rc" -eq 0 ] \
-  && printf '%s\n' "$output" | grep -Fq "dry-run: already at v1.2.0, nothing to do" \
-  && [ ! -f "$(ledger_for "$base")" ] \
-  && [ ! -f "$(logs_for "$base")/heartbeats.log" ] \
-  && [ ! -f "$(logs_for "$base")/hot-inbox.log" ]; then
-  pass "dry-run already current leaves reporters and ledger untouched"
-else
-  fail_case "dry-run already current leaves reporters and ledger untouched" "rc=$rc output=$output"
-fi
-
-base=$(make_fixture fetch-failure pass v1.0.0)
-repo=$(repo_for "$base")
-before_head=$(git -C "$repo" rev-parse HEAD)
-git -C "$repo" remote set-url origin "$base/missing-origin.git"
-output=$(run_updater "$base" canary 24)
-rc=$?
-after_head=$(git -C "$repo" rev-parse HEAD)
-if [ "$rc" -ne 0 ] && [ "$before_head" = "$after_head" ]; then
-  pass "fetch failure exits nonzero without moving HEAD"
-else
-  fail_case "fetch failure exits nonzero without moving HEAD" "rc=$rc output=$output"
-fi
-assert_file_contains "fetch failure sends fail heartbeat" "$(logs_for "$base")/heartbeats.log" "job-heartbeat updater-claire fail --reason git fetch failed"
-if [ -f "$(logs_for "$base")/hot-inbox.log" ] && [ "$(wc -l <"$(logs_for "$base")/hot-inbox.log")" -eq 1 ]; then
-  pass "fetch failure posts exactly one hot-inbox caution"
-else
-  fail_case "fetch failure posts exactly one hot-inbox caution" "hot-inbox log missing or wrong line count"
-fi
-assert_file_contains "fetch failure appends fail ledger" "$(ledger_for "$base")" "claire repo fetch-failed fail"
-
-base=$(make_fixture dirty-worktree pass v1.0.0)
-repo=$(repo_for "$base")
-before_head=$(git -C "$repo" rev-parse HEAD)
-printf 'local change\n' >>"$repo/VERSION.fixture"
-output=$(run_updater "$base" canary 24)
-rc=$?
-after_head=$(git -C "$repo" rev-parse HEAD)
-if [ "$rc" -ne 0 ] && [ "$before_head" = "$after_head" ]; then
-  pass "dirty worktree exits nonzero without moving HEAD"
-else
-  fail_case "dirty worktree exits nonzero without moving HEAD" "rc=$rc output=$output"
-fi
-assert_file_contains "dirty worktree posts refusal message" "$(logs_for "$base")/hot-inbox.log" "repo has local modifications, refusing to update"
-assert_file_contains "dirty worktree appends fail ledger" "$(ledger_for "$base")" "claire repo v1.2.0 fail"
-
-base=$(make_fixture lock-held pass v1.0.0)
-repo=$(repo_for "$base")
-before_head=$(git -C "$repo" rev-parse HEAD)
-mkdir "$repo/.family-updater.lock"
-printf '%s\n' "$$" >"$repo/.family-updater.lock/pid"
-output=$(run_updater "$base" canary 24)
-rc=$?
-after_head=$(git -C "$repo" rev-parse HEAD)
-rm -rf "$repo/.family-updater.lock"
-if [ "$rc" -ne 0 ] && [ "$before_head" = "$after_head" ]; then
-  pass "live lock exits nonzero without moving HEAD"
-else
-  fail_case "live lock exits nonzero without moving HEAD" "rc=$rc output=$output"
-fi
-assert_file_contains "live lock sends fail heartbeat" "$(logs_for "$base")/heartbeats.log" "job-heartbeat updater-claire fail --reason lock held by live pid"
-
-base=$(make_fixture stale-lock pass v1.0.0)
-repo=$(repo_for "$base")
-mkdir "$repo/.family-updater.lock"
-printf '%s\n' 999999 >"$repo/.family-updater.lock/pid"
-output=$(run_updater "$base" canary 24)
-rc=$?
-if [ "$rc" -eq 0 ] \
-  && [ "$(current_tag "$repo")" = "v1.2.0" ] \
-  && [ ! -d "$repo/.family-updater.lock" ]; then
-  pass "stale lock is reclaimed and released"
-else
-  fail_case "stale lock is reclaimed and released" "rc=$rc output=$output"
-fi
-
-base=$(make_fixture missing-fma pass v1.0.0)
-missing_dir=$base/missing-fma
-output=$(HOME=$(home_for "$base") "$ROOT/scripts/family-updater" \
-  --repo-dir "$(repo_for "$base")" \
-  --workspace "$(ws_for "$base")" \
-  --agent claire \
-  --ring canary \
-  --fma-scripts-dir "$missing_dir" 2>&1)
-rc=$?
-if [ "$rc" -eq 0 ] \
-  && [ "$(current_tag "$(repo_for "$base")")" = "v1.2.0" ] \
-  && [ -f "$(ledger_for "$base")" ] \
-  && printf '%s\n' "$output" | grep -Fq "warning: reporter script missing"; then
-  pass "missing fma dir warns but update succeeds"
-else
-  fail_case "missing fma dir warns but update succeeds" "rc=$rc output=$output"
-fi
-
-base=$(make_fixture failing-heartbeat pass v1.0.0)
-cat >"$(fma_for "$base")/job-heartbeat" <<'EOF'
+  new_fixture pre-fix-rollback
+  commit_release rollback-base pass
+  rollback_commit=$RELEASE_COMMIT
+  tag_release signed v1.0.0 "$rollback_commit"
+  push_tag v1.0.0
+  fetch_local_tag v1.0.0
+  git -C "$REPO" checkout -q --detach "$rollback_commit"
+  commit_release broken-target fail
+  tag_release signed v1.1.0 "$RELEASE_COMMIT"
+  push_tag v1.1.0
+  write_pin v1.0.0 "$rollback_commit"
+  baseline_fakebin=$BASE/fakebin
+  mismatch_state=$BASE/mismatch-count
+  mkdir -p "$baseline_fakebin"
+  cat >"$baseline_fakebin/git" <<'BASELINE_GIT_SHIM'
 #!/usr/bin/env bash
-exit 1
-EOF
-chmod +x "$(fma_for "$base")/job-heartbeat"
-output=$(run_updater "$base" canary 24)
-rc=$?
-if [ "$rc" -eq 0 ] \
-  && [ "$(current_tag "$(repo_for "$base")")" = "v1.2.0" ] \
-  && printf '%s\n' "$output" | grep -Fq "warning: heartbeat reporter failed"; then
-  pass "failing heartbeat reporter warns but update succeeds"
-else
-  fail_case "failing heartbeat reporter warns but update succeeds" "rc=$rc output=$output"
+set -u
+if [[ "$*" == "-C $MISMATCH_REPO rev-parse HEAD" ]]; then
+  count=0
+  [[ -f "$MISMATCH_STATE" ]] && count=$(sed -n '1p' "$MISMATCH_STATE")
+  count=$((count + 1))
+  printf '%s\n' "$count" >"$MISMATCH_STATE"
+  if [[ "$count" -eq 3 ]]; then
+    printf '%040d\n' 0
+    exit 0
+  fi
+fi
+exec "$REAL_GIT" "$@"
+BASELINE_GIT_SHIM
+  chmod +x "$baseline_fakebin/git"
+  output=$(PATH="$baseline_fakebin:$PATH" REAL_GIT="$REAL_GIT" MISMATCH_REPO="$REPO" MISMATCH_STATE="$mismatch_state" run_updater); rc=$?
+  sentinel_lines=$(wc -l <"$SENTINEL" 2>/dev/null || printf '0')
+  if [[ "$rc" -ne 0 && "$sentinel_lines" -eq 1 ]]; then
+    pass "pre-fix probe: rollback install requires an identity assertion"
+  else
+    fail_case "pre-fix probe: rollback install requires an identity assertion" "rc=$rc install-lines=$sentinel_lines output=$output"
+  fi
+
+  printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+  [[ "$FAIL_COUNT" -eq 0 ]]
+  exit $?
 fi
 
-base=$(make_fixture dry-run pass v1.0.0)
-before_head=$(git -C "$(repo_for "$base")" rev-parse HEAD)
-output=$(run_updater "$base" canary 24 --dry-run)
-rc=$?
-after_head=$(git -C "$(repo_for "$base")" rev-parse HEAD)
-if [ "$rc" -eq 0 ] \
-  && [ "$before_head" = "$after_head" ] \
-  && [ ! -f "$(ledger_for "$base")" ] \
-  && [ ! -f "$(logs_for "$base")/heartbeats.log" ] \
-  && [ ! -f "$(logs_for "$base")/hot-inbox.log" ]; then
-  pass "dry-run leaves head ledger and reporters untouched"
+# B1 side paths: every current/dry-run result is preceded by the full gate.
+run_side_path_variant valid current accept "already-current valid signed tag accepted"
+run_side_path_variant unsigned current reject "already-current unsigned tag rejected before success"
+run_side_path_variant unpinned current reject "already-current unpinned-key tag rejected before success"
+run_side_path_variant rebound current reject "already-current rebound-name attack M2 rejected"
+run_side_path_variant below current reject "already-current below-floor tag rejected"
+run_side_path_variant equal-different current reject "already-current equal-version different-OID rejected"
+
+run_side_path_variant valid dry accept "dry-run valid signed tag verifies without checkout"
+run_side_path_variant unsigned dry reject "dry-run unsigned tag rejected"
+run_side_path_variant unpinned dry reject "dry-run unpinned-key tag rejected"
+run_side_path_variant rebound dry reject "dry-run rebound-name attack rejected"
+run_side_path_variant below dry reject "dry-run below-floor tag rejected"
+run_side_path_variant equal-different dry reject "dry-run equal-version different-OID rejected"
+
+# Explicit lightweight/legacy rejection (legacy pins are rollback-only).
+new_fixture legacy-lightweight
+commit_release legacy pass
+CANDIDATE_COMMIT=$RELEASE_COMMIT
+tag_release lightweight v0.2.2 "$CANDIDATE_COMMIT"
+push_tag v0.2.2
+write_pin v0.1.0 "$BASE_COMMIT"
+before=$(git -C "$REPO" rev-parse HEAD)
+output=$(run_updater); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$SENTINEL" ]]; then
+  pass "legacy lightweight tag refused as update target with no install"
 else
-  fail_case "dry-run leaves head ledger and reporters untouched" "rc=$rc output=$output"
+  fail_case "legacy lightweight tag refused as update target with no install" "rc=$rc output=$output"
+fi
+
+# Numeric comparison must not become lexicographic: v0.10.0 is above v0.9.0.
+new_fixture numeric-floor
+commit_release numeric pass
+numeric_commit=$RELEASE_COMMIT
+tag_release signed v0.10.0 "$numeric_commit"
+push_tag v0.10.0
+write_pin v0.9.0 "$BASE_COMMIT"
+output=$(run_updater); rc=$?
+if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$numeric_commit" ]]; then
+  pass "floor comparison is numeric per semver component"
+else
+  fail_case "floor comparison is numeric per semver component" "rc=$rc output=$output"
+fi
+
+# One moved tag is excluded, reported once, and does not wedge a valid update.
+new_fixture moved-continues
+commit_release old-moved pass
+old_moved_commit=$RELEASE_COMMIT
+tag_release signed v1.1.0 "$old_moved_commit"
+old_moved_oid=$(git -C "$SRC" rev-parse refs/tags/v1.1.0)
+push_tag v1.1.0
+fetch_local_tag v1.1.0
+git -C "$SRC" tag -d v1.1.0 >/dev/null
+commit_release moved-content pass
+new_moved_commit=$RELEASE_COMMIT
+tag_release signed v1.1.0 "$new_moved_commit"
+force_push_tag v1.1.0
+commit_release legitimate pass
+legit_commit=$RELEASE_COMMIT
+tag_release signed v1.2.0 "$legit_commit"
+push_tag v1.2.0
+write_pin v1.0.0 "$BASE_COMMIT"
+output=$(run_updater); rc=$?
+first_reports=$(grep -Fc "updater failed: claire repo v1.1.0" "$LOGS/hot-inbox.log" 2>/dev/null || true)
+output2=$(run_updater); rc2=$?
+second_reports=$(grep -Fc "updater failed: claire repo v1.1.0" "$LOGS/hot-inbox.log" 2>/dev/null || true)
+local_moved_oid=$(git -C "$REPO" rev-parse refs/tags/v1.1.0)
+if [[ "$rc" -eq 0 && "$rc2" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$legit_commit" \
+  && "$local_moved_oid" == "$old_moved_oid" \
+  && "$first_reports" -eq 1 && "$second_reports" -eq 1 ]]; then
+  pass "moved tag stays local and ineligible, reports once, legitimate newer tag installs"
+else
+  fail_case "moved tag stays local and ineligible, reports once, legitimate newer tag installs" "rc=$rc rc2=$rc2 reports=$first_reports/$second_reports output=$output"
+fi
+
+# Two moved names produce two alerts total, not two alerts per tick.
+new_fixture two-moved
+for moved_name in v1.1.0 v1.2.0; do
+  commit_release "old-$moved_name" pass
+  tag_release signed "$moved_name" "$RELEASE_COMMIT"
+  push_tag "$moved_name"
+  fetch_local_tag "$moved_name"
+done
+for moved_name in v1.1.0 v1.2.0; do
+  git -C "$SRC" tag -d "$moved_name" >/dev/null
+  commit_release "new-$moved_name" pass
+  tag_release signed "$moved_name" "$RELEASE_COMMIT"
+  force_push_tag "$moved_name"
+done
+commit_release valid-newer pass
+valid_newer_commit=$RELEASE_COMMIT
+tag_release signed v1.3.0 "$valid_newer_commit"
+push_tag v1.3.0
+write_pin v1.0.0 "$BASE_COMMIT"
+run_updater >/dev/null; rc=$?
+run_updater >/dev/null; rc2=$?
+reports_11=$(grep -Fc "updater failed: claire repo v1.1.0" "$LOGS/hot-inbox.log" || true)
+reports_12=$(grep -Fc "updater failed: claire repo v1.2.0" "$LOGS/hot-inbox.log" || true)
+if [[ "$rc" -eq 0 && "$rc2" -eq 0 && "$reports_11" -eq 1 && "$reports_12" -eq 1 ]]; then
+  pass "two offending names report once each and never repeat on next tick"
+else
+  fail_case "two offending names report once each and never repeat on next tick" "rc=$rc/$rc2 reports=$reports_11/$reports_12"
+fi
+
+# A verification failure deduplicates its report but must be retried after an
+# out-of-band allowed_signers rotation. Passing the gate clears the dedupe state
+# so a later failure for the same name reports again.
+new_fixture signer-rotation-recovery
+commit_release installed-key-a pass
+floor_commit=$RELEASE_COMMIT
+tag_release signed v0.2.3 "$floor_commit"
+push_tag v0.2.3
+fetch_local_tag v0.2.3
+git -C "$REPO" checkout -q --detach "$floor_commit"
+write_pin v0.2.3 "$floor_commit"
+commit_release rotated-key-b pass
+rotated_commit=$RELEASE_COMMIT
+tag_release unpinned v0.3.0 "$rotated_commit"
+push_tag v0.3.0
+
+output=$(run_updater); rc=$?
+first_reports=$(grep -Fc "updater failed: claire repo v0.3.0" "$LOGS/hot-inbox.log" 2>/dev/null || true)
+first_head=$(git -C "$REPO" rev-parse HEAD)
+run_updater >/dev/null; dedupe_rc=$?
+dedupe_reports=$(grep -Fc "updater failed: claire repo v0.3.0" "$LOGS/hot-inbox.log" 2>/dev/null || true)
+printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$OTHER_KEY.pub")" >>"$ALLOWED"
+output2=$(run_updater); rc2=$?
+second_reports=$(grep -Fc "updater failed: claire repo v0.3.0" "$LOGS/hot-inbox.log" 2>/dev/null || true)
+second_head=$(git -C "$REPO" rev-parse HEAD)
+clear_records=$(grep -F 'v0.3.0 ' "$(ineligible_path)" 2>/dev/null | grep -Fc ' verification-failure-cleared' || true)
+
+# Remove key B again: because the successful tick cleared the dedupe state,
+# this later failure must emit a fresh report.
+printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$KEY.pub")" >"$ALLOWED"
+run_updater >/dev/null; rc3=$?
+third_reports=$(grep -Fc "updater failed: claire repo v0.3.0" "$LOGS/hot-inbox.log" 2>/dev/null || true)
+sentinel_lines=0
+[[ ! -f "$SENTINEL" ]] || sentinel_lines=$(wc -l <"$SENTINEL")
+if [[ "$rc" -eq 0 && "$first_head" == "$floor_commit" && "$first_reports" -eq 1 \
+  && "$dedupe_rc" -eq 0 && "$dedupe_reports" -eq 1 \
+  && "$rc2" -eq 0 && "$second_head" == "$rotated_commit" && "$second_reports" -eq 1 \
+  && "$clear_records" -eq 1 && "$sentinel_lines" -eq 1 \
+  && "$rc3" -ne 0 && "$third_reports" -eq 2 ]]; then
+  pass "signer rotation retries a verification failure, installs, clears dedupe, and can report again"
+else
+  fail_case "signer rotation retries a verification failure, installs, clears dedupe, and can report again" \
+    "rc=$rc/$dedupe_rc/$rc2/$rc3 heads=$first_head/$second_head reports=$first_reports/$dedupe_reports/$second_reports/$third_reports clears=$clear_records installs=$sentinel_lines output2=$output2"
+fi
+
+# Git shim supports deterministic transport/capability/identity failures.
+FAKEBIN=$TMP_ROOT/fakebin
+mkdir -p "$FAKEBIN"
+cat >"$FAKEBIN/git" <<'GIT_SHIM'
+#!/usr/bin/env bash
+set -u
+if [[ "${FAKE_OLD_GIT:-0}" == 1 && "${1:-}" == --version ]]; then
+  printf 'git version 2.33.9\n'
+  exit 0
+fi
+if [[ "${FAKE_LS_REMOTE:-0}" == 1 && "$*" == *" ls-remote "* ]]; then
+  exit 71
+fi
+if [[ "${EXTRA_BAD_REFSPEC:-0}" == 1 && "$*" == *" fetch --atomic "* ]]; then
+  exec "$REAL_GIT" "$@" 'refs/tags/v404.0.0:refs/tags/v404.0.0'
+fi
+if [[ -n "${MISMATCH_REPO:-}" && "$*" == "-C $MISMATCH_REPO rev-parse HEAD" ]]; then
+  count=0
+  [[ -f "$MISMATCH_STATE" ]] && count=$(sed -n '1p' "$MISMATCH_STATE")
+  count=$((count + 1))
+  printf '%s\n' "$count" >"$MISMATCH_STATE"
+  if [[ "$count" -eq 3 ]]; then
+    printf '%040d\n' 0
+    exit 0
+  fi
+fi
+exec "$REAL_GIT" "$@"
+GIT_SHIM
+chmod +x "$FAKEBIN/git"
+
+new_fixture ls-remote-failure
+commit_release candidate pass
+tag_release signed v1.1.0 "$RELEASE_COMMIT"
+push_tag v1.1.0
+write_pin v1.0.0 "$BASE_COMMIT"
+before=$(git -C "$REPO" rev-parse HEAD)
+output=$(PATH="$FAKEBIN:$PATH" REAL_GIT="$REAL_GIT" FAKE_LS_REMOTE=1 run_updater); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$SENTINEL" ]] && printf '%s\n' "$output" | grep -Fq 'ls-remote'; then
+  pass "ls-remote failure stops without checkout or install"
+else
+  fail_case "ls-remote failure stops without checkout or install" "rc=$rc output=$output"
+fi
+
+new_fixture atomic-partial-failure
+commit_release one pass
+tag_release signed v1.1.0 "$RELEASE_COMMIT"
+push_tag v1.1.0
+commit_release two pass
+tag_release signed v1.2.0 "$RELEASE_COMMIT"
+push_tag v1.2.0
+write_pin v1.0.0 "$BASE_COMMIT"
+before_tags=$(git -C "$REPO" tag | sort)
+output=$(PATH="$FAKEBIN:$PATH" REAL_GIT="$REAL_GIT" EXTRA_BAD_REFSPEC=1 run_updater); rc=$?
+after_tags=$(git -C "$REPO" tag | sort)
+if [[ "$rc" -ne 0 && "$before_tags" == "$after_tags" && ! -e "$SENTINEL" ]]; then
+  pass "failed multi-candidate atomic fetch installs no new local tag refs"
+else
+  fail_case "failed multi-candidate atomic fetch installs no new local tag refs" "rc=$rc before=[$before_tags] after=[$after_tags] output=$output"
+fi
+
+# Rollback uses the full pre-update OID and runs install only after asserting it.
+new_fixture rollback-success
+commit_release rollback-base pass
+rollback_commit=$RELEASE_COMMIT
+tag_release signed v1.0.0 "$rollback_commit"
+push_tag v1.0.0
+fetch_local_tag v1.0.0
+git -C "$REPO" checkout -q --detach "$rollback_commit"
+commit_release broken-target fail
+broken_commit=$RELEASE_COMMIT
+tag_release signed v1.1.0 "$broken_commit"
+push_tag v1.1.0
+write_pin v1.0.0 "$rollback_commit"
+output=$(run_updater); rc=$?
+sentinel_lines=$(wc -l <"$SENTINEL" 2>/dev/null || printf '0')
+if [[ "$rc" -ne 0 && $(git -C "$REPO" rev-parse HEAD) == "$rollback_commit" && "$sentinel_lines" -eq 2 ]] \
+  && grep -Fxq broken-target "$SENTINEL" && grep -Fxq rollback-base "$SENTINEL"; then
+  pass "rollback to exact pre-update OID succeeds and only then runs rollback install"
+else
+  fail_case "rollback to exact pre-update OID succeeds and only then runs rollback install" "rc=$rc lines=$sentinel_lines output=$output"
+fi
+
+new_fixture rollback-identity-mismatch
+commit_release rollback-base pass
+rollback_commit=$RELEASE_COMMIT
+tag_release signed v1.0.0 "$rollback_commit"
+push_tag v1.0.0
+fetch_local_tag v1.0.0
+git -C "$REPO" checkout -q --detach "$rollback_commit"
+commit_release broken-target fail
+tag_release signed v1.1.0 "$RELEASE_COMMIT"
+push_tag v1.1.0
+write_pin v1.0.0 "$rollback_commit"
+MISMATCH_STATE=$BASE/mismatch-count
+output=$(PATH="$FAKEBIN:$PATH" REAL_GIT="$REAL_GIT" MISMATCH_REPO="$REPO" MISMATCH_STATE="$MISMATCH_STATE" run_updater); rc=$?
+sentinel_lines=$(wc -l <"$SENTINEL" 2>/dev/null || printf '0')
+if [[ "$rc" -ne 0 && "$sentinel_lines" -eq 1 ]] && printf '%s\n' "$output" | grep -Fq 'rollback identity mismatch'; then
+  pass "rollback identity mismatch executes no rollback install.sh"
+else
+  fail_case "rollback identity mismatch executes no rollback install.sh" "rc=$rc lines=$sentinel_lines output=$output"
+fi
+
+# Bootstrap: exact owner tag only, substituted/rebound content rejected.
+new_fixture bootstrap-exact
+commit_release owner-initial pass
+owner_commit=$RELEASE_COMMIT
+tag_release signed v1.0.0 "$owner_commit"
+push_tag v1.0.0
+commit_release newer-not-selected pass
+newer_commit=$RELEASE_COMMIT
+tag_release signed v2.0.0 "$newer_commit"
+push_tag v2.0.0
+fetch_local_tag v1.0.0
+fetch_local_tag v2.0.0
+cron_dest=$BASE/cron/family-updater
+output=$(HOME="$HOME_DIR" "$BOOTSTRAP" --repo-dir "$REPO" --allowed-signers "$ALLOWED" --initial-tag v1.0.0 --cron-wrapper-dest "$cron_dest" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$owner_commit" ]] \
+  && grep -Fq '"version":"v1.0.0"' "$(pin_path)" \
+  && [[ -x "$cron_dest" ]] \
+  && cmp -s "$REPO/templates/updater-cron.tmpl.sh" "$cron_dest"; then
+  pass "fresh clone bootstrap installs exactly owner-named tag then enables cron"
+else
+  fail_case "fresh clone bootstrap installs exactly owner-named tag then enables cron" "rc=$rc output=$output"
+fi
+
+new_fixture bootstrap-cron-retry
+commit_release retry-owner pass
+retry_commit=$RELEASE_COMMIT
+tag_release signed v1.0.0 "$retry_commit"
+push_tag v1.0.0
+fetch_local_tag v1.0.0
+blocked_parent=$BASE/cron-parent
+printf 'not a directory\n' >"$blocked_parent"
+retry_cron_dest=$blocked_parent/family-updater
+output=$(HOME="$HOME_DIR" "$BOOTSTRAP" --repo-dir "$REPO" --allowed-signers "$ALLOWED" --initial-tag v1.0.0 --cron-wrapper-dest "$retry_cron_dest" 2>&1); rc=$?
+pin_after_failure=$(pin_path)
+rm -f "$blocked_parent"
+mkdir -p "$blocked_parent"
+output2=$(HOME="$HOME_DIR" "$BOOTSTRAP" --repo-dir "$REPO" --allowed-signers "$ALLOWED" --initial-tag v1.0.0 --cron-wrapper-dest "$retry_cron_dest" 2>&1); rc2=$?
+if [[ "$rc" -ne 0 && -f "$pin_after_failure" ]] \
+  && grep -Fq '"version":"v1.0.0"' "$pin_after_failure" \
+  && grep -Fq "\"commit\":\"$retry_commit\"" "$pin_after_failure" \
+  && [[ "$rc2" -eq 0 && -x "$retry_cron_dest" ]] \
+  && cmp -s "$REPO/templates/updater-cron.tmpl.sh" "$retry_cron_dest"; then
+  pass "bootstrap retries cron install when the existing pin has the same identity"
+else
+  fail_case "bootstrap retries cron install when the existing pin has the same identity" "rc=$rc/$rc2 output=$output output2=$output2"
+fi
+
+new_fixture bootstrap-different-pin
+commit_release different-pin-owner pass
+different_pin_commit=$RELEASE_COMMIT
+tag_release signed v1.0.0 "$different_pin_commit"
+push_tag v1.0.0
+fetch_local_tag v1.0.0
+write_pin v1.0.0 "$BASE_COMMIT"
+before=$(git -C "$REPO" rev-parse HEAD)
+different_pin_cron_dest=$BASE/cron/family-updater
+output=$(HOME="$HOME_DIR" "$BOOTSTRAP" --repo-dir "$REPO" --allowed-signers "$ALLOWED" --initial-tag v1.0.0 --cron-wrapper-dest "$different_pin_cron_dest" 2>&1); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$different_pin_cron_dest" ]] \
+  && printf '%s\n' "$output" | grep -Fq 'updater pin already exists; bootstrap will not replace it'; then
+  pass "bootstrap still refuses an existing pin with a different identity"
+else
+  fail_case "bootstrap still refuses an existing pin with a different identity" "rc=$rc before=$before after=$after output=$output"
+fi
+
+new_fixture bootstrap-substituted
+commit_release attacker-content pass
+attacker_commit=$RELEASE_COMMIT
+tag_release unsigned v1.0.0 "$attacker_commit"
+push_tag v1.0.0
+fetch_local_tag v1.0.0
+before=$(git -C "$REPO" rev-parse HEAD)
+output=$(HOME="$HOME_DIR" "$BOOTSTRAP" --repo-dir "$REPO" --allowed-signers "$ALLOWED" --initial-tag v1.0.0 2>&1); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$(pin_path)" ]]; then
+  pass "fresh clone attacker-substituted unsigned content is refused"
+else
+  fail_case "fresh clone attacker-substituted unsigned content is refused" "rc=$rc output=$output"
+fi
+
+new_fixture bootstrap-rebound
+commit_release genuine-old pass
+genuine_commit=$RELEASE_COMMIT
+tag_release signed v1.0.0 "$genuine_commit"
+genuine_oid=$(git -C "$SRC" rev-parse refs/tags/v1.0.0)
+git -C "$SRC" update-ref refs/tags/v9.9.9 "$genuine_oid"
+push_tag v9.9.9
+fetch_local_tag v9.9.9
+before=$(git -C "$REPO" rev-parse HEAD)
+rebound_cron_dest=$BASE/cron/family-updater
+output=$(HOME="$HOME_DIR" "$BOOTSTRAP" --repo-dir "$REPO" --allowed-signers "$ALLOWED" --initial-tag v9.9.9 --cron-wrapper-dest "$rebound_cron_dest" 2>&1); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$(pin_path)" && ! -e "$rebound_cron_dest" ]] \
+  && printf '%s\n' "$output" | grep -Fq 'does not exactly match'; then
+  pass "bootstrap rejects a rebound initial tag"
+else
+  fail_case "bootstrap rejects a rebound initial tag" "rc=$rc output=$output"
+fi
+
+# Capability and signer-pin failures are explicit and fail closed.
+new_fixture capability-old-git
+write_pin v0.0.0 "$BASE_COMMIT"
+before=$(git -C "$REPO" rev-parse HEAD)
+output=$(PATH="$FAKEBIN:$PATH" REAL_GIT="$REAL_GIT" FAKE_OLD_GIT=1 run_updater); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -ne 0 && "$before" == "$after" ]] && printf '%s\n' "$output" | grep -Fq 'git 2.34 or newer is required'; then
+  pass "simulated old git fails closed with capability message"
+else
+  fail_case "simulated old git fails closed with capability message" "rc=$rc output=$output"
+fi
+
+new_fixture missing-signers
+write_pin v0.0.0 "$BASE_COMMIT"
+missing=$BASE/does-not-exist
+output=$(HOME="$HOME_DIR" "$UPDATER" --repo-dir "$REPO" --workspace "$WS" --agent claire --ring canary --allowed-signers "$missing" --fma-scripts-dir "$FMA" 2>&1); rc=$?
+if [[ "$rc" -ne 0 ]] && printf '%s\n' "$output" | grep -Fq "allowed_signers file is absent, unreadable, or empty: $missing"; then
+  pass "missing allowed_signers fails closed and names the file"
+else
+  fail_case "missing allowed_signers fails closed and names the file" "rc=$rc output=$output"
+fi
+
+new_fixture repo-local-signers
+write_pin v0.0.0 "$BASE_COMMIT"
+cp "$ALLOWED" "$REPO/allowed_signers"
+output=$(HOME="$HOME_DIR" "$UPDATER" --repo-dir "$REPO" --workspace "$WS" --agent claire --ring canary --allowed-signers "$REPO/allowed_signers" --fma-scripts-dir "$FMA" 2>&1); rc=$?
+if [[ "$rc" -ne 0 ]] && printf '%s\n' "$output" | grep -Fq 'must live outside the repository'; then
+  pass "repository-local allowed_signers is refused"
+else
+  fail_case "repository-local allowed_signers is refused" "rc=$rc output=$output"
+fi
+
+new_fixture bootstrap-required
+output=$(run_updater); rc=$?
+if [[ "$rc" -ne 0 ]] && printf '%s\n' "$output" | grep -Fq 'scripts/updater-bootstrap'; then
+  pass "absent floor at non-semver HEAD fails closed and names bootstrap"
+else
+  fail_case "absent floor at non-semver HEAD fails closed and names bootstrap" "rc=$rc output=$output"
+fi
+
+new_fixture malformed-pin
+malformed_pin=$(pin_path)
+mkdir -p "$(dirname "$malformed_pin")"
+printf '{"version":"v1.0.0","commit":"not-an-oid","updated_at":"not-a-time"}\n' >"$malformed_pin"
+before=$(git -C "$REPO" rev-parse HEAD)
+output=$(run_updater); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$SENTINEL" ]] \
+  && printf '%s\n' "$output" | grep -Fq "updater pin file is unparsable or malformed: $malformed_pin"; then
+  pass "malformed pin fails closed, names the file, and executes no install"
+else
+  fail_case "malformed pin fails closed, names the file, and executes no install" "rc=$rc output=$output"
 fi
 
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
-[ "$FAIL_COUNT" -eq 0 ]
+[[ "$FAIL_COUNT" -eq 0 ]]

--- a/tests/family-updater.test.sh
+++ b/tests/family-updater.test.sh
@@ -16,21 +16,6 @@ mkdir -p "$TMP_ROOT"
 pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf 'PASS %s\n' "$1"; }
 fail_case() { FAIL_COUNT=$((FAIL_COUNT + 1)); printf 'FAIL %s: %s\n' "$1" "$2"; }
 
-assert_true() {
-  local name=$1
-  shift
-  if "$@"; then pass "$name"; else fail_case "$name" "assertion failed: $*"; fi
-}
-
-assert_contains() {
-  local name=$1 file=$2 text=$3
-  if [[ -f "$file" ]] && grep -Fq "$text" "$file"; then
-    pass "$name"
-  else
-    fail_case "$name" "missing '$text' in $file"
-  fi
-}
-
 write_fake_install() {
   local src=$1 result=$2
   cat >"$src/install.sh" <<'INSTALL'
@@ -121,19 +106,19 @@ CRON_WRAPPER
 }
 
 tag_release() {
-  local kind=$1 name=$2 commit=$3
+  local kind=$1 name=$2 commit=$3 tag_date=${4:-2020-02-01T00:00:00Z}
   case "$kind" in
     signed)
       git -C "$SRC" config user.signingkey "$KEY"
-      GIT_COMMITTER_DATE=2020-02-01T00:00:00Z git -C "$SRC" tag -s "$name" "$commit" -m "$name"
+      GIT_COMMITTER_DATE="$tag_date" git -C "$SRC" tag -s "$name" "$commit" -m "$name"
       ;;
     unpinned)
       git -C "$SRC" config user.signingkey "$OTHER_KEY"
-      GIT_COMMITTER_DATE=2020-02-01T00:00:00Z git -C "$SRC" tag -s "$name" "$commit" -m "$name"
+      GIT_COMMITTER_DATE="$tag_date" git -C "$SRC" tag -s "$name" "$commit" -m "$name"
       git -C "$SRC" config user.signingkey "$KEY"
       ;;
     unsigned)
-      GIT_COMMITTER_DATE=2020-02-01T00:00:00Z git -C "$SRC" tag -a "$name" "$commit" -m "$name"
+      GIT_COMMITTER_DATE="$tag_date" git -C "$SRC" tag -a "$name" "$commit" -m "$name"
       ;;
     lightweight)
       git -C "$SRC" tag "$name" "$commit"
@@ -145,8 +130,20 @@ push_tag() { git -C "$SRC" push -q "$ORIGIN" "refs/tags/$1:refs/tags/$1"; }
 force_push_tag() { git -C "$SRC" push -q --force "$ORIGIN" "refs/tags/$1:refs/tags/$1"; }
 fetch_local_tag() { git -C "$REPO" fetch -q --no-tags "$ORIGIN" "refs/tags/$1:refs/tags/$1"; }
 
-pin_path() { printf '%s/.claude/state/updater-pin/%s.json\n' "$HOME_DIR" "$(basename "$REPO")"; }
-ineligible_path() { printf '%s/.claude/state/updater-ineligible/%s.log\n' "$HOME_DIR" "$(basename "$REPO")"; }
+repo_state_key() {
+  local repo_real repo_hash
+  repo_real=$(cd "$REPO" && pwd -P)
+  repo_hash=$(printf '%s' "$repo_real" | git hash-object --stdin)
+  printf '%s-%s\n' "$(basename "$repo_real")" "${repo_hash:0:12}"
+}
+pin_path() { printf '%s/.claude/state/updater-pin/%s.json\n' "$HOME_DIR" "$(repo_state_key)"; }
+ineligible_path() { printf '%s/.claude/state/updater-ineligible/%s.log\n' "$HOME_DIR" "$(repo_state_key)"; }
+ledger_path() { printf '%s/.claude/state/installed-versions.log\n' "$HOME_DIR"; }
+
+append_ok_ledger() {
+  local tag=$1
+  printf '2020-01-01T00:00:00Z claire %s %s ok\n' "$(basename "$REPO")" "$tag" >>"$(ledger_path)"
+}
 
 write_pin() {
   local version=$1 commit=$2 path
@@ -189,6 +186,272 @@ make_candidate() {
   fi
   push_tag "$CANDIDATE_TAG"
 }
+
+if [[ "${SKIP_DELTA2_CASES:-0}" == 0 ]]; then
+  # E1: a remote-supplied high name at the installed commit is not trusted as
+  # floor evidence. The machine-authored ledger supplies the installed name.
+  for poison_kind in unsigned lightweight; do
+    new_fixture "delta2-floor-poison-$poison_kind"
+    commit_release installed pass
+    installed_commit=$RELEASE_COMMIT
+    tag_release signed v0.2.3 "$installed_commit"
+    push_tag v0.2.3
+    fetch_local_tag v0.2.3
+    git -C "$REPO" checkout -q --detach "$installed_commit"
+    append_ok_ledger v0.2.3
+    tag_release "$poison_kind" v99.0.0 "$installed_commit"
+    push_tag v99.0.0
+    fetch_local_tag v99.0.0
+    commit_release genuine pass
+    genuine_commit=$RELEASE_COMMIT
+    tag_release signed v0.3.0 "$genuine_commit"
+    push_tag v0.3.0
+    output=$(run_updater); rc=$?
+    if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$genuine_commit" ]] \
+      && grep -Fq '"version":"v0.3.0"' "$(pin_path)"; then
+      pass "ledger floor ignores $poison_kind high tag at installed HEAD"
+    else
+      fail_case "ledger floor ignores $poison_kind high tag at installed HEAD" "rc=$rc head=$(git -C "$REPO" rev-parse HEAD) output=$output"
+    fi
+  done
+
+  new_fixture delta2-floor-no-ledger
+  tag_release lightweight v99.0.0 "$BASE_COMMIT"
+  push_tag v99.0.0
+  fetch_local_tag v99.0.0
+  output=$(run_updater); rc=$?
+  if [[ "$rc" -ne 0 && ! -e "$(pin_path)" ]] \
+    && printf '%s\n' "$output" | grep -Fq 'scripts/updater-bootstrap'; then
+    pass "floor seed without a usable ledger fails closed and names bootstrap"
+  else
+    fail_case "floor seed without a usable ledger fails closed and names bootstrap" "rc=$rc pin=$(test -e "$(pin_path)" && echo yes || echo no) output=$output"
+  fi
+
+  new_fixture delta2-dry-run-state
+  commit_release installed pass
+  installed_commit=$RELEASE_COMMIT
+  tag_release signed v1.0.0 "$installed_commit"
+  push_tag v1.0.0
+  fetch_local_tag v1.0.0
+  git -C "$REPO" checkout -q --detach "$installed_commit"
+  append_ok_ledger v1.0.0
+  ledger_before=$(cksum "$(ledger_path)")
+  commit_release invalid pass
+  tag_release unsigned v1.1.0 "$RELEASE_COMMIT"
+  push_tag v1.1.0
+  output=$(run_updater --dry-run); rc=$?
+  ledger_after=$(cksum "$(ledger_path)")
+  if [[ "$rc" -eq 0 && "$ledger_before" == "$ledger_after" \
+    && ! -e "$(pin_path)" && ! -e "$(ineligible_path)" \
+    && ! -e "$LOGS/heartbeats.log" && ! -e "$LOGS/hot-inbox.log" ]]; then
+    pass "dry-run writes no pin, dedupe, ledger, heartbeat, or hot-inbox state"
+  else
+    fail_case "dry-run writes no pin, dedupe, ledger, heartbeat, or hot-inbox state" \
+      "rc=$rc pin=$(test -e "$(pin_path)" && echo yes || echo no) ineligible=$(test -e "$(ineligible_path)" && echo yes || echo no) output=$output"
+  fi
+
+  # CP2 v3.3: plain and rc-shaped non-semver names are outside candidate
+  # selection. They are skipped locally without reporting or persistent state.
+  new_fixture delta3-non-semver-skip
+  write_pin v0.0.0 "$BASE_COMMIT"
+  commit_release genuine pass
+  genuine_commit=$RELEASE_COMMIT
+  tag_release lightweight latest "$genuine_commit"
+  push_tag latest
+  tag_release lightweight v1.2.3-rc1 "$genuine_commit"
+  push_tag v1.2.3-rc1
+  tag_release signed v0.3.0 "$genuine_commit"
+  push_tag v0.3.0
+  output=$(run_updater); rc=$?
+  first_head=$(git -C "$REPO" rev-parse HEAD)
+  parse_rcs=$rc
+  for tick in 2 3; do
+    run_updater >/dev/null
+    parse_rcs="$parse_rcs $?"
+  done
+  latest_reports=$(grep -Fc 'latest' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+  rc_reports=$(grep -Fc 'v1.2.3-rc1' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+  latest_records=$(grep -Fc 'latest' "$(ineligible_path)" 2>/dev/null || true)
+  rc_records=$(grep -Fc 'v1.2.3-rc1' "$(ineligible_path)" 2>/dev/null || true)
+  if [[ "$parse_rcs" == '0 0 0' && "$first_head" == "$genuine_commit" \
+    && $(git -C "$REPO" rev-parse HEAD) == "$genuine_commit" \
+    && "$latest_reports" -eq 0 && "$rc_reports" -eq 0 \
+    && "$latest_records" -eq 0 && "$rc_records" -eq 0 ]] \
+    && ! git -C "$REPO" show-ref --verify --quiet refs/tags/latest \
+    && ! git -C "$REPO" show-ref --verify --quiet refs/tags/v1.2.3-rc1 \
+    && printf '%s\n' "$output" | grep -Fq 'family-updater: skipping non-semver remote tag name: latest' \
+    && printf '%s\n' "$output" | grep -Fq 'family-updater: skipping non-semver remote tag name: v1.2.3-rc1'; then
+    pass "non-semver and rc-shaped remote names skip without reports while genuine release installs"
+  else
+    fail_case "non-semver and rc-shaped remote names skip without reports while genuine release installs" \
+      "rcs=[$parse_rcs] first-head=$first_head head=$(git -C "$REPO" rev-parse HEAD) reports=$latest_reports/$rc_reports records=$latest_records/$rc_records output=$output"
+  fi
+
+  # A deterministic ls-remote shim injects duplicate and peeled records that
+  # --refs should normally suppress. Both must remain fail-closed.
+  parse_fakebin=$BASE/parse-fakebin
+  mkdir -p "$parse_fakebin"
+  cat >"$parse_fakebin/git" <<'PARSE_GIT_SHIM'
+#!/usr/bin/env bash
+set -u
+if [[ "$*" == *" ls-remote --refs --tags origin"* ]]; then
+  output=$($REAL_GIT "$@") || exit $?
+  printf '%s\n' "$output"
+  first=$(printf '%s\n' "$output" | sed -n '1p')
+  if [[ "${INJECT_DUPLICATE:-0}" == 1 ]]; then
+    printf '%s\n' "$first"
+  elif [[ "${INJECT_PEELED:-0}" == 1 ]]; then
+    oid=${first%%$'\t'*}
+    ref=${first#*$'\t'}
+    printf '%s\t%s^{}\n' "$oid" "$ref"
+  elif [[ "${INJECT_NONSEMVER_DUP:-0}" == 1 ]]; then
+    oid=${first%%$'\t'*}
+    printf '%s\trefs/tags/latest\n' "$oid"
+    printf '%s\trefs/tags/latest\n' "$oid"
+  fi
+  exit 0
+fi
+exec "$REAL_GIT" "$@"
+PARSE_GIT_SHIM
+  chmod +x "$parse_fakebin/git"
+  for injection in duplicate peeled; do
+    new_fixture "delta2-parse-$injection"
+    write_pin v0.0.0 "$BASE_COMMIT"
+    commit_release candidate pass
+    tag_release signed v1.1.0 "$RELEASE_COMMIT"
+    push_tag v1.1.0
+    before=$(git -C "$REPO" rev-parse HEAD)
+    parse_rcs=
+    for tick in 1 2 3; do
+      if [[ "$injection" == duplicate ]]; then
+        output=$(PATH="$parse_fakebin:$PATH" REAL_GIT="$REAL_GIT" INJECT_DUPLICATE=1 run_updater)
+      else
+        output=$(PATH="$parse_fakebin:$PATH" REAL_GIT="$REAL_GIT" INJECT_PEELED=1 run_updater)
+      fi
+      parse_rcs="$parse_rcs $?"
+    done
+    if [[ "$injection" == duplicate ]]; then
+      expected='duplicate remote tag name'
+    else
+      expected='unparsable remote tag record'
+    fi
+    after=$(git -C "$REPO" rev-parse HEAD)
+    reports=$(grep -Fc "$expected" "$LOGS/hot-inbox.log" 2>/dev/null || true)
+    if [[ "$parse_rcs" == ' 1 1 1' && "$before" == "$after" && "$reports" -eq 1 ]]; then
+      pass "$injection remote tag record fails closed and reports once across three ticks"
+    else
+      fail_case "$injection remote tag record fails closed and reports once across three ticks" \
+        "rcs=[$parse_rcs] reports=$reports output=$output"
+    fi
+  done
+
+  new_fixture delta3-parse-non-semver-duplicate
+  write_pin v0.0.0 "$BASE_COMMIT"
+  commit_release genuine pass
+  genuine_commit=$RELEASE_COMMIT
+  tag_release signed v0.3.0 "$genuine_commit"
+  push_tag v0.3.0
+  output=$(PATH="$parse_fakebin:$PATH" REAL_GIT="$REAL_GIT" INJECT_NONSEMVER_DUP=1 run_updater); rc=$?
+  reports=$(grep -Fc 'latest' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+  ineligible_records=$(grep -Fc 'latest' "$(ineligible_path)" 2>/dev/null || true)
+  skip_notes=$(printf '%s\n' "$output" | grep -Fc 'family-updater: skipping non-semver remote tag name: latest' || true)
+  if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$genuine_commit" \
+    && "$reports" -eq 0 && "$ineligible_records" -eq 0 && "$skip_notes" -eq 2 ]]; then
+    pass "duplicated non-semver records are skipped outside duplicate detection"
+  else
+    fail_case "duplicated non-semver records are skipped outside duplicate detection" \
+      "rc=$rc head=$(git -C "$REPO" rev-parse HEAD) reports=$reports records=$ineligible_records notes=$skip_notes output=$output"
+  fi
+
+  # E3: one broken (name, commit) pair is tried once, rolled back once, and
+  # then skipped without repeating checkout or reports.
+  new_fixture delta2-install-failure-once
+  commit_release installed pass
+  installed_commit=$RELEASE_COMMIT
+  tag_release signed v1.0.0 "$installed_commit"
+  push_tag v1.0.0
+  fetch_local_tag v1.0.0
+  git -C "$REPO" checkout -q --detach "$installed_commit"
+  write_pin v1.0.0 "$installed_commit"
+  commit_release broken fail
+  broken_commit=$RELEASE_COMMIT
+  tag_release signed v1.1.0 "$broken_commit"
+  push_tag v1.1.0
+  install_rcs=
+  for tick in 1 2 3; do
+    run_updater >/dev/null
+    install_rcs="$install_rcs $?"
+  done
+  installs=$(wc -l <"$SENTINEL" 2>/dev/null || printf '0')
+  reports=$(grep -Fc 'updater failed: claire repo v1.1.0' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+  install_failure_records=$(awk -v commit="$broken_commit" \
+    '$1 == "v1.1.0" && $3 == "install-failure" && $4 == commit {count++} END {print count+0}' \
+    "$(ineligible_path)" 2>/dev/null || printf '0')
+  if HOME="$HOME_DIR" bash -c \
+    'source "$1"; updater_has_install_failure "$2" v1.1.0 0000000000000000000000000000000000000000' \
+    _ "$ROOT/scripts/lib-updater-verify.sh" "$(ineligible_path)"; then
+    different_pair_suppressed=1
+  else
+    different_pair_suppressed=0
+  fi
+  if [[ "$install_rcs" == ' 1 0 0' && "$installs" -eq 2 && "$reports" -eq 1 \
+    && "$install_failure_records" -eq 1 && "$different_pair_suppressed" -eq 0 \
+    && $(git -C "$REPO" rev-parse HEAD) == "$installed_commit" ]]; then
+    pass "install failure reports once and exact pair causes no repeated checkout churn"
+  else
+    fail_case "install failure reports once and exact pair causes no repeated checkout churn" \
+      "rcs=[$install_rcs] installs=$installs reports=$reports records=$install_failure_records different-pair=$different_pair_suppressed"
+  fi
+
+  # E7: fail only the second candidate refspec. A single atomic batch leaves
+  # the first ref absent; a per-candidate loop would install it before failing.
+  new_fixture delta2-atomic-second
+  commit_release first pass
+  tag_release signed v1.1.0 "$RELEASE_COMMIT"
+  push_tag v1.1.0
+  commit_release second pass
+  tag_release signed v1.2.0 "$RELEASE_COMMIT"
+  push_tag v1.2.0
+  write_pin v1.0.0 "$BASE_COMMIT"
+  atomic_fakebin=$BASE/atomic-fakebin
+  atomic_counter=$BASE/atomic-counter
+  mkdir -p "$atomic_fakebin"
+  cat >"$atomic_fakebin/git" <<'ATOMIC_GIT_SHIM'
+#!/usr/bin/env bash
+set -u
+if [[ "$*" == *" fetch --atomic "* ]]; then
+  args=()
+  for arg in "$@"; do
+    if [[ "$arg" == refs/tags/*:refs/tags/* ]]; then
+      count=0
+      [[ ! -f "$ATOMIC_COUNTER" ]] || count=$(sed -n '1p' "$ATOMIC_COUNTER")
+      count=$((count + 1))
+      printf '%s\n' "$count" >"$ATOMIC_COUNTER"
+      if [[ "$count" -eq 2 ]]; then
+        arg='refs/tags/v404.0.0:refs/tags/v404.0.0'
+      fi
+    fi
+    args+=("$arg")
+  done
+  exec "$REAL_GIT" "${args[@]}"
+fi
+exec "$REAL_GIT" "$@"
+ATOMIC_GIT_SHIM
+  chmod +x "$atomic_fakebin/git"
+  output=$(PATH="$atomic_fakebin:$PATH" REAL_GIT="$REAL_GIT" ATOMIC_COUNTER="$atomic_counter" run_updater); rc=$?
+  if [[ "$rc" -ne 0 ]] && ! git -C "$REPO" show-ref --verify --quiet refs/tags/v1.1.0 \
+    && ! git -C "$REPO" show-ref --verify --quiet refs/tags/v1.2.0; then
+    pass "second-candidate fetch failure leaves first and second tag refs absent"
+  else
+    fail_case "second-candidate fetch failure leaves first and second tag refs absent" "rc=$rc tags=[$(git -C "$REPO" tag | sort)] output=$output"
+  fi
+
+  if [[ "${DELTA2_FOCUSED:-0}" == 1 ]]; then
+    printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+    [[ "$FAIL_COUNT" -eq 0 ]]
+    exit $?
+  fi
+fi
 
 run_side_path_variant() {
   local kind=$1 mode=$2 expected=$3 label=$4
@@ -360,6 +623,23 @@ else
   fail_case "floor comparison is numeric per semver component" "rc=$rc output=$output"
 fi
 
+# Reverse numeric direction: v0.9.0 must be refused below a v0.10.0 floor.
+new_fixture numeric-floor-reverse
+commit_release lower-numeric pass
+lower_numeric_commit=$RELEASE_COMMIT
+tag_release signed v0.9.0 "$lower_numeric_commit"
+push_tag v0.9.0
+write_pin v0.10.0 "$BASE_COMMIT"
+before=$(git -C "$REPO" rev-parse HEAD)
+output=$(run_updater); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$SENTINEL" ]] \
+  && printf '%s\n' "$output" | grep -Fq 'tag v0.9.0 is below installed floor v0.10.0'; then
+  pass "floor comparison refuses v0.9.0 below v0.10.0"
+else
+  fail_case "floor comparison refuses v0.9.0 below v0.10.0" "rc=$rc output=$output"
+fi
+
 # One moved tag is excluded, reported once, and does not wedge a valid update.
 new_fixture moved-continues
 commit_release old-moved pass
@@ -478,9 +758,6 @@ fi
 if [[ "${FAKE_LS_REMOTE:-0}" == 1 && "$*" == *" ls-remote "* ]]; then
   exit 71
 fi
-if [[ "${EXTRA_BAD_REFSPEC:-0}" == 1 && "$*" == *" fetch --atomic "* ]]; then
-  exec "$REAL_GIT" "$@" 'refs/tags/v404.0.0:refs/tags/v404.0.0'
-fi
 if [[ -n "${MISMATCH_REPO:-}" && "$*" == "-C $MISMATCH_REPO rev-parse HEAD" ]]; then
   count=0
   [[ -f "$MISMATCH_STATE" ]] && count=$(sed -n '1p' "$MISMATCH_STATE")
@@ -507,23 +784,6 @@ if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$SENTINEL" ]] && printf '%s\
   pass "ls-remote failure stops without checkout or install"
 else
   fail_case "ls-remote failure stops without checkout or install" "rc=$rc output=$output"
-fi
-
-new_fixture atomic-partial-failure
-commit_release one pass
-tag_release signed v1.1.0 "$RELEASE_COMMIT"
-push_tag v1.1.0
-commit_release two pass
-tag_release signed v1.2.0 "$RELEASE_COMMIT"
-push_tag v1.2.0
-write_pin v1.0.0 "$BASE_COMMIT"
-before_tags=$(git -C "$REPO" tag | sort)
-output=$(PATH="$FAKEBIN:$PATH" REAL_GIT="$REAL_GIT" EXTRA_BAD_REFSPEC=1 run_updater); rc=$?
-after_tags=$(git -C "$REPO" tag | sort)
-if [[ "$rc" -ne 0 && "$before_tags" == "$after_tags" && ! -e "$SENTINEL" ]]; then
-  pass "failed multi-candidate atomic fetch installs no new local tag refs"
-else
-  fail_case "failed multi-candidate atomic fetch installs no new local tag refs" "rc=$rc before=[$before_tags] after=[$after_tags] output=$output"
 fi
 
 # Rollback uses the full pre-update OID and runs install only after asserting it.
@@ -566,6 +826,165 @@ if [[ "$rc" -ne 0 && "$sentinel_lines" -eq 1 ]] && printf '%s\n' "$output" | gre
   pass "rollback identity mismatch executes no rollback install.sh"
 else
   fail_case "rollback identity mismatch executes no rollback install.sh" "rc=$rc lines=$sentinel_lines output=$output"
+fi
+
+# Reinstated operational coverage from the pre-CP2 suite.
+new_fixture stable-soak-skip
+commit_release fresh pass
+fresh_commit=$RELEASE_COMMIT
+tag_release signed v1.1.0 "$fresh_commit" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+push_tag v1.1.0
+write_pin v1.0.0 "$BASE_COMMIT"
+before=$(git -C "$REPO" rev-parse HEAD)
+output=$(HOME="$HOME_DIR" UPDATER_INSTALL_SENTINEL="$SENTINEL" "$UPDATER" \
+  --repo-dir "$REPO" --workspace "$WS" --agent claire --ring stable \
+  --soak-hours 1 --allowed-signers "$ALLOWED" --fma-scripts-dir "$FMA" 2>&1); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -eq 0 && "$before" == "$after" && ! -e "$LOGS/hot-inbox.log" ]] \
+  && printf '%s\n' "$output" | grep -Fq 'no stable tag old enough for 1 hour soak'; then
+  pass "stable-ring soak skip leaves HEAD unchanged and sends no hot-inbox"
+else
+  fail_case "stable-ring soak skip leaves HEAD unchanged and sends no hot-inbox" "rc=$rc output=$output"
+fi
+output=$(HOME="$HOME_DIR" UPDATER_INSTALL_SENTINEL="$SENTINEL" "$UPDATER" \
+  --repo-dir "$REPO" --workspace "$WS" --agent claire --ring canary \
+  --soak-hours 999 --allowed-signers "$ALLOWED" --fma-scripts-dir "$FMA" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$fresh_commit" ]]; then
+  pass "canary ignores soak hours"
+else
+  fail_case "canary ignores soak hours" "rc=$rc output=$output"
+fi
+
+new_fixture live-lock
+write_pin v0.0.0 "$BASE_COMMIT"
+mkdir "$REPO/.family-updater.lock"
+printf '%s\n' "$$" >"$REPO/.family-updater.lock/pid"
+before=$(git -C "$REPO" rev-parse HEAD)
+output=$(run_updater); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+rm -rf "$REPO/.family-updater.lock"
+if [[ "$rc" -ne 0 && "$before" == "$after" ]] \
+  && grep -Fq 'lock held by live pid' "$LOGS/heartbeats.log"; then
+  pass "live lock refuses the run and sends a failure heartbeat"
+else
+  fail_case "live lock refuses the run and sends a failure heartbeat" "rc=$rc output=$output"
+fi
+
+new_fixture stale-lock
+commit_release candidate pass
+stale_lock_commit=$RELEASE_COMMIT
+tag_release signed v1.1.0 "$stale_lock_commit"
+push_tag v1.1.0
+write_pin v1.0.0 "$BASE_COMMIT"
+mkdir "$REPO/.family-updater.lock"
+printf '%s\n' 999999 >"$REPO/.family-updater.lock/pid"
+output=$(run_updater); rc=$?
+if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$stale_lock_commit" \
+  && ! -d "$REPO/.family-updater.lock" ]]; then
+  pass "stale lock is reclaimed and released"
+else
+  fail_case "stale lock is reclaimed and released" "rc=$rc output=$output"
+fi
+
+new_fixture dirty-worktree
+commit_release candidate pass
+tag_release signed v1.1.0 "$RELEASE_COMMIT"
+push_tag v1.1.0
+write_pin v1.0.0 "$BASE_COMMIT"
+printf 'local change\n' >>"$REPO/VERSION.fixture"
+before=$(git -C "$REPO" rev-parse HEAD)
+output=$(run_updater); rc=$?
+after=$(git -C "$REPO" rev-parse HEAD)
+if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$SENTINEL" ]] \
+  && grep -Fq 'repo has local modifications, refusing to update' "$LOGS/hot-inbox.log" \
+  && grep -Fq ' v1.1.0 fail' "$(ledger_path)"; then
+  pass "dirty worktree refuses checkout and records the failure"
+else
+  fail_case "dirty worktree refuses checkout and records the failure" "rc=$rc output=$output"
+fi
+
+new_fixture already-current
+commit_release current pass
+current_commit=$RELEASE_COMMIT
+tag_release signed v1.1.0 "$current_commit"
+push_tag v1.1.0
+fetch_local_tag v1.1.0
+git -C "$REPO" checkout -q --detach "$current_commit"
+write_pin v1.1.0 "$current_commit"
+output=$(run_updater); rc=$?
+if [[ "$rc" -eq 0 && ! -e "$(ledger_path)" && ! -e "$LOGS/hot-inbox.log" ]] \
+  && grep -Fq 'job-heartbeat updater-claire ok --reason v1.1.0' "$LOGS/heartbeats.log"; then
+  pass "already-up-to-date sends heartbeat but skips ledger and hot-inbox"
+else
+  fail_case "already-up-to-date sends heartbeat but skips ledger and hot-inbox" "rc=$rc output=$output"
+fi
+
+new_fixture missing-reporter
+commit_release candidate pass
+missing_reporter_commit=$RELEASE_COMMIT
+tag_release signed v1.1.0 "$missing_reporter_commit"
+push_tag v1.1.0
+write_pin v1.0.0 "$BASE_COMMIT"
+FMA=$BASE/missing-fma
+output=$(run_updater); rc=$?
+if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$missing_reporter_commit" ]] \
+  && printf '%s\n' "$output" | grep -Fq 'warning: reporter script missing'; then
+  pass "missing reporters warn while a valid update succeeds"
+else
+  fail_case "missing reporters warn while a valid update succeeds" "rc=$rc output=$output"
+fi
+
+new_fixture failing-reporter
+commit_release candidate pass
+failing_reporter_commit=$RELEASE_COMMIT
+tag_release signed v1.1.0 "$failing_reporter_commit"
+push_tag v1.1.0
+write_pin v1.0.0 "$BASE_COMMIT"
+cat >"$FMA/job-heartbeat" <<'FAILING_REPORTER'
+#!/usr/bin/env bash
+exit 1
+FAILING_REPORTER
+chmod +x "$FMA/job-heartbeat"
+output=$(run_updater); rc=$?
+if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$failing_reporter_commit" ]] \
+  && printf '%s\n' "$output" | grep -Fq 'warning: heartbeat reporter failed'; then
+  pass "failing heartbeat reporter warns while a valid update succeeds"
+else
+  fail_case "failing heartbeat reporter warns while a valid update succeeds" "rc=$rc output=$output"
+fi
+
+new_fixture rollback-also-fails
+commit_release failing-base fail
+failing_base_commit=$RELEASE_COMMIT
+tag_release signed v1.0.0 "$failing_base_commit"
+push_tag v1.0.0
+fetch_local_tag v1.0.0
+git -C "$REPO" checkout -q --detach "$failing_base_commit"
+write_pin v1.0.0 "$failing_base_commit"
+commit_release broken-target fail
+tag_release signed v1.1.0 "$RELEASE_COMMIT"
+push_tag v1.1.0
+output=$(run_updater); rc=$?
+report_lines=$(wc -l <"$LOGS/hot-inbox.log" 2>/dev/null || printf '0')
+if [[ "$rc" -ne 0 && $(git -C "$REPO" rev-parse HEAD) == "$failing_base_commit" \
+  && "$report_lines" -eq 1 ]] && grep -Fq 'ALSO failed its check' "$LOGS/hot-inbox.log"; then
+  pass "rollback check failure produces one caution with the ALSO-failed shape"
+else
+  fail_case "rollback check failure produces one caution with the ALSO-failed shape" "rc=$rc reports=$report_lines output=$output"
+fi
+
+state_collision_base=$TMP_ROOT/state-key-collision
+mkdir -p "$state_collision_base/one/repo" "$state_collision_base/two/repo" "$state_collision_base/home"
+first_state_path=$(HOME="$state_collision_base/home" bash -c \
+  'source "$1"; updater_default_pin_path "$2"' _ "$ROOT/scripts/lib-updater-verify.sh" "$state_collision_base/one/repo")
+second_state_path=$(HOME="$state_collision_base/home" bash -c \
+  'source "$1"; updater_default_pin_path "$2"' _ "$ROOT/scripts/lib-updater-verify.sh" "$state_collision_base/two/repo")
+if [[ "$first_state_path" != "$second_state_path" \
+  && $(basename "$first_state_path") == repo-*.json \
+  && $(basename "$second_state_path") == repo-*.json ]]; then
+  pass "same-basename clones receive distinct physical-path state keys"
+else
+  fail_case "same-basename clones receive distinct physical-path state keys" "$first_state_path == $second_state_path"
 fi
 
 # Bootstrap: exact owner tag only, substituted/rebound content rejected.


### PR DESCRIPTION
Third child of security Epic #9 (order #10 → #11 → #12 → #13). Implements the frozen CP2 contract: #12 issuecomment-5251304831 (v2) → -5251529672 (v3) → -5251604043 (v3.1) → -5251664892 (v3.2) → -5251709827 (closure). Owner prerequisite is satisfied: the SSH release signing key exists and signs non-interactively (verified end to end — signed tag created and verified against an `allowed_signers` file).

## The hole this closes, measured

`git verify-tag` does not bind a tag object to the ref that points at it. Point a **new** ref `refs/tags/v9.9.9` at the **genuine signed** tag object of an older release: verification returns **rc=0**, the header block still reads `tag v0.1.0`, and `--sort=-v:refname` selects `v9.9.9`. Run end to end against the **pre-change** updater with an orchestrator-built fixture (two genuine signed releases, attacker rebinds a high name onto the older one): the machine **checked out the older commit** — a genuinely-signed downgrade. The same harness also reproduced, on pre-change code, a moved upstream tag wedging the machine (`rc=1`, no update ever again), unsigned/lightweight/unpinned-key tags being installed with `install.sh` executed, and success being reported while sitting on an unverifiable tag.

## What this PR does

- **B-ALG (ordered, per candidate)** — annotated semver enumeration → capture ref name `R`, tag OID `T`, peeled commit `C` **once** → `git -c gpg.format=ssh -c gpg.ssh.allowedSignersFile=<external pin> verify-tag "$T"` → parse **only the header block of that same object** and require its `tag <name>` to equal `R` by exact string equality (plus "exactly one `tag ` header" so a crafted object cannot smuggle a second) → numeric floor with the equal-version-different-OID refusal → `checkout --detach "$C"` with a `HEAD == C` assertion → `install.sh` strictly last. None of the three named anti-patterns are present (no `describe`/`points-at`/`for-each-ref` name derivation, no whole-object substring match, no re-resolution between verify and parse).
- **B8-1′** — branch fetch with `--no-tags` and an explicit refspec; `ls-remote --refs --tags` with explicit `^{}` rejection, 40-hex/ref-shape validation, and fail-closed on duplicate, unparsable or non-semver names; three-way local comparison; **one** `fetch --atomic --no-tags` carrying every candidate refspec. Moved names are isolated by name, never fetched or forced, reported once, and the run continues. The `--atomic` claim is stated precisely (ref-update atomicity, not object-store rollback).
- **B-BOOT** — `scripts/updater-bootstrap` runs the same shared gate (`scripts/lib-updater-verify.sh`) for exactly the owner-named initial tag, initializes the floor, and only then installs the cron wrapper; `templates/updater-cron.tmpl.sh` refuses to run without a bootstrap pin.
- **B1/B4/B6-1/B7/B8/B9/B10** — verification precedes the already-current check, the heartbeat, dry-run claims, checkout and install; no name re-resolution after capture; legacy unsigned tags are rollback-only; rollback is the recorded pre-update commit OID asserted by identity before any rollback install runs; no wedge and no per-tick storm; soak documented as rollout pacing, not security; git ≥ 2.34, ssh signature support, and an out-of-repo non-symlink signer file all fail closed.

## Orchestrator inspection before review (three defects found and fixed)

The implementation report claimed a green suite. It was not. Independent verification found:

1. **The suite was red and could not have been green** — the bootstrap case failed deterministically because the test fixture never contained `templates/updater-cron.tmpl.sh`, and its final assertion ended in a bare `-x "$cron_dest"` outside any test bracket (the shell ran a command named `-x`). Both fixed; the case now also proves the installed wrapper is byte-identical to the verified release's.
2. **A verification failure permanently blacklisted the tag, breaking the documented key rotation** (MAJOR). Reproduced: machine trusts key A; owner rotates and signs `v0.3.0` with key B; the machine correctly refuses it **and writes it to the ineligible store**; the operator then delivers the rotated `allowed_signers` (A and B) exactly as B10 prescribes; the next tick **still skips `v0.3.0`, and emits no report** because the same store is the report-dedupe store — a silent, permanent fleet wedge, which is the failure class B8 exists to prevent. The contract authorizes persistent exclusion for **moved tags only**; for verification failures it authorizes report dedupe. Fixed by separating the two meanings: moved-tag records still exclude; verification-failure records are dedupe-only, re-evaluated every tick, and cleared on a later success so a future failure reports again.
3. **A failed cron install left the machine pinned but un-bootstrappable** (MINOR) — the pin is written before the wrapper install, so a retry aborted with "pin already exists". Fixed by making the re-run idempotent when the existing pin records exactly the same version and commit OID; any other pin still refuses.

## Files changed (declared vs actual)

Declared in the WIP (#12 issuecomment-5269420207): `scripts/family-updater`, new `scripts/lib-updater-verify.sh`, new `scripts/updater-bootstrap`, `scripts/activation-manifest.tsv`, `templates/updater-cron.tmpl.sh`, `docs/updater-rollout.md`, `tests/family-updater.test.sh`, plus `docs/reference.md` / `docs/reference.ja.md`. Actual: everything above **except** the two reference docs, which needed no change (the updater contract surface lives in `docs/updater-rollout.md`). No file outside the declaration.

## Completion record (L1-7)

- Done-when 1 (owner picks the mechanism at checkpoint 2) → **PASS**: signed tags, owner-approved 2026-08-11 (#9 issuecomment-5251380656), contract closed at v3.2.
- Done-when 2 (refuses unverified checkouts, fail-closed with a clear message, tests cover a tampered tag) → **PASS**: every refusal path names its reason; the tampered-tag scenario is covered in three shapes (rebound name, moved tag, substituted content) plus unsigned, lightweight and unpinned-key.
- Candidate commit: `870fca5` (base main `dfbc094`).
- Implementer verification (Codex Sol): updater suite 31 PASS / 0 FAIL; `make test` exit 0; `make lint` clean; red-before-green evidence recorded for each delta item.
- **Orchestrator verification (independent, not using the repo's own test helpers)**: a separate probe harness builds signed/lightweight/unsigned/unpinned/rebound/moved fixtures with runtime-generated ephemeral keys and asserts on observable outcomes (HEAD OID, an `install.sh` execution sentinel, exit status, pin contents, report store). Result **9/9 PASS** on this branch, and **6 of those 9 FAIL against pre-change `main`** — including the rebinding downgrade, the moved-tag wedge, unsigned/lightweight/unpinned installation, and the false success claim — so the assertions are not passing for unrelated reasons. The key-rotation sequence was probed separately and now recovers (refused while untrusted, installs after the signer is delivered). Own `make test`: **403 PASS / 0 FAIL across 16 reporting suites, exit 0**.
- Intersection with main at PR time: main is `dfbc094` (another lane merged #49 during this work); `git merge-tree --write-tree` clean; the changed-file sets are disjoint from #49's (`install.sh`, `lib-secrets-env.sh`, `cron-wrapper.tmpl.sh`, `secrets-env-rules.test.sh`).

## Operational note carried to the seats (not a defect)

The contract mandates fail-closed on a remote tag name that is not strict semver (v3.2 §1). The repo has 5 tags today and all are strict semver, so nothing breaks now — but the day any non-semver tag is pushed upstream (`nightly`, an rc suffix), every machine stops updating. That is contract-compliant and deliberate; flagging it as an operational consequence for the seats to weigh rather than deciding it unilaterally.

Review: 4 heterogeneous seats (Opus 5 / GLM 5.2 / Fable 5 / Grok 4.5) per the owner-approved downgrade while Kimi and Qwen are quota-absent (#9 issuecomment-5251589535); Codex Sol wrote this implementation and is ineligible as a reviewer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
