### PR TITLE
fix #74: locale-independent control-character rejection in pause guard (macOS runner fail-open)

### DIFF
--- a/scripts/lib-pause.sh
+++ b/scripts/lib-pause.sh
@@ -14,8 +14,10 @@ caty_pause_value_is_record_safe() {
   local value=${1-}
 
   [[ -n "$value" ]] || return 1
+  # Bracket ranges are collation-dependent (fail-open on bash 3.2 under any non-C collation);
+  # [[:cntrl:]] classifies C0+DEL stably across locales.
   case "$value" in
-    *[$'\001'-$'\037'$'\177']*) return 1 ;;
+    *[[:cntrl:]]*) return 1 ;;
     *) return 0 ;;
   esac
 }

--- a/tests/pause-contract.test.sh
+++ b/tests/pause-contract.test.sh
@@ -659,6 +659,47 @@ assert_paused_automation_capture "next invocation after mid-flight pause" "$boun
 assert_eq "next paused invocation makes zero additional provider calls" "1" "$(wc -l <"$boundary_calls" | tr -d ' ')"
 assert_eq "next paused invocation leaves exact workspace snapshot" "$boundary_before_next" "$(snapshot_workspace "$boundary")"
 
+# UTF-8 locale coverage exercises locale-stable control-character rejection.
+set +e
+available_locales=$(locale -a 2>/dev/null)
+locale_list_rc=$?
+set -e
+if (( locale_list_rc != 0 )); then
+  fail_case "locale availability can be queried" \
+    "locale -a exited $locale_list_rc"
+elif grep -Ei '^en_US\.(UTF-8|utf8)$' <<<"$available_locales" >/dev/null; then
+  set +e
+  # Pin Apple's bash 3.2 semantics even when a Homebrew bash shadows PATH.
+  env LC_ALL=en_US.UTF-8 /bin/bash -c \
+    'source "$1" || exit 99; caty_pause_value_is_record_safe "$2"' \
+    _ "$ROOT/scripts/lib-pause.sh" $'unsafe\nrecord'
+  locale_record_safe_rc=$?
+  set -e
+  assert_eq "en_US UTF-8 rejects newline record value" "1" "$locale_record_safe_rc"
+
+  locale_unsafe_parent="$TMP/"$'locale-unsafe\nphysical-parent'
+  mkdir -p "$locale_unsafe_parent/initialized"
+  "$ROOT/scripts/loop-init" --workspace "$locale_unsafe_parent/initialized" >/dev/null
+  ln -s "$locale_unsafe_parent" "$TMP/locale-safe-ancestor"
+  capture_run locale-unsafe-physical env LC_ALL=en_US.UTF-8 /bin/bash \
+    "$ROOT/install.sh" --disable --workspace "$TMP/locale-safe-ancestor/initialized"
+  assert_eq "en_US UTF-8 rejects safe alias to newline physical parent" "2" "$CAPTURE_RC"
+  assert_eq "en_US UTF-8 unsafe physical parent emits no stdout records" "" "$CAPTURE_OUT"
+  assert_eq "en_US UTF-8 unsafe physical parent stdout is empty at byte level" \
+    "0" "$(wc -c <"$CAPTURE_STDOUT" | tr -d ' ')"
+  assert_eq "en_US UTF-8 unsafe physical parent stderr is exact invalid workspace path" \
+    "invalid workspace path" "$CAPTURE_ERR"
+  assert_eq "en_US UTF-8 unsafe physical parent error remains one line" \
+    "1" "$(wc -l <"$CAPTURE_STDERR" | tr -d ' ')"
+else
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    fail_case "en_US.UTF-8 locale available on macOS" \
+      "locale -a lists no en_US.UTF-8/utf8"
+  else
+    pass "en_US UTF-8 locale unavailable # SKIP locale-sensitive path safety regressions"
+  fi
+fi
+
 # Unsafe logical and physical paths are rejected without multiline status records.
 unsafe_direct="$TMP/"$'unsafe\nworkspace'
 mkdir -p "$unsafe_direct"


### PR DESCRIPTION
Fixes #74.

## Root cause

`caty_pause_value_is_record_safe` (scripts/lib-pause.sh) rejected control characters with a glob bracket **range**:

```bash
*[$'\001'-$'\037'$'\177']*) return 1 ;;
```

Bracket-expression ranges in bash glob matching are **collation-dependent** unless `globasciiranges` is in effect. Apple `/bin/bash` 3.2.57 predates that option entirely, so range endpoints are compared with `strcoll()` in the active locale. Under `en_US.UTF-8` — the GitHub `macos-latest` runner default — `$'\n'` does not collate inside `\001`–`\037`, so a newline-bearing path sails through the record-safety check: fail-open (exit 0, workspace record leaked to stdout split across two lines). Exactly the three `test-macos` assertion failures in PR #73's first run.

