### PR TITLE
#68: configurable + hardened example verifier provider (base URL, no-redirect, key separation)

### DIFF
--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -85,6 +85,24 @@ The rules there apply in addition to the Hermes-specific wiring below.
    - `adapters/hermes/examples/verifier-probe.sh` relocates and genuinely calls the
      provider through the wrapper before reporting conformance.
 
+   Anthropic remains the default: set an Anthropic key in `ANTHROPIC_API_KEY`,
+   optionally set `VERIFIER_MODEL`, and leave `VERIFIER_API_BASE` unset to use
+   `https://api.anthropic.com`.
+
+   **Z.ai GLM 5.2 configuration.** Set these values through the job's protected
+   `SECRETS_ENV` (the existing key variable carries the Z.ai member key because the
+   endpoint uses the Anthropic wire format):
+
+   ```sh
+   ANTHROPIC_API_KEY=<Z.ai member key>
+   VERIFIER_MODEL=glm-5.2
+   VERIFIER_API_BASE=https://api.z.ai/api/anthropic
+   ```
+
+   The attestation pins the provider executable and its configured model. A verifier
+   vendor or model swap is a configuration change: update the environment and
+   re-attest before enabling the job with the new vendor/model pair.
+
    Operational contract: the example wrapper forwards only the validated verdict and
    reason lines. It intentionally discards the findings body requested by the bundle
    to remove an injection surface; that body cannot be recovered from this wrapper.

--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -80,28 +80,36 @@ The rules there apply in addition to the Hermes-specific wiring below.
    - `adapters/hermes/examples/verifier-wrapper.sh` validates the argv bundle and
      rejects missing, malformed, or multiple verdicts.
    - `adapters/hermes/examples/verifier-provider.py` makes one stateless API call;
-     set `ANTHROPIC_API_KEY` through the job's protected `SECRETS_ENV`, and optionally
-     set `VERIFIER_MODEL`.
+     set `VERIFIER_API_KEY` through the job's protected `SECRETS_ENV`, and optionally
+     set `VERIFIER_MODEL`. `ANTHROPIC_API_KEY` remains a backward-compatible fallback.
    - `adapters/hermes/examples/verifier-probe.sh` relocates and genuinely calls the
      provider through the wrapper before reporting conformance.
 
-   Anthropic remains the default: set an Anthropic key in `ANTHROPIC_API_KEY`,
+   Anthropic remains the default: set an Anthropic key in `VERIFIER_API_KEY`,
    optionally set `VERIFIER_MODEL`, and leave `VERIFIER_API_BASE` unset to use
    `https://api.anthropic.com`.
 
    **Z.ai GLM 5.2 configuration.** Set these values through the job's protected
-   `SECRETS_ENV` (the existing key variable carries the Z.ai member key because the
-   endpoint uses the Anthropic wire format):
+   `SECRETS_ENV`:
 
    ```sh
-   ANTHROPIC_API_KEY=<Z.ai member key>
+   VERIFIER_API_KEY=<Z.ai member key>
    VERIFIER_MODEL=glm-5.2
    VERIFIER_API_BASE=https://api.z.ai/api/anthropic
    ```
 
-   The attestation pins the provider executable and its configured model. A verifier
-   vendor or model swap is a configuration change: update the environment and
-   re-attest before enabling the job with the new vendor/model pair.
+   `SECRETS_ENV` is an additive overlay. When switching vendors, remove or overwrite
+   the old key line: a leftover key for vendor A will be sent to vendor B. Prefer
+   `VERIFIER_API_KEY` for both vendors; `ANTHROPIC_API_KEY` is accepted only as a
+   backward-compatible fallback when the preferred variable is unset or empty.
+
+   The conformance gate pins the staged wrapper, provider, and probe files by SHA-256,
+   plus the TTL and recorded behavioral flags. It does not pin the API key,
+   `VERIFIER_API_BASE`, or live `VERIFIER_MODEL`; `provider_version` is only the model
+   label present at attestation time, not the model actually served. Re-attesting after
+   a vendor, model, or endpoint change is therefore an operator duty the gate cannot
+   enforce today; a follow-up issue tracks gating the endpoint and served model in the
+   evidence record.
 
    Operational contract: the example wrapper forwards only the validated verdict and
    reason lines. It intentionally discards the findings body requested by the bundle