Why nowhere else saw it: ubuntu runners use bash 5.x where `globasciiranges` is **on by default** (byte-value ranges regardless of locale), and the dev-machine harness environment runs `LANG=C.UTF-8`, where the collation degenerates to byte order. The failure needs the conjunction *bash 3.2 semantics × non-C collating locale* — the runner is the only place in our fleet where both hold. The issue's initial "runner uses brew bash 5" hypothesis was inverted: bash 5 is the *immune* side (review-panel matrix also showed the range fail-opens under `en_US.ISO8859-1`, i.e. any non-C collation, not just UTF-8).

Minimal repro (any Mac):

```bash
LC_ALL=en_US.UTF-8 /bin/bash -c \
  'v=$'\''a\nb'\''; case "$v" in (*[$'\''\001'\''-$'\''\037'\''$'\''\177'\'']*) echo caught;; (*) echo FAIL-OPEN;; esac'
# bash 3.2 + en_US.UTF-8 → FAIL-OPEN;  LC_ALL=C (or bash 5.x) → caught
```

## Fix

Replace the range with the locale-independent POSIX character class (scripts/lib-pause.sh):

```bash
*[[:cntrl:]]*) return 1 ;;
```

Verified 48/48: {`/bin/bash` 3.2.57, brew bash 5.3.15} × {C, C.UTF-8, en_US.UTF-8, ja_JP.UTF-8} × {NL, TAB, CR, \001, \037, \177} all match; review seats extended the matrix (ISO8859-1, LC_CTYPE/LC_COLLATE split, C1 controls, multibyte false-positive checks) with zero fail-open cells — non-ASCII divergence exists only in the *stricter* direction. Repo swept for the same idiom: the only other control-char filter (`scripts/flush-intake.sh`) already pins `LC_ALL=C tr` — safe, untouched. All ~20 entrypoints funnel through this single helper, so the one-line change covers the whole surface.

## Regression tests (red before fix, green after)

`tests/pause-contract.test.sh` pins the hostile conditions explicitly (`LC_ALL=en_US.UTF-8` + `/bin/bash`, so Apple bash 3.2 semantics are exercised even where brew bash shadows PATH):

- direct unit assertion: `caty_pause_value_is_record_safe` must reject `$'\n'` (with `source || exit 99` so a broken source cannot masquerade as a rejection)
- full-path scenario: symlink-alias-to-newline-physical-parent → exit 2, stdout empty **at byte level** (`wc -c` on the capture file — a string compare alone would swallow newline-only leaks), exactly one stderr line `invalid workspace path`
- locale gate fail-closed: `locale -a` error → test failure; missing en_US.UTF-8 on Darwin → **failure** (macOS is the platform the bug lives on); missing elsewhere → explicit SKIP notice

Pre-fix, exactly these assertions fail with the CI failure signature (fail-open rc=0, 161-byte stdout leak, split error line); post-fix `make test` exits 0 under both ambient env and `LC_ALL=en_US.UTF-8` (verified again after rebase onto current main).

Note: README support-table updates were deliberately **kept out** of this PR (5-seat convergent finding: the macOS "CI-tested" claim must not merge before the macOS job exists on main). They land as a follow-up after #73 is green.

## Completion record (L1-7)

| Done when | Status |
|---|---|
| 3 assertions pass on macos-latest with defense firing (no assertion weakening, no bash pinning) | LOCAL PASS under pinned hostile conditions; CI final verdict = #73 re-run after merge |
| Root cause named in the PR (which construct diverges, minimal repro) | PASS (above) |
| PR #73 merges green afterwards | PENDING — next step in this lane |

- Candidate SHA: 54a3646 (rebased on main @ 5907837)
- Files touched vs WIP declaration: scripts/lib-pause.sh, tests/pause-contract.test.sh — inside declared set (install.sh not needed; README deferred by review adjudication)
- Review (loom-seats: size M + enforcement → 5-seat panel): GLM 5.2 (actual glm-5.3) GO · Grok 4.5 (actual 4.6) GO · Fable 5 GO · Opus 5 NO-GO→**GO** after delta · Codex GPT-5.6 Sol sol-xhigh same-family seat (per review_council 2026-08-12) NO-GO→**GO** after delta. Adjudicated deltas: README deferral, byte-level stdout assert (Codex-seat oracle-proven MAJOR), Darwin fail-closed locale gate (4-seat convergence), source guard, comment/placement fixes. Cross-model quorum met; writer=Codex Sol (no self-approve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