--- a/adapters/hermes/examples/verifier-provider.py
+++ b/adapters/hermes/examples/verifier-provider.py
@@ -6,6 +6,7 @@ import os
 import secrets
 import sys
 import unicodedata
+import urllib.parse
 import urllib.request
 from typing import NoReturn
 
@@ -18,21 +19,41 @@ def fail(message: str) -> NoReturn:
     raise SystemExit(1)
 
 
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, fp, code, message, headers, new_url):
+        return None
+
+
 if len(sys.argv) != 2 or not sys.argv[1]:
     fail("provider requires one non-empty bundle argument")
 
-api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+api_key = os.environ.get("VERIFIER_API_KEY", "")
+if not api_key:
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
 if not api_key:
     fail("provider credential is unavailable")
 
 api_base = os.environ.get("VERIFIER_API_BASE", "https://api.anthropic.com")
-if not api_base.startswith("https://") or any(
-    character.isspace() or unicodedata.category(character) == "Cc"
-    for character in api_base
-):
+try:
+    parsed_api_base = urllib.parse.urlsplit(api_base)
+    api_base_valid = (
+        api_base.isascii()
+        and not any(
+            character.isspace() or unicodedata.category(character) == "Cc"
+            for character in api_base
+        )
+        and parsed_api_base.scheme == "https"
+        and bool(parsed_api_base.hostname)
+        and parsed_api_base.username is None
+        and parsed_api_base.password is None
+        and not parsed_api_base.query
+        and not parsed_api_base.fragment
+    )
+except ValueError:
+    api_base_valid = False
+if not api_base_valid:
     fail("provider API base is invalid")
-if api_base.endswith("/"):
-    api_base = api_base[:-1]
+api_base = api_base.rstrip("/")
 
 model = os.environ.get("VERIFIER_MODEL", "claude-sonnet-5")
 try:
@@ -76,7 +97,8 @@ request = urllib.request.Request(
 )
 
 try:
-    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+    opener = urllib.request.build_opener(NoRedirectHandler())
+    with opener.open(request, timeout=timeout_seconds) as response:
         response_body = response.read()
     decoded = json.loads(response_body)
     text_parts = [

--- a/adapters/hermes/examples/verifier-provider.py
+++ b/adapters/hermes/examples/verifier-provider.py
@@ -34,15 +34,16 @@ if not api_key:
     fail("provider credential is unavailable")
 
 api_base = os.environ.get("VERIFIER_API_BASE", "https://api.anthropic.com")
+api_base_valid = api_base.isascii() and not any(
+    character.isspace() or unicodedata.category(character) == "Cc"
+    for character in api_base
+)
+if not api_base_valid:
+    fail("provider API base is invalid")
 try:
     parsed_api_base = urllib.parse.urlsplit(api_base)
     api_base_valid = (
-        api_base.isascii()
-        and not any(
-            character.isspace() or unicodedata.category(character) == "Cc"
-            for character in api_base
-        )
-        and parsed_api_base.scheme == "https"
+        parsed_api_base.scheme == "https"
         and bool(parsed_api_base.hostname)
         and parsed_api_base.username is None
         and parsed_api_base.password is None
@@ -53,7 +54,9 @@ except ValueError:
     api_base_valid = False
 if not api_base_valid:
     fail("provider API base is invalid")
-api_base = api_base.rstrip("/")
+api_base = (
+    f"{parsed_api_base.scheme}://{parsed_api_base.netloc}{parsed_api_base.path}"
+).rstrip("/")
 
 model = os.environ.get("VERIFIER_MODEL", "claude-sonnet-5")
 try:

--- a/adapters/hermes/examples/verifier-provider.py
+++ b/adapters/hermes/examples/verifier-provider.py
@@ -5,6 +5,7 @@ import json
 import os
 import secrets
 import sys
+import unicodedata
 import urllib.request
 from typing import NoReturn
 
@@ -23,6 +24,15 @@ if len(sys.argv) != 2 or not sys.argv[1]:
 api_key = os.environ.get("ANTHROPIC_API_KEY", "")
 if not api_key:
     fail("provider credential is unavailable")
+
+api_base = os.environ.get("VERIFIER_API_BASE", "https://api.anthropic.com")
+if not api_base.startswith("https://") or any(
+    character.isspace() or unicodedata.category(character) == "Cc"
+    for character in api_base
+):
+    fail("provider API base is invalid")
+if api_base.endswith("/"):
+    api_base = api_base[:-1]
 
 model = os.environ.get("VERIFIER_MODEL", "claude-sonnet-5")
 try:
@@ -55,7 +65,7 @@ payload = json.dumps(
     }
 ).encode("utf-8")
 request = urllib.request.Request(
-    "https://api.anthropic.com/v1/messages",
+    f"{api_base}/v1/messages",
     data=payload,
     method="POST",
     headers={

--- a/tests/hermes-verifier-examples.test.sh
+++ b/tests/hermes-verifier-examples.test.sh
@@ -388,6 +388,25 @@ else
     "rc=$double_slash_rc output=$double_slash_output"
 fi
 
+bare_delimiter_guard_ok=1
+for bare_delimiter in '#' '?'; do
+  rm -f "$request_url_marker"
+  set +e
+  bare_delimiter_output=$(VERIFIER_API_KEY=fixture \
+    VERIFIER_API_BASE="$zai_base$bare_delimiter" \
+    REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+    REQUEST_COUNT_MARKER="$request_count_marker" \
+    python3 "$opener_stub" "$PROVIDER" "$bundle")
+  bare_delimiter_rc=$?
+  set -e
+  if [ "$bare_delimiter_rc" -ne 0 ] \
+    || [ "$bare_delimiter_output" != 'VERDICT: pass
+stub accepted the request URL' ] \
+    || [ "$(cat "$request_url_marker")" != "$zai_base/v1/messages" ]; then
+    bare_delimiter_guard_ok=0
+  fi
+done
+
 invalid_base_guard_ok=1
 zero_width_space=$(printf '\342\200\213')
 for invalid_base in \
@@ -409,11 +428,11 @@ for invalid_base in \
     invalid_base_guard_ok=0
   fi
 done
-if [ "$invalid_base_guard_ok" -eq 1 ]; then
-  pass '[15] provider rejects malformed or unsafe API bases without a verdict'
+if [ "$bare_delimiter_guard_ok" -eq 1 ] && [ "$invalid_base_guard_ok" -eq 1 ]; then
+  pass '[15] provider normalizes bare delimiters and rejects malformed or unsafe API bases'
 else
-  fail_case '[15] provider rejects malformed or unsafe API bases without a verdict' \
-    'one or more invalid bases escaped the config-error path'
+  fail_case '[15] provider normalizes bare delimiters and rejects malformed or unsafe API bases' \
+    'a bare delimiter corrupted the URL or an invalid base escaped the config-error path'
 fi
 
 set +e

--- a/tests/hermes-verifier-examples.test.sh
+++ b/tests/hermes-verifier-examples.test.sh
@@ -194,10 +194,13 @@ fi
 # The single-quoted text below is an intentional literal source pattern.
 # shellcheck disable=SC2016
 if grep -Fq '"$FABLE_CONFORMING_PROVIDER_PATH" "$bundle"' "$CANONICAL_WRAPPER" \
+  && grep -Fq 'os.environ.get("VERIFIER_API_KEY"' "$PROVIDER" \
   && grep -Fq 'os.environ.get("ANTHROPIC_API_KEY"' "$PROVIDER" \
   && grep -Fq 'os.environ.get("VERIFIER_MODEL", "claude-sonnet-5")' "$PROVIDER" \
   && grep -Fq 'os.environ.get("VERIFIER_API_BASE"' "$PROVIDER" \
   && grep -Fq 'f"{api_base}/v1/messages"' "$PROVIDER" \
+  && grep -Fq 'urllib.parse.urlsplit(api_base)' "$PROVIDER" \
+  && grep -Fq 'urllib.request.build_opener(NoRedirectHandler())' "$PROVIDER" \
   && grep -Fq 'secrets.token_hex' "$PROVIDER" \
   && grep -Fq 'VERIFIER_TEMPERATURE' "$PROVIDER" \
   && grep -Fq '"temperature": temperature' "$PROVIDER" \
@@ -231,13 +234,14 @@ else
     'temperature validation contract failed'
 fi
 
-urlopen_stub=$TMP_ROOT/urlopen-stub.py
-cat >"$urlopen_stub" <<'PY'
+opener_stub=$TMP_ROOT/opener-stub.py
+cat >"$opener_stub" <<'PY'
 #!/usr/bin/env python3
 import json
 import os
 import runpy
 import sys
+import urllib.error
 import urllib.request
 
 
@@ -261,26 +265,70 @@ class StubResponse:
         ).encode("utf-8")
 
 
-def stub_urlopen(request, timeout):
-    del timeout
-    with open(os.environ["REQUEST_URL_MARKER"], "w", encoding="utf-8") as marker:
-        marker.write(request.full_url)
-    return StubResponse()
+class StubOpener:
+    def __init__(self, redirect_handler):
+        self.redirect_handler = redirect_handler
+
+    def open(self, request, timeout):
+        del timeout
+        with open(os.environ["REQUEST_COUNT_MARKER"], "w", encoding="utf-8") as marker:
+            marker.write("1")
+        with open(os.environ["REQUEST_URL_MARKER"], "w", encoding="utf-8") as marker:
+            marker.write(request.full_url)
+        with open(os.environ["REQUEST_KEY_MARKER"], "w", encoding="utf-8") as marker:
+            marker.write(request.get_header("X-api-key", ""))
+
+        if os.environ.get("STUB_RESPONSE_MODE") == "redirect":
+            redirected = self.redirect_handler.redirect_request(
+                request,
+                None,
+                302,
+                "Found",
+                {},
+                "http://redirect.example.test/collect",
+            )
+            if redirected is not None:
+                with open(
+                    os.environ["REQUEST_COUNT_MARKER"], "w", encoding="utf-8"
+                ) as marker:
+                    marker.write("2")
+                return StubResponse()
+            raise urllib.error.HTTPError(
+                request.full_url, 302, "Found", {}, None
+            )
+
+        return StubResponse()
+
+
+def stub_build_opener(*handlers):
+    redirect_handlers = [
+        handler
+        for handler in handlers
+        if isinstance(handler, urllib.request.HTTPRedirectHandler)
+    ]
+    if len(redirect_handlers) != 1:
+        raise AssertionError("provider must install exactly one redirect handler")
+    return StubOpener(redirect_handlers[0])
 
 
 provider_path, bundle = sys.argv[1:]
-urllib.request.urlopen = stub_urlopen
+urllib.request.build_opener = stub_build_opener
 sys.argv = [provider_path, bundle]
 runpy.run_path(provider_path, run_name="__main__")
 PY
 
 request_url_marker=$TMP_ROOT/request-url.marker
+request_key_marker=$TMP_ROOT/request-key.marker
+request_count_marker=$TMP_ROOT/request-count.marker
 expected_anthropic_base='https://api.'"anthropic.com"
 rm -f "$request_url_marker"
-default_base_output=$(env -u VERIFIER_API_BASE ANTHROPIC_API_KEY=fixture \
-  REQUEST_URL_MARKER="$request_url_marker" \
-  python3 "$urlopen_stub" "$PROVIDER" "$bundle")
+set +e
+default_base_output=$(env -u VERIFIER_API_BASE VERIFIER_API_KEY=fixture \
+  REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+  REQUEST_COUNT_MARKER="$request_count_marker" \
+  python3 "$opener_stub" "$PROVIDER" "$bundle")
 default_base_rc=$?
+set -e
 if [ "$default_base_rc" -eq 0 ] \
   && [ "$default_base_output" = 'VERDICT: pass
 stub accepted the request URL' ] \
@@ -293,10 +341,13 @@ fi
 
 zai_base=https://api.z.ai/api/anthropic
 rm -f "$request_url_marker"
-zai_base_output=$(ANTHROPIC_API_KEY=fixture VERIFIER_API_BASE="$zai_base" \
-  REQUEST_URL_MARKER="$request_url_marker" \
-  python3 "$urlopen_stub" "$PROVIDER" "$bundle")
+set +e
+zai_base_output=$(VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$zai_base" \
+  REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+  REQUEST_COUNT_MARKER="$request_count_marker" \
+  python3 "$opener_stub" "$PROVIDER" "$bundle")
 zai_base_rc=$?
+set -e
 if [ "$zai_base_rc" -eq 0 ] \
   && [ "$(cat "$request_url_marker")" = "$zai_base/v1/messages" ]; then
   pass '[12] provider sends a Z.ai-compatible request through the configured base URL'
@@ -306,10 +357,13 @@ else
 fi
 
 rm -f "$request_url_marker"
-trailing_slash_output=$(ANTHROPIC_API_KEY=fixture VERIFIER_API_BASE="$zai_base/" \
-  REQUEST_URL_MARKER="$request_url_marker" \
-  python3 "$urlopen_stub" "$PROVIDER" "$bundle")
+set +e
+trailing_slash_output=$(VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$zai_base/" \
+  REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+  REQUEST_COUNT_MARKER="$request_count_marker" \
+  python3 "$opener_stub" "$PROVIDER" "$bundle")
 trailing_slash_rc=$?
+set -e
 if [ "$trailing_slash_rc" -eq 0 ] \
   && [ "$(cat "$request_url_marker")" = "$zai_base/v1/messages" ]; then
   pass '[13] provider strips one trailing slash before joining the Messages path'
@@ -318,10 +372,34 @@ else
     "rc=$trailing_slash_rc output=$trailing_slash_output"
 fi
 
+rm -f "$request_url_marker"
+set +e
+double_slash_output=$(VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$zai_base//" \
+  REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+  REQUEST_COUNT_MARKER="$request_count_marker" \
+  python3 "$opener_stub" "$PROVIDER" "$bundle")
+double_slash_rc=$?
+set -e
+if [ "$double_slash_rc" -eq 0 ] \
+  && [ "$(cat "$request_url_marker")" = "$zai_base/v1/messages" ]; then
+  pass '[14] provider strips repeated trailing slashes before joining the Messages path'
+else
+  fail_case '[14] provider strips repeated trailing slashes before joining the Messages path' \
+    "rc=$double_slash_rc output=$double_slash_output"
+fi
+
 invalid_base_guard_ok=1
-for invalid_base in 'http://api.example.test' 'https://api.example.test/embedded space'; do
+zero_width_space=$(printf '\342\200\213')
+for invalid_base in \
+  'http://api.example.test' \
+  'https://' \
+  'https://api.example.test/embedded space' \
+  'https://api.example.test/base#fragment' \
+  'https://api.example.test/base?query=value' \
+  'https://user@api.example.test/base' \
+  "https://api.example.test/$zero_width_space"; do
   set +e
-  invalid_base_output=$(ANTHROPIC_API_KEY=fixture VERIFIER_API_BASE="$invalid_base" \
+  invalid_base_output=$(VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$invalid_base" \
     "$PROVIDER" "$bundle" 2>"$TMP_ROOT/invalid-base.err")
   invalid_base_rc=$?
   set -e
@@ -332,10 +410,76 @@ for invalid_base in 'http://api.example.test' 'https://api.example.test/embedded
   fi
 done
 if [ "$invalid_base_guard_ok" -eq 1 ]; then
-  pass '[14] provider rejects non-HTTPS or whitespace-bearing API bases without a verdict'
+  pass '[15] provider rejects malformed or unsafe API bases without a verdict'
 else
-  fail_case '[14] provider rejects non-HTTPS or whitespace-bearing API bases without a verdict' \
+  fail_case '[15] provider rejects malformed or unsafe API bases without a verdict' \
     'one or more invalid bases escaped the config-error path'
+fi
+
+set +e
+redirect_output=$(VERIFIER_API_KEY=redirect-secret VERIFIER_API_BASE="$zai_base" \
+  STUB_RESPONSE_MODE=redirect REQUEST_URL_MARKER="$request_url_marker" \
+  REQUEST_KEY_MARKER="$request_key_marker" REQUEST_COUNT_MARKER="$request_count_marker" \
+  python3 "$opener_stub" "$PROVIDER" "$bundle" 2>"$TMP_ROOT/redirect.err")
+redirect_rc=$?
+set -e
+redirect_verdicts=$(printf '%s\n' "$redirect_output" | awk '/^VERDICT:/ {count++} END {print count + 0}')
+if [ "$redirect_rc" -ne 0 ] \
+  && [ "$redirect_verdicts" -eq 0 ] \
+  && [ "$(cat "$request_count_marker")" -eq 1 ] \
+  && grep -Fqx 'provider request failed' "$TMP_ROOT/redirect.err"; then
+  pass '[16] provider refuses a 302 without issuing a second request or verdict'
+else
+  fail_case '[16] provider refuses a 302 without issuing a second request or verdict' \
+    "rc=$redirect_rc verdicts=$redirect_verdicts requests=$(cat "$request_count_marker")"
+fi
+
+credential_guard_ok=1
+set +e
+both_keys_output=$(VERIFIER_API_KEY=preferred-key ANTHROPIC_API_KEY=legacy-key \
+  REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+  REQUEST_COUNT_MARKER="$request_count_marker" \
+  python3 "$opener_stub" "$PROVIDER" "$bundle")
+both_keys_rc=$?
+set -e
+if [ "$both_keys_rc" -ne 0 ] \
+  || [ "$both_keys_output" != 'VERDICT: pass
+stub accepted the request URL' ] \
+  || [ "$(cat "$request_key_marker")" != preferred-key ]; then
+  credential_guard_ok=0
+fi
+
+set +e
+legacy_key_output=$(env -u VERIFIER_API_KEY ANTHROPIC_API_KEY=legacy-key \
+  REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+  REQUEST_COUNT_MARKER="$request_count_marker" \
+  python3 "$opener_stub" "$PROVIDER" "$bundle")
+legacy_key_rc=$?
+set -e
+if [ "$legacy_key_rc" -ne 0 ] \
+  || [ "$legacy_key_output" != 'VERDICT: pass
+stub accepted the request URL' ] \
+  || [ "$(cat "$request_key_marker")" != legacy-key ]; then
+  credential_guard_ok=0
+fi
+
+set +e
+missing_key_output=$(env -u VERIFIER_API_KEY -u ANTHROPIC_API_KEY \
+  "$PROVIDER" "$bundle" 2>"$TMP_ROOT/missing-key.err")
+missing_key_rc=$?
+set -e
+missing_key_verdicts=$(printf '%s\n' "$missing_key_output" | awk '/^VERDICT:/ {count++} END {print count + 0}')
+if [ "$missing_key_rc" -eq 0 ] \
+  || [ "$missing_key_verdicts" -ne 0 ] \
+  || ! grep -Fqx 'provider credential is unavailable' "$TMP_ROOT/missing-key.err"; then
+  credential_guard_ok=0
+fi
+
+if [ "$credential_guard_ok" -eq 1 ]; then
+  pass '[17] provider prefers VERIFIER_API_KEY, preserves the legacy fallback, and fails without either key'
+else
+  fail_case '[17] provider prefers VERIFIER_API_KEY, preserves the legacy fallback, and fails without either key' \
+    "both=$both_keys_rc legacy=$legacy_key_rc missing=$missing_key_rc"
 fi
 
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"

--- a/tests/hermes-verifier-examples.test.sh
+++ b/tests/hermes-verifier-examples.test.sh
@@ -191,10 +191,13 @@ else
     "modes_ok=$modes_ok"
 fi
 
+# The single-quoted text below is an intentional literal source pattern.
+# shellcheck disable=SC2016
 if grep -Fq '"$FABLE_CONFORMING_PROVIDER_PATH" "$bundle"' "$CANONICAL_WRAPPER" \
   && grep -Fq 'os.environ.get("ANTHROPIC_API_KEY"' "$PROVIDER" \
   && grep -Fq 'os.environ.get("VERIFIER_MODEL", "claude-sonnet-5")' "$PROVIDER" \
-  && grep -Fq 'https://api.anthropic.com/v1/messages' "$PROVIDER" \
+  && grep -Fq 'os.environ.get("VERIFIER_API_BASE"' "$PROVIDER" \
+  && grep -Fq 'f"{api_base}/v1/messages"' "$PROVIDER" \
   && grep -Fq 'secrets.token_hex' "$PROVIDER" \
   && grep -Fq 'VERIFIER_TEMPERATURE' "$PROVIDER" \
   && grep -Fq '"temperature": temperature' "$PROVIDER" \
@@ -226,6 +229,113 @@ if [ "$temperature_guard_ok" -eq 1 ] \
 else
   fail_case '[10] provider pins temperature to zero and rejects malformed or out-of-range overrides before I/O' \
     'temperature validation contract failed'
+fi
+
+urlopen_stub=$TMP_ROOT/urlopen-stub.py
+cat >"$urlopen_stub" <<'PY'
+#!/usr/bin/env python3
+import json
+import os
+import runpy
+import sys
+import urllib.request
+
+
+class StubResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        return json.dumps(
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "VERDICT: pass\nstub accepted the request URL",
+                    }
+                ]
+            }
+        ).encode("utf-8")
+
+
+def stub_urlopen(request, timeout):
+    del timeout
+    with open(os.environ["REQUEST_URL_MARKER"], "w", encoding="utf-8") as marker:
+        marker.write(request.full_url)
+    return StubResponse()
+
+
+provider_path, bundle = sys.argv[1:]
+urllib.request.urlopen = stub_urlopen
+sys.argv = [provider_path, bundle]
+runpy.run_path(provider_path, run_name="__main__")
+PY
+
+request_url_marker=$TMP_ROOT/request-url.marker
+expected_anthropic_base='https://api.'"anthropic.com"
+rm -f "$request_url_marker"
+default_base_output=$(env -u VERIFIER_API_BASE ANTHROPIC_API_KEY=fixture \
+  REQUEST_URL_MARKER="$request_url_marker" \
+  python3 "$urlopen_stub" "$PROVIDER" "$bundle")
+default_base_rc=$?
+if [ "$default_base_rc" -eq 0 ] \
+  && [ "$default_base_output" = 'VERDICT: pass
+stub accepted the request URL' ] \
+  && [ "$(cat "$request_url_marker")" = "$expected_anthropic_base/v1/messages" ]; then
+  pass '[11] provider sends the default request to the Anthropic Messages URL'
+else
+  fail_case '[11] provider sends the default request to the Anthropic Messages URL' \
+    "rc=$default_base_rc output=$default_base_output"
+fi
+
+zai_base=https://api.z.ai/api/anthropic
+rm -f "$request_url_marker"
+zai_base_output=$(ANTHROPIC_API_KEY=fixture VERIFIER_API_BASE="$zai_base" \
+  REQUEST_URL_MARKER="$request_url_marker" \
+  python3 "$urlopen_stub" "$PROVIDER" "$bundle")
+zai_base_rc=$?
+if [ "$zai_base_rc" -eq 0 ] \
+  && [ "$(cat "$request_url_marker")" = "$zai_base/v1/messages" ]; then
+  pass '[12] provider sends a Z.ai-compatible request through the configured base URL'
+else
+  fail_case '[12] provider sends a Z.ai-compatible request through the configured base URL' \
+    "rc=$zai_base_rc output=$zai_base_output"
+fi
+
+rm -f "$request_url_marker"
+trailing_slash_output=$(ANTHROPIC_API_KEY=fixture VERIFIER_API_BASE="$zai_base/" \
+  REQUEST_URL_MARKER="$request_url_marker" \
+  python3 "$urlopen_stub" "$PROVIDER" "$bundle")
+trailing_slash_rc=$?
+if [ "$trailing_slash_rc" -eq 0 ] \
+  && [ "$(cat "$request_url_marker")" = "$zai_base/v1/messages" ]; then
+  pass '[13] provider strips one trailing slash before joining the Messages path'
+else
+  fail_case '[13] provider strips one trailing slash before joining the Messages path' \
+    "rc=$trailing_slash_rc output=$trailing_slash_output"
+fi
+
+invalid_base_guard_ok=1
+for invalid_base in 'http://api.example.test' 'https://api.example.test/embedded space'; do
+  set +e
+  invalid_base_output=$(ANTHROPIC_API_KEY=fixture VERIFIER_API_BASE="$invalid_base" \
+    "$PROVIDER" "$bundle" 2>"$TMP_ROOT/invalid-base.err")
+  invalid_base_rc=$?
+  set -e
+  if [ "$invalid_base_rc" -eq 0 ] \
+    || printf '%s\n' "$invalid_base_output" | grep -q '^VERDICT:' \
+    || ! grep -Fqx 'provider API base is invalid' "$TMP_ROOT/invalid-base.err"; then
+    invalid_base_guard_ok=0
+  fi
+done
+if [ "$invalid_base_guard_ok" -eq 1 ]; then
+  pass '[14] provider rejects non-HTTPS or whitespace-bearing API bases without a verdict'
+else
+  fail_case '[14] provider rejects non-HTTPS or whitespace-bearing API bases without a verdict' \
+    'one or more invalid bases escaped the config-error path'
 fi
 
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"


### PR DESCRIPTION
Closes #68.

Hardens the example verifier provider that #56 shipped, and makes its endpoint configurable.

## What

- `VERIFIER_API_BASE` (default `https://api.anthropic.com`), validated with `urlsplit` — https scheme, non-empty host, no userinfo/query/fragment, ASCII only, whitespace/control chars rejected on the raw string *before* parsing; the URL is rebuilt from parsed components so a bare `#`/`?` cannot swallow the `/v1/messages` join.
- **No-redirect opener**: urllib's default handler follows 301/302/303, turns POST into GET, and keeps the custom `x-api-key` — including to an `http://` Location. Any 3xx is now a provider failure instead of a second request carrying the key.
- **`VERIFIER_API_KEY` preferred** over `ANTHROPIC_API_KEY` (fallback kept). `SECRETS_ENV` is an additive overlay, so a leftover key line for one vendor would otherwise be sent to another; INSTALL.md warns about this explicitly.
- INSTALL.md: Z.ai GLM 5.2 configuration, and a precise statement of what attestation pins (wrapper/provider/probe sha256 + TTL + recorded behavioral flags) versus what it does not (key, base URL, live model — re-attesting after a swap is an operator duty the gate cannot enforce).
- Tests: stub-based URL construction, key precedence, redirect refusal, invalid-base matrix; the new cases regained the `set +e/-e` bracket so a failure reports instead of aborting the suite.

## Verification

- 26 test files green (`hermes-verifier-examples` 10 → 17), re-run independently by the orchestrator at the merge candidate.
- Review (S/M 3 seats, blind, read-only): GLM 5.2 GO-WITH-MINOR→delta **GO** / Grok 4.5 GO-WITH-MINOR (all findings converged and adopted) / Opus 5 GO-WITH-MINOR→delta GO-WITH-MINOR (one new MINOR, fixed in the final commit). Ledger and completion record on #68 (comments -5283606261, -5284364465).
- The redirect finding was independent 3-seat convergence; the additive-`SECRETS_ENV` key hazard and the swallowed-failure test defect were single-seat finds.

## Note on deployment

The owner has since decided the deployed verifier will be a **CLI-backed provider** (the mini's `claude` CLI on an Anthropic subscription, no API key) — tracked as #70. This PR still lands because #56 already shipped the API-client example to `main`; these are hardenings to what is already there, and the API shape remains valid for hosts without a CLI. Real Z.ai traffic has not been exercised (stub-only, no key used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
