### PR TITLE
feat: bind a verified release tag to this repository (#54)

### DIFF
--- a/docs/updater-rollout.md
+++ b/docs/updater-rollout.md
@@ -79,14 +79,22 @@ endpoint.
 
 IPv6 hosts, `git://`, non-default ports, relative paths, nested group paths such
 as `host/group/subgroup/repo`, query or fragment suffixes, multi-valued origin
-URLs, and `file://` URLs with a non-local host are refused. `insteadOf` rewrites are evaluated as the effective fetch endpoint;
-mirror layouts that normalize to a different or four-component identity are
-unsupported. Failure reasons never include the raw URL.
+URLs, scp-like absolute paths such as `git@github.com:/abs/path/repo.git`, and
+`file://` URLs with a non-local host are refused. Mirror layouts that normalize
+to a different or four-component identity are unsupported. Failure reasons
+never include the raw URL.
 
-The effective origin URL is captured once during signer validation. Branch
-fetches, `ls-remote`, candidate-tag fetches, and bootstrap fetches all consume
-that captured endpoint, never the mutable remote name. Ref updates still target
-`refs/remotes/origin/*` through explicit refspecs.
+The effective origin URL, including any pre-existing `insteadOf` expansion, is
+captured once during signer validation. Before each branch fetch, tag listing,
+candidate-tag fetch, and bootstrap fetch, the updater asks Git to resolve that
+captured value again. It refuses if resolution fails or a new URL rewrite would
+change the endpoint. Ref updates still target `refs/remotes/origin/*` through
+explicit refspecs.
+
+Repository-local Git configuration is trusted operator state. The updater does
+not neutralize it; it detects endpoint-changing URL configuration immediately
+before every network operation and fails closed. A legitimate mirror rewrite
+that already expanded during capture remains equal and continues to work.
 
 ## Release ritual and reachability
 
@@ -209,12 +217,28 @@ Before enabling this release:
 The upgraded updater refuses until the directive exists and releases are
 branch-backed, so migrate signer files before enabling it. If a host's pin or
 floor is foreign or suspect, quarantine it; never lower or hand-edit the floor.
-Under incident procedure, remove the affected clone and its per-clone updater
-state, create a clean clone, and run trusted bootstrap with an owner-confirmed
-release name. Publish the repair release before cloning: bootstrap fetches
-branches with tags suppressed, so the owner-named tag must already be present
-in the clean clone. Name an annotated, signed tag; `v0.1.0` is lightweight and
-verification refuses it.
+Name an annotated, signed repair tag; `v0.1.0` is lightweight and verification
+refuses it. Use one of these two recovery routes:
+
+- **Clean clone:** publish the repair release before cloning, remove the
+  affected clone and its per-clone updater state, create a clean clone, and run
+  trusted bootstrap with the owner-confirmed release name. Bootstrap fetches
+  branches with tags suppressed, so the tag must arrive with the clean clone.
+- **Existing clone:** capture the validated origin endpoint, fetch tags
+  non-forced from that endpoint, then re-run trusted bootstrap. Non-forced tag
+  fetching never moves an existing local tag ref:
+
+  ```sh
+  captured_origin=$(git -C "$repo" remote get-url origin)
+  git -C "$repo" fetch --tags "$captured_origin"
+  /trusted/updater-bootstrap \
+    --repo-dir "$repo" \
+    --allowed-signers "$signers" \
+    --initial-tag "$owner_confirmed_tag" \
+    --cron-wrapper-dest "$HOME/.local/bin/caty-family-updater-cron"
+  ```
+
+The clean-clone route is:
 
 ```sh
 mkdir -p "$quarantine"

--- a/docs/updater-rollout.md
+++ b/docs/updater-rollout.md
@@ -1,140 +1,262 @@
 # Family updater rollout
 
-The updater follows released tags only after verifying the exact tag object it
-will use. SSH tag signatures are the security control. The stable-ring soak is
-only rollout pacing: a signer can backdate `GIT_COMMITTER_DATE`, so tag age must
-never be treated as proof of authenticity.
+The updater accepts a release only after verifying the exact tag object and
+proving that its captured commit is an ancestor of the configured release
+branch. Per-repository SSH signing keys are the cryptographic boundary.
+Release-branch reachability closes tag-object-only cross-repository replay; the
+signer-file directive below prevents one trust file from being wired to the
+wrong repository. The directive does not cryptographically bind a key or tag to
+a repository.
+
+Stable-ring soak is rollout pacing only. A signer can backdate
+`GIT_COMMITTER_DATE`, so tag age is never proof of authenticity.
 
 ## First installation: mechanical bootstrap gate
 
 Do not execute the clone's cron wrapper or recurring updater before bootstrap.
 The owner must deliver two values out of band:
 
-1. an SSH `allowed_signers` file, normally
+1. an absolute path to an SSH `allowed_signers` file, normally
    `$HOME/.claude/state/updater-allowed-signers`; and
 2. the exact initial release name, such as `v1.3.0`.
 
-The signer file must be non-empty, readable, and outside the clone. Never copy
-it from the repository, auto-create it, or fall back to Git configuration. Run
-an out-of-band copy of the bootstrap command (or compare its bytes with a trusted
-copy before execution). The trusted directory must contain both
-`updater-bootstrap` and its sibling `lib-updater-verify.sh`:
+The signer file must be non-empty, readable, outside the clone, and contain
+exactly one repository directive followed by the pinned keys:
+
+```text
+# updater-repo: github.com/example/caty-agent-harness
+release@example.invalid ssh-ed25519 AAAA...
+```
+
+The identity must equal the normalized effective fetch endpoint. Never copy the
+file from the repository, auto-create it, or fall back to Git configuration.
+The updater snapshots the validated file into private 0600 transient state;
+directive parsing and every `verify-tag` call consume those same bytes.
+
+Run an out-of-band copy of bootstrap, or compare its bytes with a trusted copy
+before execution. The trusted directory must contain `updater-bootstrap` and
+its sibling `lib-updater-verify.sh`:
 
 ```sh
-/trusted/updater-bootstrap \
+CATY_UPDATER_RELEASE_BRANCH=main /trusted/updater-bootstrap \
   --repo-dir "$HOME/claude-workspace/caty-agent-harness" \
   --allowed-signers "$HOME/.claude/state/updater-allowed-signers" \
   --initial-tag v1.3.0 \
   --cron-wrapper-dest "$HOME/.local/bin/caty-family-updater-cron"
 ```
 
-Bootstrap verifies exactly the owner-named tag; it does not select a newer tag.
-It captures the tag-object and commit OIDs once, verifies the captured tag object
-with the forced out-of-repo signer pin, binds the `tag` header exactly to the
-owner-named ref, checks out the captured commit OID, asserts `HEAD`, records the
-per-repository floor, and only then installs the cron wrapper. A rebound tag is
-refused.
+Bootstrap is online-only. It captures and validates the origin endpoint,
+fetches all branches with tags suppressed and pruning enabled, then verifies
+exactly the owner-named tag; it never selects a newer tag. It captures the tag
+object and commit OIDs once, verifies the tag with the signer snapshot, binds
+the `tag` header exactly to the owner-named ref, proves the commit is on the
+release branch, checks out and asserts the captured commit, records the floor,
+and only then installs the cron wrapper. Rebound and tag-only foreign releases
+are refused. Offline and air-gapped bootstrap is unsupported.
 
-After bootstrap, configure the copied wrapper. Example:
+Example recurring configuration:
 
 ```cron
-12 * * * * REPO_DIR="$HOME/claude-workspace/caty-agent-harness" WORKSPACE="$HOME/claude-workspace" AGENT="claude-code" RING="stable" SOAK_HOURS="24" FMA_SCRIPTS_DIR="$HOME/claude-workspace/family-memory-architecture/scripts" CATY_UPDATER_ALLOWED_SIGNERS="$HOME/.claude/state/updater-allowed-signers" "$HOME/.local/bin/caty-family-updater-cron" >>"$HOME/claude-workspace/updater-cron.log" 2>&1
+12 * * * * REPO_DIR="$HOME/claude-workspace/caty-agent-harness" WORKSPACE="$HOME/claude-workspace" AGENT="claude-code" RING="stable" SOAK_HOURS="24" FMA_SCRIPTS_DIR="$HOME/claude-workspace/family-memory-architecture/scripts" CATY_UPDATER_ALLOWED_SIGNERS="$HOME/.claude/state/updater-allowed-signers" CATY_UPDATER_RELEASE_BRANCH="main" "$HOME/.local/bin/caty-family-updater-cron" >>"$HOME/claude-workspace/updater-cron.log" 2>&1
 ```
 
-Use `RING=canary SOAK_HOURS=0` only for the assigned canary. Give every clone a
-read-only deploy credential; the updater never pushes.
+Use `RING=canary SOAK_HOURS=0` only for the assigned canary. Give every
+clone a read-only deploy credential; the updater never pushes.
 
-## Persistent state
+## Repository identity and transports
 
-Each physical clone path has an independent monotonic pin. The readable clone
-basename is suffixed with a stable short hash of its resolved physical path, so
-two clones named alike do not share state:
+Accepted host forms are `[user@]host:org/repo[.git]`,
+`ssh://[user@]host[:22]/org/repo[.git]`, and
+`https://host[:443]/org/repo[.git]`. Full URL userinfo is removed before
+comparison, and the entire host-form identity is lowercased. Only default
+explicit ports are accepted. Trailing slashes and one trailing `.git` suffix
+are removed repeatedly until stable.
+
+Absolute filesystem paths, `file:///absolute/path`, and
+`file://localhost/absolute/path` are accepted for tests and local development;
+their identity is the resolved physical path. Production must use a host-form
+endpoint.
+
+IPv6 hosts, `git://`, non-default ports, relative paths, nested group paths such
+as `host/group/subgroup/repo`, query or fragment suffixes, multi-valued origin
+URLs, and `file://` URLs with a non-local host are refused. `insteadOf` rewrites are evaluated as the effective fetch endpoint;
+mirror layouts that normalize to a different or four-component identity are
+unsupported. Failure reasons never include the raw URL.
+
+The effective origin URL is captured once during signer validation. Branch
+fetches, `ls-remote`, candidate-tag fetches, and bootstrap fetches all consume
+that captured endpoint, never the mutable remote name. Ref updates still target
+`refs/remotes/origin/*` through explicit refspecs.
+
+## Release ritual and reachability
+
+Every release tag must point to a commit already on the configured release
+branch (`CATY_UPDATER_RELEASE_BRANCH`, default `main`). The value must pass
+`git check-ref-format --branch`. Protect that branch, and push it before or with
+the tag. Pointing the variable at an unprotected branch restores the ordinary
+branch-write bypass for that deployment.
+
+Spell the branch name with exact case. The syntax check accepts `MaIn`, and ref
+lookup goes through the filesystem, so a case-drifted value can resolve to the
+intended branch on a case-insensitive macOS clone while refusing on Linux hosts
+and in the git-2.34 container cell.
+
+A `push --follow-tags` can land between the updater's branch fetch and tag
+listing. The resulting one-tick refusal is expected and self-heals on the next
+tick. Branches are fetched with `--no-tags --prune`; a deleted release branch
+cannot keep vouching after the next fetch.
+
+The existing production releases `v0.1.0` through `v0.3.0` are already on their
+release branch; this was checked read-only before rollout.
+
+Tags are enumerated with `git ls-remote --refs --tags`, compared by direct ref
+OID, and only absent names are fetched in one `git fetch --atomic --no-tags`
+call. A moved name is never forced over the local ref. `--atomic` guarantees
+atomic ref updates, not object-download rollback; unreachable objects are
+ordinary `git gc` housekeeping and confer no trust.
+
+## Persistent state and retry behavior
+
+Each physical clone path has an independent monotonic pin:
 
 ```text
 $HOME/.claude/state/updater-pin/<repo-name>-<path-hash>.json
 ```
 
-It records the highest successfully installed version and its full commit OID.
-An existing machine without a pin takes the version name only from the most
-recent `ok` entry for this repository in the machine-written
-`$HOME/.claude/state/installed-versions.log`, and accepts it only when that name
-still points at pre-fetch `HEAD`. The floor commit is always that recorded
-pre-fetch OID. Without consistent ledger evidence the updater fails closed and
-names `scripts/updater-bootstrap`. Unreadable or malformed pins also fail
-closed. A `--dry-run` computes this floor in memory but writes no pin, dedupe or
-ledger state and sends no heartbeat or hot-inbox report.
+The pin stores the highest successfully installed version and full commit OID.
+An existing machine without a pin takes a version name only from the most recent
+machine-written `ok` ledger entry and accepts it only when the tag still points
+at pre-fetch `HEAD`. Without consistent evidence the updater fails closed and
+names `scripts/updater-bootstrap`. A `--dry-run` computes the floor in memory
+but writes no pin, dedupe, or ledger state and sends no reports.
 
-Moved names, report dedupe, and exact install-failure identities are recorded in
-the append-only state log at:
+Moved names, report dedupe, and exact install-failure identities use:
 
 ```text
 $HOME/.claude/state/updater-ineligible/<repo-name>-<path-hash>.log
 ```
 
-A moved name remains excluded. A cryptographic or floor verification failure is
-retried on later ticks so signer rotation or another out-of-band repair can
-recover it; its report is deduplicated until that name passes verification.
-Structurally valid remote records with non-semver tag names are skipped with a
-local stdout note. They never become candidates and produce no report or
-persistent record. Skipped names do not enter duplicate detection, so a repeated
-non-semver record is skipped again. Duplicate strict-semver names and unparsable
-remote records still stop the run and report once per offending name. An
-`install.sh --check` failure excludes only the exact tag-name/commit-OID pair
-after rollback, preventing hourly checkout and report churn.
+A moved name remains excluded. Cryptographic, reachability, and floor failures
+are retryable; each name produces one deduplicated verification-failure report
+until it passes, at which point a clear record is appended. Reachability failure
+is never classified as `moved-tag` or `install-failure`. A high foreign tag does
+not abort candidate selection, so a legitimate lower sibling can install in the
+same tick. An install check failure excludes only the exact tag/commit pair.
 
-## Release signing and key rotation
+Non-semver names are skipped locally without reports or state. Duplicate strict
+semver names and malformed remote records stop and report once. A failed install
+rolls back to the exact pre-update OID, asserts it, and only then runs the
+rollback install check.
 
-Every update target must be a strict semver annotated tag signed by a pinned SSH
-key. Legacy lightweight or unsigned releases are rollback identities only and
-can never be selected as update targets.
+## Signing keys and rotation
 
-The gate binds a verified tag to its exact name and a pinned signing key; it
-does **not** bind that tag to a repository. Each repository therefore must have
-its own signing key and its own `allowed_signers` file. Sharing a key across
-repositories lets a release signed for one repository pass the gate and be
-installed by another repository.
+Every update target must be a strict-semver annotated tag signed by a pinned SSH
+key. Lightweight and unsigned releases are rollback identities only. Each
+repository must have a disjoint signing key and signer file. Sharing a key
+destroys cryptographic separation; the repository directive only detects file
+reuse and is not a substitute for key separation.
 
-A tag name rejected as moved is permanently excluded on that machine. Publish
-the corrected release under a higher version; never re-push it under the same
-name.
+A moved tag name is permanently excluded on that host. Publish the correction
+under a higher version; never force the old name.
 
-Rotate signing keys with overlap:
+Rotate keys with overlap:
 
-1. distribute the new public key in `allowed_signers` while retaining the old;
+1. add the new public key while retaining the old and preserving exactly one
+   `# updater-repo: <identity>` directive;
 2. verify adoption on every updater host;
 3. sign a release with the new key and verify fleet acceptance; then
 4. retire the old key from every host.
 
-Never switch the release signer before the overlap has been verified.
+## Migration preflight and recovery
 
-## Fetch behavior and atomicity
+Before enabling this release:
 
-Branches are fetched with tags suppressed. Tags are enumerated with
-`git ls-remote --refs --tags`, compared by direct ref OID, and only absent names
-are fetched in one `git fetch --atomic --no-tags` call. A moved name is never
-forced over the local ref. `--atomic` guarantees atomic **ref updates**: a failed
-batch installs no new tag refs. It does not roll back downloaded objects;
-unreachable objects are ordinary `git gc` housekeeping and confer no trust.
+1. Compare the public-key material in every family repository's signer files
+   pairwise. For each pair, extract key type and base64 material, then require an
+   empty intersection. Any shared key blocks rollout until one repository is
+   rotated:
 
-## Residual bootstrap risks
+   ```sh
+   awk '!/^#/ && NF >= 3 {print $2, $3}' "$repo_a_signers" | LC_ALL=C sort -u >"$secure_tmp/repo-a.keys"
+   awk '!/^#/ && NF >= 3 {print $2, $3}' "$repo_b_signers" | LC_ALL=C sort -u >"$secure_tmp/repo-b.keys"
+   comm -12 "$secure_tmp/repo-a.keys" "$secure_tmp/repo-b.keys" >"$secure_tmp/shared.keys"
+   test ! -s "$secure_tmp/shared.keys"
+   ```
 
-A fresh clone has no prior direct OID, so it cannot detect that an existing tag
-name was moved before the clone was created. The owner-named bootstrap removes
-automatic selection, while signature verification prevents substituted content
-and exact header name binding prevents an old genuine tag object being rebound
-under a new version name.
+2. On every host, verify the current pin/floor tag and `HEAD`, fetch the release
+   branch, and prove the pinned commit is reachable:
 
-If an attacker controls both the remote and the owner channel that supplies the
-initial tag name, the owner can still be induced to name an older genuine signed
-release. That owner-channel compromise is out of scope for this mechanism and
-must be addressed by protecting the out-of-band channel.
+   ```sh
+   git -C "$repo" fetch --no-tags origin \
+     "+refs/heads/$CATY_UPDATER_RELEASE_BRANCH:refs/remotes/origin/$CATY_UPDATER_RELEASE_BRANCH"
+   git -C "$repo" -c gpg.format=ssh \
+     -c gpg.ssh.allowedSignersFile="$signers" verify-tag "$pinned_tag"
+   git -C "$repo" merge-base --is-ancestor "$pinned_commit" \
+     "refs/remotes/origin/$CATY_UPDATER_RELEASE_BRANCH"
+   test "$(git -C "$repo" rev-parse HEAD)" = "$pinned_commit"
+   ```
+
+3. Refuse production rollout if the effective origin is a filesystem path or
+   `file://` URL. Production transports must use a supported host form:
+
+   ```sh
+   effective_origin=$(git -C "$repo" remote get-url origin)
+   case "$effective_origin" in
+     /*|file://*) printf 'production origin must use a host form\n' >&2; exit 1 ;;
+   esac
+   ```
+
+The upgraded updater refuses until the directive exists and releases are
+branch-backed, so migrate signer files before enabling it. If a host's pin or
+floor is foreign or suspect, quarantine it; never lower or hand-edit the floor.
+Under incident procedure, remove the affected clone and its per-clone updater
+state, create a clean clone, and run trusted bootstrap with an owner-confirmed
+release name. Publish the repair release before cloning: bootstrap fetches
+branches with tags suppressed, so the owner-named tag must already be present
+in the clean clone. Name an annotated, signed tag; `v0.1.0` is lightweight and
+verification refuses it.
+
+```sh
+mkdir -p "$quarantine"
+mv "$repo" "$quarantine/suspect-clone"
+mv "$pin_path" "$quarantine/suspect-pin.json"
+test ! -e "$ineligible_path" || mv "$ineligible_path" "$quarantine/suspect-ineligible.log"
+git clone "$trusted_origin" "$clean_clone"
+/trusted/updater-bootstrap \
+  --repo-dir "$clean_clone" \
+  --allowed-signers "$signers" \
+  --initial-tag "$owner_confirmed_tag" \
+  --cron-wrapper-dest "$HOME/.local/bin/caty-family-updater-cron"
+```
+
+Shallow clones, no-branch or release-only origins, offline bootstrap,
+unprotected release branches, and unsupported endpoint forms are not valid
+deployments.
+
+## Residual risks
+
+A fresh clone has no prior direct OID and cannot detect a tag name moved before
+the clone existed. Owner-named bootstrap removes automatic selection; signature
+verification prevents substituted content; exact header binding prevents a
+genuine tag object being rebound under a new version; release reachability
+prevents tag-object-only replay.
+
+If an attacker controls both the remote and the owner channel supplying the
+initial name, the owner can still be induced to name an older genuine release.
+Protect the out-of-band channel.
+
+An attacker with ordinary write authority to both the configured release branch
+and tags can place a foreign signed commit on that branch before tagging it; a
+full remote compromise can do the same. Reachability does not defend against
+either case. Branch protection, disjoint keys, and the migration preflight are
+required.
 
 ## Operational checks
 
 - Git 2.34 or newer with SSH signature verification is mandatory.
-- A missing, empty, unreadable, or repository-local `allowed_signers` file stops
-  the run.
-- Successful real updates and failures append to
+- Relative, missing, empty, unreadable, repository-local, unbound, multiply
+  bound, CRLF-tainted, and mismatched signer files stop the run.
+- `family-updater: repository binding verified: <identity>` is emitted once per
+  successfully bound run.
+- Successful installs and failures append to
   `~/.claude/state/installed-versions.log`; no-op current runs do not.
-- A failed install check rolls back to the exact pre-update full commit OID,
-  asserts that identity, and only then runs the rollback install check.

--- a/docs/updater-rollout.md
+++ b/docs/updater-rollout.md
@@ -77,6 +77,14 @@ Absolute filesystem paths, `file:///absolute/path`, and
 their identity is the resolved physical path. Production must use a host-form
 endpoint.
 
+Host-form identity comparison is case-folded and `.git`-suffix-insensitive:
+`Org/Repo`, `org/repo`, and `Org/Repo.GIT` are one identity. This matches the
+hosts this updater supports and keeps a display-case clone URL from wedging a
+deployment permanently. It also means a host that serves distinct repositories
+whose paths differ only by letter case or by a `.git` suffix is **unsupported**:
+one directive would bind both. Path identities are not folded — they are the
+exact resolved physical path.
+
 IPv6 hosts, `git://`, non-default ports, relative paths, nested group paths such
 as `host/group/subgroup/repo`, query or fragment suffixes, multi-valued origin
 URLs, scp-like absolute paths such as `git@github.com:/abs/path/repo.git`, and

--- a/scripts/family-updater
+++ b/scripts/family-updater
@@ -67,7 +67,18 @@ cleanup_lock() {
     rm -rf "$lock_dir"
   fi
 }
-trap 'cleanup_lock' EXIT HUP INT TERM
+
+family_updater_signal_exit() {
+  local status=$1
+
+  trap - HUP INT TERM
+  exit "$status"
+}
+
+trap 'cleanup_lock' EXIT
+trap 'family_updater_signal_exit 129' HUP
+trap 'family_updater_signal_exit 130' INT
+trap 'family_updater_signal_exit 143' TERM
 
 is_live_pid() {
   local pid=$1

--- a/scripts/family-updater
+++ b/scripts/family-updater
@@ -40,6 +40,10 @@ Flags:
   --fma-scripts-dir <dir> Directory containing job-heartbeat and hot-inbox-post.
                            When omitted, reporting is disabled with a warning.
   -h, --help              Show this help.
+
+Environment:
+  CATY_UPDATER_RELEASE_BRANCH  Release branch required to contain every update
+                               commit. Defaults to main.
 USAGE
 }
 
@@ -58,6 +62,7 @@ die() {
 
 # shellcheck disable=SC2329
 cleanup_lock() {
+  updater_cleanup_allowed_signers_snapshot
   if [[ "$lock_acquired" -eq 1 && -n "$lock_dir" ]]; then
     rm -rf "$lock_dir"
   fi
@@ -397,6 +402,7 @@ if ! updater_validate_allowed_signers "$repo_dir" "$allowed_signers"; then
   report_startup_failure "signers-failed" "$UPDATER_VERIFY_REASON"
   exit 1
 fi
+printf 'family-updater: repository binding verified: %s\n' "$UPDATER_REPOSITORY_IDENTITY"
 if ! clear_startup_failure "signers-failed"; then
   exit 1
 fi
@@ -417,7 +423,7 @@ if ! clear_startup_failure "pin-failed"; then
   exit 1
 fi
 
-if ! updater_sync_remote_tags "$repo_dir" "$ineligible_path" "$dry_run"; then
+if ! updater_sync_remote_tags "$repo_dir" "$ineligible_path" "$dry_run" "$UPDATER_ORIGIN_URL"; then
   if [[ "$UPDATER_SYNC_FAILURE_HANDLED" -eq 0 ]]; then
     report_failure "fetch-failed" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
   fi
@@ -459,7 +465,16 @@ while IFS= read -r candidate; do
 
   # B-ALG steps 2-4: capture once, verify T with forced config, parse only T's
   # header block, and bind its embedded tag name exactly to the candidate name.
-  if ! updater_capture_verify_and_bind "$repo_dir" "$candidate" "$allowed_signers"; then
+  if ! updater_capture_verify_and_bind "$repo_dir" "$candidate" "$UPDATER_ALLOWED_SIGNERS_SNAPSHOT"; then
+    reason=$UPDATER_VERIFY_REASON
+    if ! record_candidate_verification_failure "$candidate" "$reason"; then
+      report_failure "$candidate" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"
+      exit 1
+    fi
+    continue
+  fi
+
+  if ! updater_assert_commit_on_release_ref "$repo_dir" "$UPDATER_CAPTURED_COMMIT"; then
     reason=$UPDATER_VERIFY_REASON
     if ! record_candidate_verification_failure "$candidate" "$reason"; then
       report_failure "$candidate" "$UPDATER_VERIFY_REASON" "" "$UPDATER_VERIFY_REASON"

--- a/scripts/lib-updater-verify.sh
+++ b/scripts/lib-updater-verify.sh
@@ -686,7 +686,7 @@ updater_sync_remote_tags() {
   local repo=$1
   local ineligible_path=$2
   local dry_run=${3:-0}
-  local origin_url=$4
+  local origin_url=${4:-}
   local output line oid ref name extra local_oid mark_rc reason record_name
   local names= records= candidates=
   local -a refspecs
@@ -785,7 +785,7 @@ updater_sync_remote_tags() {
 
 updater_fetch_release_refs() {
   local repo=$1
-  local origin_url=$2
+  local origin_url=${2:-}
 
   if [[ -z "$origin_url" ]]; then
     UPDATER_VERIFY_REASON="captured origin URL is unavailable"
@@ -807,7 +807,7 @@ updater_assert_commit_on_release_ref() {
   local branch=${CATY_UPDATER_RELEASE_BRANCH:-main}
   local release_ref release_tip rc ref_rc
 
-  if ! git check-ref-format --branch "$branch" >/dev/null 2>&1; then
+  if ! git -C "$repo" check-ref-format --branch "$branch" >/dev/null 2>&1; then
     UPDATER_VERIFY_REASON="invalid release branch name configured"
     return 1
   fi

--- a/scripts/lib-updater-verify.sh
+++ b/scripts/lib-updater-verify.sh
@@ -161,70 +161,110 @@ updater_normalize_host_identity() {
   local host=$1
   local path=$2
   local output_var=$3
-  local normalized_identity
+  local normalized_host normalized_path normalized_identity
 
-  updater_strip_host_repo_suffix "$path" path
-  if [[ -z "$host" || "$host" == *[[:space:]]* || "$host" == *:* || "$host" == */* \
-    || "$host" == *'['* || "$host" == *']'* || "$path" == *[[:space:]]* \
-    || "$path" == /* || "$path" == */*/* || "$path" != */* \
-    || "$path" == */ || "$path" == *//* ]]; then
+  printf -v "$output_var" '%s' ''
+  normalized_host=$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]') || return 1
+  normalized_path=$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]') || return 1
+  updater_strip_host_repo_suffix "$normalized_path" normalized_path
+  if [[ -z "$normalized_host" || "$normalized_host" == *[[:space:]]* \
+    || "$normalized_host" == *:* || "$normalized_host" == */* \
+    || "$normalized_host" == *'['* || "$normalized_host" == *']'* \
+    || "$normalized_path" == *[[:space:]]* || "$normalized_path" == /* \
+    || "$normalized_path" == */*/* || "$normalized_path" != */* \
+    || "$normalized_path" == */ || "$normalized_path" == *//* ]]; then
     return 1
   fi
-  normalized_identity=$(printf '%s/%s' "$host" "$path" | tr '[:upper:]' '[:lower:]') || return 1
+  normalized_identity=$normalized_host/$normalized_path
   printf -v "$output_var" '%s' "$normalized_identity"
 }
 
 updater_normalize_repo_url() {
   local value=$1
   local output_var=$2
-  local rest authority host_port host path port normalized_url
+  local rest authority host_port host path port normalized_url scheme scp_value userinfo
 
+  printf -v "$output_var" '%s' ''
   normalized_url=
   if [[ "$value" == /* ]]; then
     [[ "$value" != *'?'* && "$value" != *'#'* ]] || return 1
+    while [[ "$value" == //* ]]; do value=${value#/}; done
     normalized_url=$(cd "$value" 2>/dev/null && pwd -P) || return 1
-  elif [[ "$value" == file://* ]]; then
+  elif [[ "$value" == *://* ]]; then
     [[ "$value" != *'?'* && "$value" != *'#'* ]] || return 1
-    rest=${value#file://}
-    if [[ "$rest" == /* ]]; then
-      path=$rest
-    elif [[ "$rest" == localhost/* ]]; then
-      path=/${rest#localhost/}
-    else
-      return 1
-    fi
-    normalized_url=$(cd "$path" 2>/dev/null && pwd -P) || return 1
-  elif [[ "$value" == ssh://* || "$value" == https://* ]]; then
-    [[ "$value" != *'?'* && "$value" != *'#'* ]] || return 1
-    if [[ "$value" == ssh://* ]]; then
-      rest=${value#ssh://}
-      port=22
-    else
-      rest=${value#https://}
-      port=443
-    fi
-    [[ "$rest" == */* ]] || return 1
-    authority=${rest%%/*}
-    path=${rest#*/}
-    host_port=${authority##*@}
-    [[ -n "$host_port" && "$host_port" != *'['* && "$host_port" != *']'* ]] || return 1
-    if [[ "$host_port" == *:* ]]; then
-      host=${host_port%:*}
-      [[ "${host_port##*:}" == "$port" ]] || return 1
-    else
-      host=$host_port
-    fi
-    updater_normalize_host_identity "$host" "$path" normalized_url || return 1
-  elif [[ "$value" == *://* || "$value" != *:* ]]; then
-    return 1
+    scheme=${value%%://*}
+    scheme=$(printf '%s' "$scheme" | tr '[:upper:]' '[:lower:]') || return 1
+    rest=${value#*://}
+    case "$scheme" in
+      file)
+        if [[ "$rest" == /* ]]; then
+          path=$rest
+        elif [[ "$rest" == */* ]]; then
+          authority=${rest%%/*}
+          authority=$(printf '%s' "$authority" | tr '[:upper:]' '[:lower:]') || return 1
+          [[ "$authority" == localhost ]] || return 1
+          path=/${rest#*/}
+        else
+          return 1
+        fi
+        while [[ "$path" == //* ]]; do path=${path#/}; done
+        normalized_url=$(cd "$path" 2>/dev/null && pwd -P) || return 1
+        ;;
+      ssh|https)
+        if [[ "$scheme" == ssh ]]; then
+          port=22
+        else
+          port=443
+        fi
+        [[ "$rest" == */* ]] || return 1
+        authority=${rest%%/*}
+        path=${rest#*/}
+        host_port=${authority##*@}
+        [[ -n "$host_port" && "$host_port" != *'['* && "$host_port" != *']'* ]] || return 1
+        if [[ "$host_port" == *:* ]]; then
+          host=${host_port%:*}
+          [[ "${host_port##*:}" == "$port" ]] || return 1
+        else
+          host=$host_port
+        fi
+        updater_normalize_host_identity "$host" "$path" normalized_url || return 1
+        ;;
+      *)
+        return 1
+        ;;
+    esac
   else
+    [[ "$value" == *:* ]] || return 1
     [[ "$value" != *'?'* && "$value" != *'#'* && "$value" != *[[:space:]]* ]] || return 1
-    authority=${value%%:*}
-    path=${value#*:}
-    host=${authority##*@}
+    scp_value=$value
+    if [[ "$scp_value" == *@* ]]; then
+      userinfo=${scp_value%%@*}
+      [[ -n "$userinfo" && "$userinfo" != *:* ]] || return 1
+      scp_value=${scp_value#*@}
+      [[ "$scp_value" != *@* ]] || return 1
+    fi
+    authority=${scp_value%%:*}
+    path=${scp_value#*:}
+    [[ "$authority" != "$scp_value" ]] || return 1
+    host=$authority
     updater_normalize_host_identity "$host" "$path" normalized_url || return 1
   fi
   printf -v "$output_var" '%s' "$normalized_url"
+}
+
+updater_assert_endpoint_unrewritten() {
+  local repo=$1
+  local url=$2
+  local resolved
+
+  if ! resolved=$(git -C "$repo" ls-remote --get-url "$url" 2>/dev/null); then
+    UPDATER_VERIFY_REASON="cannot resolve the effective origin endpoint: $repo"
+    return 1
+  fi
+  if [[ "$resolved" != "$url" ]]; then
+    UPDATER_VERIFY_REASON="origin endpoint is rewritten by git URL configuration: $repo"
+    return 1
+  fi
 }
 
 updater_check_capabilities() {
@@ -658,13 +698,19 @@ updater_sync_remote_tags() {
     UPDATER_VERIFY_REASON="captured origin URL is unavailable"
     return 1
   fi
+  if ! updater_assert_endpoint_unrewritten "$repo" "$origin_url"; then
+    return 1
+  fi
   if ! git -C "$repo" fetch --no-tags --prune "$origin_url" \
     '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1; then
-    UPDATER_VERIFY_REASON="branch fetch failed"
+    UPDATER_VERIFY_REASON="branch fetch failed against captured endpoint"
+    return 1
+  fi
+  if ! updater_assert_endpoint_unrewritten "$repo" "$origin_url"; then
     return 1
   fi
   if ! output=$(git -C "$repo" ls-remote --refs --tags "$origin_url" 2>/dev/null); then
-    UPDATER_VERIFY_REASON="git ls-remote --refs --tags origin failed"
+    UPDATER_VERIFY_REASON="git ls-remote --refs --tags against captured endpoint failed"
     return 1
   fi
 
@@ -724,9 +770,12 @@ updater_sync_remote_tags() {
     refspecs+=("refs/tags/$name:refs/tags/$name")
   done <<<"$candidates"
   if (( ${#refspecs[@]} > 0 )); then
+    if ! updater_assert_endpoint_unrewritten "$repo" "$origin_url"; then
+      return 1
+    fi
     if ! git -C "$repo" fetch --atomic --no-tags "$origin_url" "${refspecs[@]}" \
       >/dev/null 2>&1; then
-      UPDATER_VERIFY_REASON="atomic candidate tag fetch failed; no new tag refs were installed"
+      UPDATER_VERIFY_REASON="atomic candidate tag fetch failed against captured endpoint; no new tag refs were installed"
       return 1
     fi
   fi
@@ -742,9 +791,12 @@ updater_fetch_release_refs() {
     UPDATER_VERIFY_REASON="captured origin URL is unavailable"
     return 1
   fi
+  if ! updater_assert_endpoint_unrewritten "$repo" "$origin_url"; then
+    return 1
+  fi
   if ! git -C "$repo" fetch --no-tags --prune "$origin_url" \
     '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1; then
-    UPDATER_VERIFY_REASON="branch fetch failed"
+    UPDATER_VERIFY_REASON="branch fetch failed against captured endpoint"
     return 1
   fi
 }

--- a/scripts/lib-updater-verify.sh
+++ b/scripts/lib-updater-verify.sh
@@ -13,6 +13,10 @@ UPDATER_FLOOR_COMMIT=
 UPDATER_REMOTE_TAGS=
 UPDATER_MOVED_TAGS=
 UPDATER_SYNC_FAILURE_HANDLED=0
+UPDATER_ALLOWED_SIGNERS_SNAPSHOT=
+UPDATER_ALLOWED_SIGNERS_SNAPSHOT_DIR=
+UPDATER_ORIGIN_URL=
+UPDATER_REPOSITORY_IDENTITY=
 
 updater_is_semver() {
   [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
@@ -129,6 +133,100 @@ updater_path_is_outside_repo() {
   [[ "$signers_real" != "$repo_real" && "$signers_real" != "$repo_real/"* ]]
 }
 
+updater_cleanup_allowed_signers_snapshot() {
+  if [[ -n "${UPDATER_ALLOWED_SIGNERS_SNAPSHOT:-}" ]]; then
+    rm -f "$UPDATER_ALLOWED_SIGNERS_SNAPSHOT"
+    UPDATER_ALLOWED_SIGNERS_SNAPSHOT=
+  fi
+  if [[ -n "${UPDATER_ALLOWED_SIGNERS_SNAPSHOT_DIR:-}" ]]; then
+    rmdir "$UPDATER_ALLOWED_SIGNERS_SNAPSHOT_DIR" 2>/dev/null || true
+    UPDATER_ALLOWED_SIGNERS_SNAPSHOT_DIR=
+  fi
+}
+
+updater_strip_host_repo_suffix() {
+  local value=$1
+  local output_var=$2
+  local previous=
+
+  while [[ "$value" != "$previous" ]]; do
+    previous=$value
+    while [[ "$value" == */ ]]; do value=${value%/}; done
+    [[ "$value" != *.git ]] || value=${value%.git}
+  done
+  printf -v "$output_var" '%s' "$value"
+}
+
+updater_normalize_host_identity() {
+  local host=$1
+  local path=$2
+  local output_var=$3
+  local normalized_identity
+
+  updater_strip_host_repo_suffix "$path" path
+  if [[ -z "$host" || "$host" == *[[:space:]]* || "$host" == *:* || "$host" == */* \
+    || "$host" == *'['* || "$host" == *']'* || "$path" == *[[:space:]]* \
+    || "$path" == /* || "$path" == */*/* || "$path" != */* \
+    || "$path" == */ || "$path" == *//* ]]; then
+    return 1
+  fi
+  normalized_identity=$(printf '%s/%s' "$host" "$path" | tr '[:upper:]' '[:lower:]') || return 1
+  printf -v "$output_var" '%s' "$normalized_identity"
+}
+
+updater_normalize_repo_url() {
+  local value=$1
+  local output_var=$2
+  local rest authority host_port host path port normalized_url
+
+  normalized_url=
+  if [[ "$value" == /* ]]; then
+    [[ "$value" != *'?'* && "$value" != *'#'* ]] || return 1
+    normalized_url=$(cd "$value" 2>/dev/null && pwd -P) || return 1
+  elif [[ "$value" == file://* ]]; then
+    [[ "$value" != *'?'* && "$value" != *'#'* ]] || return 1
+    rest=${value#file://}
+    if [[ "$rest" == /* ]]; then
+      path=$rest
+    elif [[ "$rest" == localhost/* ]]; then
+      path=/${rest#localhost/}
+    else
+      return 1
+    fi
+    normalized_url=$(cd "$path" 2>/dev/null && pwd -P) || return 1
+  elif [[ "$value" == ssh://* || "$value" == https://* ]]; then
+    [[ "$value" != *'?'* && "$value" != *'#'* ]] || return 1
+    if [[ "$value" == ssh://* ]]; then
+      rest=${value#ssh://}
+      port=22
+    else
+      rest=${value#https://}
+      port=443
+    fi
+    [[ "$rest" == */* ]] || return 1
+    authority=${rest%%/*}
+    path=${rest#*/}
+    host_port=${authority##*@}
+    [[ -n "$host_port" && "$host_port" != *'['* && "$host_port" != *']'* ]] || return 1
+    if [[ "$host_port" == *:* ]]; then
+      host=${host_port%:*}
+      [[ "${host_port##*:}" == "$port" ]] || return 1
+    else
+      host=$host_port
+    fi
+    updater_normalize_host_identity "$host" "$path" normalized_url || return 1
+  elif [[ "$value" == *://* || "$value" != *:* ]]; then
+    return 1
+  else
+    [[ "$value" != *'?'* && "$value" != *'#'* && "$value" != *[[:space:]]* ]] || return 1
+    authority=${value%%:*}
+    path=${value#*:}
+    host=${authority##*@}
+    updater_normalize_host_identity "$host" "$path" normalized_url || return 1
+  fi
+  printf -v "$output_var" '%s' "$normalized_url"
+}
+
 updater_check_capabilities() {
   local repo=$1
   local version_text major minor probe_output ssh_probe
@@ -168,7 +266,17 @@ updater_check_capabilities() {
 updater_validate_allowed_signers() {
   local repo=$1
   local path=$2
+  local snapshot_dir snapshot directive_count directive declared
+  local origin_output origin_count actual
 
+  updater_cleanup_allowed_signers_snapshot
+  UPDATER_ORIGIN_URL=
+  UPDATER_REPOSITORY_IDENTITY=
+
+  if [[ "$path" != /* ]]; then
+    UPDATER_VERIFY_REASON="allowed_signers path must be absolute: $path"
+    return 1
+  fi
   if [[ ! -f "$path" || ! -r "$path" || ! -s "$path" ]]; then
     UPDATER_VERIFY_REASON="allowed_signers file is absent, unreadable, or empty: $path"
     return 1
@@ -181,6 +289,72 @@ updater_validate_allowed_signers() {
     UPDATER_VERIFY_REASON="allowed_signers must live outside the repository: $path"
     return 1
   fi
+
+  snapshot_dir="$HOME/.claude/state/updater-signers-snapshot"
+  updater_prepare_private_dir "$snapshot_dir" || return 1
+  snapshot=$(mktemp "$snapshot_dir/allowed-signers.XXXXXX") || {
+    UPDATER_VERIFY_REASON="cannot create allowed_signers snapshot"
+    rmdir "$snapshot_dir" 2>/dev/null || true
+    return 1
+  }
+  UPDATER_ALLOWED_SIGNERS_SNAPSHOT_DIR=$snapshot_dir
+  UPDATER_ALLOWED_SIGNERS_SNAPSHOT=$snapshot
+  if ! chmod 600 "$snapshot" || ! cp "$path" "$snapshot" || ! chmod 600 "$snapshot"; then
+    UPDATER_VERIFY_REASON="cannot snapshot allowed_signers file: $path"
+    updater_cleanup_allowed_signers_snapshot
+    return 1
+  fi
+
+  directive_count=$(grep -c '^# updater-repo: ' "$snapshot" 2>/dev/null || true)
+  if [[ "$directive_count" -eq 0 ]]; then
+    UPDATER_VERIFY_REASON="allowed_signers has no repository binding directive (expected '# updater-repo: <identity>'): $path"
+    updater_cleanup_allowed_signers_snapshot
+    return 1
+  fi
+  if [[ "$directive_count" -ne 1 ]]; then
+    UPDATER_VERIFY_REASON="allowed_signers has multiple repository binding directives: $path"
+    updater_cleanup_allowed_signers_snapshot
+    return 1
+  fi
+  directive=$(grep '^# updater-repo: ' "$snapshot")
+  if [[ "$directive" == *$'\r' || "$directive" == *[[:blank:]] ]]; then
+    UPDATER_VERIFY_REASON="repository binding directive has trailing whitespace or a CRLF line ending: $path"
+    updater_cleanup_allowed_signers_snapshot
+    return 1
+  fi
+  declared=${directive#'# updater-repo: '}
+  if [[ -z "$declared" || "$declared" == "$directive" ]]; then
+    UPDATER_VERIFY_REASON="allowed_signers has no repository binding directive (expected '# updater-repo: <identity>'): $path"
+    updater_cleanup_allowed_signers_snapshot
+    return 1
+  fi
+
+  if ! origin_output=$(git -C "$repo" remote get-url --all origin 2>/dev/null); then
+    UPDATER_VERIFY_REASON="cannot determine origin URL for repository binding: $repo"
+    updater_cleanup_allowed_signers_snapshot
+    return 1
+  fi
+  origin_count=$(printf '%s\n' "$origin_output" | awk 'NF {count++} END {print count+0}')
+  if [[ "$origin_count" -ne 1 ]]; then
+    UPDATER_VERIFY_REASON="cannot determine origin URL for repository binding: $repo"
+    updater_cleanup_allowed_signers_snapshot
+    return 1
+  fi
+  UPDATER_ORIGIN_URL=$origin_output
+  if ! updater_normalize_repo_url "$UPDATER_ORIGIN_URL" actual; then
+    UPDATER_VERIFY_REASON="cannot normalize origin URL for repository binding: $repo"
+    updater_cleanup_allowed_signers_snapshot
+    UPDATER_ORIGIN_URL=
+    return 1
+  fi
+  if [[ "$declared" != "$actual" ]]; then
+    UPDATER_VERIFY_REASON="allowed_signers repository binding mismatch: file declares '$declared', origin normalizes to '$actual'"
+    updater_cleanup_allowed_signers_snapshot
+    UPDATER_ORIGIN_URL=
+    return 1
+  fi
+  # shellcheck disable=SC2034  # Public result consumed by sourcing callers.
+  UPDATER_REPOSITORY_IDENTITY=$actual
 }
 
 updater_prepare_private_dir() {
@@ -472,6 +646,7 @@ updater_sync_remote_tags() {
   local repo=$1
   local ineligible_path=$2
   local dry_run=${3:-0}
+  local origin_url=$4
   local output line oid ref name extra local_oid mark_rc reason record_name
   local names= records= candidates=
   local -a refspecs
@@ -479,11 +654,16 @@ updater_sync_remote_tags() {
   UPDATER_MOVED_TAGS=
   UPDATER_SYNC_FAILURE_HANDLED=0
 
-  if ! git -C "$repo" fetch --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'; then
+  if [[ -z "$origin_url" ]]; then
+    UPDATER_VERIFY_REASON="captured origin URL is unavailable"
+    return 1
+  fi
+  if ! git -C "$repo" fetch --no-tags --prune "$origin_url" \
+    '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1; then
     UPDATER_VERIFY_REASON="branch fetch failed"
     return 1
   fi
-  if ! output=$(git -C "$repo" ls-remote --refs --tags origin); then
+  if ! output=$(git -C "$repo" ls-remote --refs --tags "$origin_url" 2>/dev/null); then
     UPDATER_VERIFY_REASON="git ls-remote --refs --tags origin failed"
     return 1
   fi
@@ -544,13 +724,66 @@ updater_sync_remote_tags() {
     refspecs+=("refs/tags/$name:refs/tags/$name")
   done <<<"$candidates"
   if (( ${#refspecs[@]} > 0 )); then
-    if ! git -C "$repo" fetch --atomic --no-tags origin "${refspecs[@]}"; then
+    if ! git -C "$repo" fetch --atomic --no-tags "$origin_url" "${refspecs[@]}" \
+      >/dev/null 2>&1; then
       UPDATER_VERIFY_REASON="atomic candidate tag fetch failed; no new tag refs were installed"
       return 1
     fi
   fi
 
   UPDATER_REMOTE_TAGS=$records
+}
+
+updater_fetch_release_refs() {
+  local repo=$1
+  local origin_url=$2
+
+  if [[ -z "$origin_url" ]]; then
+    UPDATER_VERIFY_REASON="captured origin URL is unavailable"
+    return 1
+  fi
+  if ! git -C "$repo" fetch --no-tags --prune "$origin_url" \
+    '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1; then
+    UPDATER_VERIFY_REASON="branch fetch failed"
+    return 1
+  fi
+}
+
+updater_assert_commit_on_release_ref() {
+  local repo=$1
+  local commit=$2
+  local branch=${CATY_UPDATER_RELEASE_BRANCH:-main}
+  local release_ref release_tip rc ref_rc
+
+  if ! git check-ref-format --branch "$branch" >/dev/null 2>&1; then
+    UPDATER_VERIFY_REASON="invalid release branch name configured"
+    return 1
+  fi
+  release_ref="refs/remotes/origin/$branch"
+  if ! release_tip=$(git -C "$repo" rev-parse --verify "$release_ref" 2>/dev/null); then
+    if git -C "$repo" show-ref --verify --quiet "$release_ref"; then
+      ref_rc=0
+    else
+      ref_rc=$?
+    fi
+    if [[ "$ref_rc" -eq 1 ]]; then
+      UPDATER_VERIFY_REASON="release ref $release_ref is unavailable: $repo"
+    else
+      UPDATER_VERIFY_REASON="reachability check failed (git error) for $commit against origin/$branch"
+    fi
+    return 1
+  fi
+  if git -C "$repo" merge-base --is-ancestor "$commit" "$release_tip" >/dev/null 2>&1; then
+    return 0
+  else
+    rc=$?
+  fi
+  if [[ "$rc" -eq 1 ]]; then
+    UPDATER_VERIFY_REASON="captured commit $commit is not on release branch origin/$branch"
+  else
+    UPDATER_VERIFY_REASON="reachability check failed (git error) for $commit against origin/$branch"
+  fi
+  return 1
 }
 
 updater_header_from_object() {

--- a/scripts/updater-bootstrap
+++ b/scripts/updater-bootstrap
@@ -30,7 +30,18 @@ fail() {
   exit 1
 }
 
-trap 'updater_cleanup_allowed_signers_snapshot' EXIT HUP INT TERM
+updater_bootstrap_signal_exit() {
+  local status=$1
+
+  trap - HUP INT TERM
+  updater_cleanup_allowed_signers_snapshot
+  exit "$status"
+}
+
+trap 'updater_cleanup_allowed_signers_snapshot' EXIT
+trap 'updater_bootstrap_signal_exit 129' HUP
+trap 'updater_bootstrap_signal_exit 130' INT
+trap 'updater_bootstrap_signal_exit 143' TERM
 
 while (($# > 0)); do
   case "$1" in

--- a/scripts/updater-bootstrap
+++ b/scripts/updater-bootstrap
@@ -19,8 +19,9 @@ Usage:
                             [--cron-wrapper-dest <absolute-path>]
 
 The owner supplies the exact initial tag and allowed_signers out of band. This
-command verifies that one named tag only, checks it out by captured commit OID,
-records the per-repository floor, and only then may copy the cron wrapper.
+online command fetches branches, verifies that one named tag only, requires its
+commit on CATY_UPDATER_RELEASE_BRANCH (default main), checks it out by captured
+commit OID, records the floor, and only then may copy the cron wrapper.
 USAGE
 }
 
@@ -28,6 +29,8 @@ fail() {
   printf 'updater-bootstrap error: %s\n' "$1" >&2
   exit 1
 }
+
+trap 'updater_cleanup_allowed_signers_snapshot' EXIT HUP INT TERM
 
 while (($# > 0)); do
   case "$1" in
@@ -80,9 +83,16 @@ fi
 
 pin_path=$(updater_default_pin_path "$repo_dir")
 
+if ! updater_fetch_release_refs "$repo_dir" "$UPDATER_ORIGIN_URL"; then
+  fail "$UPDATER_VERIFY_REASON"
+fi
+
 # B-BOOT uses the same B-ALG steps 2-4 as the recurring updater and operates on
 # exactly the owner-named ref. It performs no remote enumeration or selection.
-if ! updater_capture_verify_and_bind "$repo_dir" "$initial_tag" "$allowed_signers"; then
+if ! updater_capture_verify_and_bind "$repo_dir" "$initial_tag" "$UPDATER_ALLOWED_SIGNERS_SNAPSHOT"; then
+  fail "$UPDATER_VERIFY_REASON"
+fi
+if ! updater_assert_commit_on_release_ref "$repo_dir" "$UPDATER_CAPTURED_COMMIT"; then
   fail "$UPDATER_VERIFY_REASON"
 fi
 

--- a/templates/updater-cron.tmpl.sh
+++ b/templates/updater-cron.tmpl.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 # Copy this file next to a checked-out harness clone, set REPO_DIR to the
 # absolute clone path, and run it from cron. It validates wrapper-level
 # assumptions before execing the clone's scripts/family-updater.
+#
+# CATY_UPDATER_RELEASE_BRANCH selects the branch every update must be reachable
+# from (default: main). It is not validated here; it passes through exec to
+# family-updater. Set it in the crontab environment when this deployment's
+# release branch is not main, or every tick refuses with an unavailable
+# release ref.
 
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 export PATH

--- a/tests/family-updater.test.sh
+++ b/tests/family-updater.test.sh
@@ -205,6 +205,60 @@ FOREIGN_CRON_WRAPPER
   git -C "$FOREIGN_SRC" push -q "$ORIGIN" "refs/tags/$tag:refs/tags/$tag"
 }
 
+make_endpoint_rewrite_foreign_release() {
+  local label=$1 tag=$2
+
+  FOREIGN_ORIGIN=$BASE/rewrite-foreign-origin.git
+  FOREIGN_SRC=$BASE/rewrite-foreign-src
+  git init -q --bare "$FOREIGN_ORIGIN"
+  git init -q "$FOREIGN_SRC"
+  git -C "$FOREIGN_SRC" config user.name 'Rewrite Foreign Fixture'
+  git -C "$FOREIGN_SRC" config user.email fixture@example.invalid
+  git -C "$FOREIGN_SRC" config gpg.format ssh
+  git -C "$FOREIGN_SRC" config user.signingkey "$KEY"
+  write_fake_install "$FOREIGN_SRC" pass
+  mkdir -p "$FOREIGN_SRC/templates"
+  cat >"$FOREIGN_SRC/templates/updater-cron.tmpl.sh" <<'FOREIGN_CRON_WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'rewrite foreign fixture updater cron wrapper\n'
+FOREIGN_CRON_WRAPPER
+  printf '%s\n' "$label" >"$FOREIGN_SRC/VERSION.fixture"
+  git -C "$FOREIGN_SRC" add -A
+  GIT_AUTHOR_DATE=2020-04-01T00:00:00Z GIT_COMMITTER_DATE=2020-04-01T00:00:00Z \
+    git -C "$FOREIGN_SRC" commit -qm "$label"
+  FOREIGN_COMMIT=$(git -C "$FOREIGN_SRC" rev-parse HEAD)
+  FOREIGN_BRANCH=$(git -C "$FOREIGN_SRC" rev-parse --abbrev-ref HEAD)
+  GIT_COMMITTER_DATE=2020-04-01T00:00:00Z \
+    git -C "$FOREIGN_SRC" tag -s "$tag" "$FOREIGN_COMMIT" -m "$tag"
+  git -C "$FOREIGN_SRC" push -q "$FOREIGN_ORIGIN" \
+    "refs/heads/$FOREIGN_BRANCH:refs/heads/$BRANCH" \
+    "refs/tags/$tag:refs/tags/$tag"
+}
+
+write_post_binding_rewrite_shim() {
+  local fakebin=$1
+
+  mkdir -p "$fakebin"
+  cat >"$fakebin/git" <<'POST_BINDING_REWRITE_GIT_SHIM'
+#!/usr/bin/env bash
+set -u
+if [[ "$*" == "-C $BIND_REPO remote get-url --all origin" ]]; then
+  output=$($REAL_GIT "$@") || exit $?
+  printf 'armed\n' >"$REWRITE_STATE"
+  printf '%s\n' "$output"
+  exit 0
+fi
+if [[ -f "$REWRITE_STATE" ]]; then
+  mv "$REWRITE_STATE" "$REWRITE_STATE.injected"
+  "$REAL_GIT" -C "$BIND_REPO" config --local \
+    "url.$FOREIGN_ORIGIN.insteadOf" "$CAPTURED_ORIGIN" || exit $?
+fi
+exec "$REAL_GIT" "$@"
+POST_BINDING_REWRITE_GIT_SHIM
+  chmod +x "$fakebin/git"
+}
+
 run_issue54_updater_replay_case() {
   local legitimate_commit foreign_commit expected_reason output rc
   local verification_records moved_records install_failure_records
@@ -279,6 +333,99 @@ run_issue54_bootstrap_replay_case() {
   else
     fail_case "bootstrap refuses a foreign owner-named tag without checkout, pin, or wrapper" \
       "foreign replay was accepted: rc=$rc before=$before after=$after pin=$(test -e "$(pin_path)" && echo yes || echo no) wrapper=$(test -e "$cron_dest" && echo yes || echo no) output=$output"
+  fi
+}
+
+run_issue54_endpoint_rewrite_cases() {
+  local before after before_pin after_pin expected output rc fakebin rewrite_state cron_dest
+  local report_surface foreign_ref
+
+  new_fixture issue54-post-binding-endpoint-rewrite
+  write_pin v1.0.0 "$BASE_COMMIT"
+  before=$(git -C "$REPO" rev-parse HEAD)
+  before_pin=$(sed -n '1p' "$(pin_path)")
+  make_endpoint_rewrite_foreign_release rewrite-foreign-release v1.1.0
+  fakebin=$BASE/rewrite-fakebin
+  rewrite_state=$BASE/rewrite-state
+  write_post_binding_rewrite_shim "$fakebin"
+  expected="origin endpoint is rewritten by git URL configuration: $REPO"
+
+  output=$(PATH="$fakebin:$PATH" REAL_GIT="$REAL_GIT" BIND_REPO="$REPO" \
+    CAPTURED_ORIGIN="$ORIGIN" FOREIGN_ORIGIN="$FOREIGN_ORIGIN" \
+    REWRITE_STATE="$rewrite_state" run_updater --dry-run); rc=$?
+  after=$(git -C "$REPO" rev-parse HEAD)
+  after_pin=$(sed -n '1p' "$(pin_path)")
+  foreign_ref=$(git -C "$REPO" show-ref --verify --hash "refs/remotes/origin/$BRANCH" 2>/dev/null || true)
+  report_surface=$(grep -R -E 'job-heartbeat|hot-inbox-post| fail$' "$LOGS" "$HOME_DIR/.claude/state" \
+    2>/dev/null || true)
+  if [[ "$rc" -ne 0 && "$before" == "$after" && "$before_pin" == "$after_pin" \
+    && "$foreign_ref" == "$BASE_COMMIT" && ! -e "$SENTINEL" && -z "$report_surface" \
+    && -f "$rewrite_state.injected" ]] \
+    && ! git -C "$REPO" show-ref --verify --quiet refs/tags/v1.1.0 \
+    && printf '%s\n' "$output" | grep -Fq "family-updater error: $expected"; then
+    pass "post-binding URL rewrite is refused before recurring network and side effects"
+  else
+    fail_case "post-binding URL rewrite is refused before recurring network and side effects" \
+      "rc=$rc head=$before/$after pin-same=$(test "$before_pin" = "$after_pin" && echo yes || echo no) remote-ref=$foreign_ref foreign-tag=$(git -C "$REPO" show-ref --verify --quiet refs/tags/v1.1.0 && echo yes || echo no) reports=$(test -n "$report_surface" && echo yes || echo no) output=$output"
+  fi
+
+  new_fixture issue54-bootstrap-post-binding-endpoint-rewrite
+  before=$(git -C "$REPO" rev-parse HEAD)
+  make_endpoint_rewrite_foreign_release rewrite-foreign-bootstrap v1.1.0
+  "$REAL_GIT" -C "$REPO" fetch -q --no-tags "$FOREIGN_ORIGIN" \
+    refs/tags/v1.1.0:refs/tags/v1.1.0
+  fakebin=$BASE/rewrite-fakebin
+  rewrite_state=$BASE/rewrite-state
+  write_post_binding_rewrite_shim "$fakebin"
+  cron_dest=$BASE/cron/family-updater
+  expected="origin endpoint is rewritten by git URL configuration: $REPO"
+
+  output=$(HOME="$HOME_DIR" PATH="$fakebin:$PATH" REAL_GIT="$REAL_GIT" \
+    BIND_REPO="$REPO" CAPTURED_ORIGIN="$ORIGIN" FOREIGN_ORIGIN="$FOREIGN_ORIGIN" \
+    REWRITE_STATE="$rewrite_state" CATY_UPDATER_RELEASE_BRANCH="$BRANCH" "$BOOTSTRAP" \
+    --repo-dir "$REPO" --allowed-signers "$ALLOWED" --initial-tag v1.1.0 \
+    --cron-wrapper-dest "$cron_dest" 2>&1); rc=$?
+  after=$(git -C "$REPO" rev-parse HEAD)
+  foreign_ref=$(git -C "$REPO" show-ref --verify --hash "refs/remotes/origin/$BRANCH" 2>/dev/null || true)
+  if [[ "$rc" -ne 0 && "$before" == "$after" && "$foreign_ref" == "$BASE_COMMIT" \
+    && ! -e "$(pin_path)" && ! -e "$cron_dest" && -f "$rewrite_state.injected" ]] \
+    && printf '%s\n' "$output" | grep -Fq "updater-bootstrap error: $expected"; then
+    pass "post-binding URL rewrite is refused before bootstrap network and side effects"
+  else
+    fail_case "post-binding URL rewrite is refused before bootstrap network and side effects" \
+      "rc=$rc head=$before/$after remote-ref=$foreign_ref pin=$(test -e "$(pin_path)" && echo yes || echo no) wrapper=$(test -e "$cron_dest" && echo yes || echo no) output=$output"
+  fi
+}
+
+run_issue54_endpoint_resolution_failure_case() {
+  local output rc fakebin expected
+
+  new_fixture issue54-endpoint-resolution-failure
+  fakebin=$BASE/resolve-fakebin
+  mkdir -p "$fakebin"
+  cat >"$fakebin/git" <<'ENDPOINT_RESOLVE_GIT_SHIM'
+#!/usr/bin/env bash
+set -u
+if [[ "$*" == "-C $RESOLVE_REPO ls-remote --get-url $RESOLVE_URL" ]]; then
+  exit 71
+fi
+exec "$REAL_GIT" "$@"
+ENDPOINT_RESOLVE_GIT_SHIM
+  chmod +x "$fakebin/git"
+  expected="cannot resolve the effective origin endpoint: $REPO"
+  output=$(HOME="$HOME_DIR" PATH="$fakebin:$PATH" REAL_GIT="$REAL_GIT" \
+    RESOLVE_REPO="$REPO" RESOLVE_URL="$ORIGIN" bash -c '
+      source "$1"
+      updater_assert_endpoint_unrewritten "$2" "$3" || {
+        printf "%s\n" "$UPDATER_VERIFY_REASON"
+        exit 1
+      }
+    ' _ "$ROOT/scripts/lib-updater-verify.sh" "$REPO" "$ORIGIN" 2>&1); rc=$?
+  if [[ "$rc" -ne 0 && "$output" == "$expected" ]]; then
+    pass "endpoint resolution failure is refused without exposing the endpoint"
+  else
+    fail_case "endpoint resolution failure is refused without exposing the endpoint" \
+      "rc=$rc output=$output"
   fi
 }
 
@@ -397,7 +544,7 @@ run_issue54_binding_cases() {
 }
 
 run_issue54_normalization_cases() {
-  local identity output rc probe_cred token_surface multi_url token_fakebin
+  local identity output rc probe_cred token_surface multi_url token_fakebin duplicate_path
 
   new_fixture issue54-normalization
   identity=$(cd "$ORIGIN" && pwd -P)
@@ -412,6 +559,29 @@ run_issue54_normalization_cases() {
       fail_case "accepted host origin normalizes without userinfo: ${accepted%%:*}" "rc=$rc output=$output"
     fi
   done
+  for accepted in \
+    'git@GitHub.COM:MixedOrg/MixedRepo.git' \
+    'git@GitHub.COM:MixedOrg/MixedRepo.GIT' \
+    'git@GitHub.COM:MixedOrg/MixedRepo.Git'; do
+    output=$(normalize_fixture_url "$accepted"); rc=$?
+    if [[ "$rc" -eq 0 && "$output" == github.com/mixedorg/mixedrepo ]]; then
+      pass "host suffix spelling and mixed-case identity normalize consistently"
+    else
+      fail_case "host suffix spelling and mixed-case identity normalize consistently" \
+        "origin=$accepted rc=$rc output=$output"
+    fi
+  done
+  for accepted in \
+    'SSH://git@GitHub.COM:22/Org/Repo.git' \
+    'Https://GitHub.COM:443/Org/Repo.git'; do
+    output=$(normalize_fixture_url "$accepted"); rc=$?
+    if [[ "$rc" -eq 0 && "$output" == github.com/org/repo ]]; then
+      pass "mixed-case URL scheme normalizes case-insensitively"
+    else
+      fail_case "mixed-case URL scheme normalizes case-insensitively" \
+        "origin=$accepted rc=$rc output=$output"
+    fi
+  done
   for accepted in "$ORIGIN" "file://$ORIGIN" "file://localhost$ORIGIN"; do
     output=$(normalize_fixture_url "$accepted"); rc=$?
     if [[ "$rc" -eq 0 && "$output" == "$identity" ]]; then
@@ -420,6 +590,20 @@ run_issue54_normalization_cases() {
       fail_case "accepted local origin resolves to its physical path" "rc=$rc output=$output"
     fi
   done
+  output=$(normalize_fixture_url "FILE://$ORIGIN"); rc=$?
+  if [[ "$rc" -eq 0 && "$output" == "$identity" ]]; then
+    pass "uppercase file URL scheme preserves the case-exact path identity"
+  else
+    fail_case "uppercase file URL scheme preserves the case-exact path identity" "rc=$rc output=$output"
+  fi
+  duplicate_path=//${ORIGIN#/}
+  output=$(normalize_fixture_url "$duplicate_path"); rc=$?
+  if [[ "$rc" -eq 0 && "$output" == "$identity" ]]; then
+    pass "duplicate leading slashes collapse to one physical path identity"
+  else
+    fail_case "duplicate leading slashes collapse to one physical path identity" \
+      "origin=$duplicate_path rc=$rc output=$output expected=$identity"
+  fi
   for refused in \
     'ssh://git@example.invalid:2222/org/repo.git' \
     'https://example.invalid:444/org/repo.git' \
@@ -476,6 +660,27 @@ TOKEN_GIT_SHIM
   else
     fail_case "malformed credential origin is refused without exposing its token" \
       "rc=$rc output-token=$(case $output in *$probe_cred*) echo yes;; *) echo no;; esac) state-token=$(test -n "$token_surface" && echo yes || echo no)"
+  fi
+
+  new_fixture issue54-malformed-scp-credential-origin
+  probe_cred='issue54-scp-secret'
+  git -C "$REPO" remote set-url origin "user:$probe_cred@host:org/repo.git"
+  write_pin v0.0.0 "$BASE_COMMIT"
+  output=$(run_updater); rc=$?
+  token_surface=$(grep -R -F "$probe_cred" "$HOME_DIR/.claude/state" "$LOGS" 2>/dev/null || true)
+  if [[ "$rc" -ne 0 && "$output" != *"$probe_cred"* && -z "$token_surface" ]] \
+    && printf '%s\n' "$output" | grep -Fq "cannot normalize origin URL for repository binding: $REPO"; then
+    pass "malformed scp credential origin is refused without exposing its secret"
+  else
+    fail_case "malformed scp credential origin is refused without exposing its secret" \
+      "rc=$rc output-token=$(case $output in *$probe_cred*) echo yes;; *) echo no;; esac) surface-token=$(test -n "$token_surface" && echo yes || echo no) output=$output"
+  fi
+
+  output=$(normalize_fixture_url 'git@GitHub.COM:Org/Repo.git'); rc=$?
+  if [[ "$rc" -eq 0 && "$output" == github.com/org/repo ]]; then
+    pass "well-formed scp origin still normalizes correctly"
+  else
+    fail_case "well-formed scp origin still normalizes correctly" "rc=$rc output=$output"
   fi
 
   new_fixture issue54-multiple-origin-urls
@@ -683,6 +888,13 @@ case "${ISSUE54_REPLAY_CASE:-all}" in
     [[ "$FAIL_COUNT" -eq 0 ]]
     exit $?
     ;;
+  endpoint-rewrite)
+    run_issue54_endpoint_rewrite_cases
+    run_issue54_endpoint_resolution_failure_case
+    printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+    [[ "$FAIL_COUNT" -eq 0 ]]
+    exit $?
+    ;;
   binding)
     run_issue54_binding_cases
     printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
@@ -712,13 +924,15 @@ case "${ISSUE54_REPLAY_CASE:-all}" in
   all)
     run_issue54_updater_replay_case
     run_issue54_bootstrap_replay_case
+    run_issue54_endpoint_rewrite_cases
+    run_issue54_endpoint_resolution_failure_case
     run_issue54_binding_cases
     run_issue54_normalization_cases
     run_issue54_reachability_cases
     run_issue54_retry_case
     ;;
   *)
-    printf 'unknown ISSUE54_REPLAY_CASE: %s (expected updater, bootstrap, binding, normalization, reachability, retry, or none)\n' \
+    printf 'unknown ISSUE54_REPLAY_CASE: %s (expected updater, bootstrap, endpoint-rewrite, binding, normalization, reachability, retry, or none)\n' \
       "$ISSUE54_REPLAY_CASE" >&2
     exit 2
     ;;

--- a/tests/family-updater.test.sh
+++ b/tests/family-updater.test.sh
@@ -338,7 +338,7 @@ run_issue54_bootstrap_replay_case() {
 
 run_issue54_endpoint_rewrite_cases() {
   local before after before_pin after_pin expected output rc fakebin rewrite_state cron_dest
-  local report_surface foreign_ref
+  local foreign_ref
 
   new_fixture issue54-post-binding-endpoint-rewrite
   write_pin v1.0.0 "$BASE_COMMIT"
@@ -356,17 +356,14 @@ run_issue54_endpoint_rewrite_cases() {
   after=$(git -C "$REPO" rev-parse HEAD)
   after_pin=$(sed -n '1p' "$(pin_path)")
   foreign_ref=$(git -C "$REPO" show-ref --verify --hash "refs/remotes/origin/$BRANCH" 2>/dev/null || true)
-  report_surface=$(grep -R -E 'job-heartbeat|hot-inbox-post| fail$' "$LOGS" "$HOME_DIR/.claude/state" \
-    2>/dev/null || true)
   if [[ "$rc" -ne 0 && "$before" == "$after" && "$before_pin" == "$after_pin" \
-    && "$foreign_ref" == "$BASE_COMMIT" && ! -e "$SENTINEL" && -z "$report_surface" \
-    && -f "$rewrite_state.injected" ]] \
+    && "$foreign_ref" == "$BASE_COMMIT" && ! -e "$SENTINEL" && -f "$rewrite_state.injected" ]] \
     && ! git -C "$REPO" show-ref --verify --quiet refs/tags/v1.1.0 \
     && printf '%s\n' "$output" | grep -Fq "family-updater error: $expected"; then
     pass "post-binding URL rewrite is refused before recurring network and side effects"
   else
     fail_case "post-binding URL rewrite is refused before recurring network and side effects" \
-      "rc=$rc head=$before/$after pin-same=$(test "$before_pin" = "$after_pin" && echo yes || echo no) remote-ref=$foreign_ref foreign-tag=$(git -C "$REPO" show-ref --verify --quiet refs/tags/v1.1.0 && echo yes || echo no) reports=$(test -n "$report_surface" && echo yes || echo no) output=$output"
+      "rc=$rc head=$before/$after pin-same=$(test "$before_pin" = "$after_pin" && echo yes || echo no) remote-ref=$foreign_ref foreign-tag=$(git -C "$REPO" show-ref --verify --quiet refs/tags/v1.1.0 && echo yes || echo no) output=$output"
   fi
 
   new_fixture issue54-bootstrap-post-binding-endpoint-rewrite
@@ -742,7 +739,7 @@ run_issue54_reachability_cases() {
   publish_branch_backed_release v1.1.0
   output=$(CATY_UPDATER_RELEASE_BRANCH='bad..branch' run_updater); rc=$?
   if [[ "$rc" -ne 0 ]] && printf '%s\n' "$output" | grep -Fq 'invalid release branch name configured' \
-    && printf '%s\n' "$output" | grep -Fqv 'bad..branch'; then
+    && ! printf '%s\n' "$output" | grep -Fq 'bad..branch'; then
     pass "invalid release branch config is refused without echoing its value"
   else
     fail_case "invalid release branch config is refused without echoing its value" "rc=$rc output=$output"

--- a/tests/family-updater.test.sh
+++ b/tests/family-updater.test.sh
@@ -39,6 +39,12 @@ INSTALL
   fi
 }
 
+write_allowed_signers_for_key() {
+  local public_key=$1
+  printf '# updater-repo: %s\n' "$(cd "$ORIGIN" && pwd -P)" >"$ALLOWED"
+  printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$public_key")" >>"$ALLOWED"
+}
+
 new_fixture() {
   local name=$1
   name=${name// /-}
@@ -58,9 +64,9 @@ new_fixture() {
   mkdir -p "$BASE" "$HOME_DIR/.claude/state" "$FMA" "$LOGS" "$WS"
   ssh-keygen -q -t ed25519 -N '' -f "$KEY"
   ssh-keygen -q -t ed25519 -N '' -f "$OTHER_KEY"
-  printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$KEY.pub")" >"$ALLOWED"
 
   git init -q --bare "$ORIGIN"
+  write_allowed_signers_for_key "$KEY.pub"
   git init -q "$SRC"
   git -C "$SRC" config user.name Fixture
   git -C "$SRC" config user.email fixture@example.invalid
@@ -73,6 +79,7 @@ new_fixture() {
     git -C "$SRC" commit -qm base
   BASE_COMMIT=$(git -C "$SRC" rev-parse HEAD)
   BRANCH=$(git -C "$SRC" rev-parse --abbrev-ref HEAD)
+  export CATY_UPDATER_RELEASE_BRANCH=$BRANCH
   git -C "$SRC" remote add origin "$ORIGIN"
   git -C "$SRC" push -q origin "$BRANCH"
   git clone -q --no-tags "$ORIGIN" "$REPO"
@@ -126,7 +133,11 @@ tag_release() {
   esac
 }
 
-push_tag() { git -C "$SRC" push -q "$ORIGIN" "refs/tags/$1:refs/tags/$1"; }
+push_tag_only() { git -C "$SRC" push -q "$ORIGIN" "refs/tags/$1:refs/tags/$1"; }
+publish_branch_backed_release() {
+  git -C "$SRC" push -q "$ORIGIN" "$BRANCH"
+  push_tag_only "$1"
+}
 force_push_tag() { git -C "$SRC" push -q --force "$ORIGIN" "refs/tags/$1:refs/tags/$1"; }
 fetch_local_tag() { git -C "$REPO" fetch -q --no-tags "$ORIGIN" "refs/tags/$1:refs/tags/$1"; }
 
@@ -167,9 +178,555 @@ run_updater() {
   fi
 }
 
+make_foreign_release() {
+  local label=$1 tag=$2
+  local foreign_src=$BASE/foreign-src
+
+  FOREIGN_SRC=$foreign_src
+  git init -q "$FOREIGN_SRC"
+  git -C "$FOREIGN_SRC" config user.name 'Foreign Fixture'
+  git -C "$FOREIGN_SRC" config user.email fixture@example.invalid
+  git -C "$FOREIGN_SRC" config gpg.format ssh
+  git -C "$FOREIGN_SRC" config user.signingkey "$KEY"
+  write_fake_install "$FOREIGN_SRC" pass
+  mkdir -p "$FOREIGN_SRC/templates"
+  cat >"$FOREIGN_SRC/templates/updater-cron.tmpl.sh" <<'FOREIGN_CRON_WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'foreign fixture updater cron wrapper\n'
+FOREIGN_CRON_WRAPPER
+  printf '%s\n' "$label" >"$FOREIGN_SRC/VERSION.fixture"
+  git -C "$FOREIGN_SRC" add -A
+  GIT_AUTHOR_DATE=2020-03-01T00:00:00Z GIT_COMMITTER_DATE=2020-03-01T00:00:00Z \
+    git -C "$FOREIGN_SRC" commit -qm "$label"
+  FOREIGN_COMMIT=$(git -C "$FOREIGN_SRC" rev-parse HEAD)
+  GIT_COMMITTER_DATE=2020-03-01T00:00:00Z \
+    git -C "$FOREIGN_SRC" tag -s "$tag" "$FOREIGN_COMMIT" -m "$tag"
+  git -C "$FOREIGN_SRC" push -q "$ORIGIN" "refs/tags/$tag:refs/tags/$tag"
+}
+
+run_issue54_updater_replay_case() {
+  local legitimate_commit foreign_commit expected_reason output rc
+  local verification_records moved_records install_failure_records
+  local failure_reports failure_heartbeats success_heartbeats binding_lines sentinel_lines
+
+  new_fixture issue54-updater-cross-repo-replay
+  write_pin v1.0.0 "$BASE_COMMIT"
+
+  commit_release legitimate-sibling pass
+  legitimate_commit=$RELEASE_COMMIT
+  tag_release signed v1.1.0 "$legitimate_commit"
+  publish_branch_backed_release v1.1.0
+
+  make_foreign_release foreign-replay v9.9.9
+  foreign_commit=$FOREIGN_COMMIT
+  expected_reason="captured commit $foreign_commit is not on release branch origin/$BRANCH"
+
+  output=$(CATY_UPDATER_RELEASE_BRANCH="$BRANCH" run_updater); rc=$?
+  verification_records=$(grep -F 'v9.9.9 ' "$(ineligible_path)" 2>/dev/null \
+    | grep -Fc " verification-failure $expected_reason" || true)
+  moved_records=$(grep -F 'v9.9.9 ' "$(ineligible_path)" 2>/dev/null \
+    | grep -Fc ' moved-tag' || true)
+  install_failure_records=$(grep -F 'v9.9.9 ' "$(ineligible_path)" 2>/dev/null \
+    | grep -Fc ' install-failure ' || true)
+  failure_reports=$(grep -Fc 'updater failed: claire repo v9.9.9' \
+    "$LOGS/hot-inbox.log" 2>/dev/null || true)
+  failure_heartbeats=$(grep -Fc "job-heartbeat updater-claire fail --reason $expected_reason" \
+    "$LOGS/heartbeats.log" 2>/dev/null || true)
+  success_heartbeats=$(grep -Fc 'job-heartbeat updater-claire ok --reason v1.1.0' \
+    "$LOGS/heartbeats.log" 2>/dev/null || true)
+  binding_lines=$(printf '%s\n' "$output" \
+    | grep -Fc "family-updater: repository binding verified: $(cd "$ORIGIN" && pwd -P)" || true)
+  sentinel_lines=0
+  [[ ! -f "$SENTINEL" ]] || sentinel_lines=$(wc -l <"$SENTINEL")
+
+  if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$legitimate_commit" \
+    && "$foreign_commit" != "$legitimate_commit" && "$sentinel_lines" -eq 1 ]] \
+    && grep -Fxq legitimate-sibling "$SENTINEL" \
+    && grep -Fq '"version":"v1.1.0"' "$(pin_path)" \
+    && grep -Fq "\"commit\":\"$legitimate_commit\"" "$(pin_path)" \
+    && [[ "$verification_records" -eq 1 && "$moved_records" -eq 0 \
+      && "$install_failure_records" -eq 0 && "$failure_reports" -eq 1 \
+      && "$failure_heartbeats" -eq 1 && "$success_heartbeats" -eq 1 \
+      && "$binding_lines" -eq 1 \
+      && ! -e "$HOME_DIR/.claude/state/updater-signers-snapshot" ]]; then
+    pass "cross-repo replay is refused while a release-branch sibling installs"
+  else
+    fail_case "cross-repo replay is refused while a release-branch sibling installs" \
+      "foreign replay was accepted or sibling did not install: rc=$rc head=$(git -C "$REPO" rev-parse HEAD) expected-head=$legitimate_commit records=$verification_records/$moved_records/$install_failure_records reports=$failure_reports heartbeats=$failure_heartbeats/$success_heartbeats binding-lines=$binding_lines snapshot-dir=$(test -e "$HOME_DIR/.claude/state/updater-signers-snapshot" && echo yes || echo no) installs=$sentinel_lines output=$output"
+  fi
+}
+
+run_issue54_bootstrap_replay_case() {
+  local before after foreign_commit expected_reason cron_dest output rc
+
+  new_fixture issue54-bootstrap-cross-repo-replay
+  make_foreign_release foreign-bootstrap-replay v1.0.0
+  foreign_commit=$FOREIGN_COMMIT
+  fetch_local_tag v1.0.0
+  before=$(git -C "$REPO" rev-parse HEAD)
+  cron_dest=$BASE/cron/family-updater
+  expected_reason="captured commit $foreign_commit is not on release branch origin/$BRANCH"
+
+  output=$(HOME="$HOME_DIR" CATY_UPDATER_RELEASE_BRANCH="$BRANCH" "$BOOTSTRAP" \
+    --repo-dir "$REPO" --allowed-signers "$ALLOWED" --initial-tag v1.0.0 \
+    --cron-wrapper-dest "$cron_dest" 2>&1); rc=$?
+  after=$(git -C "$REPO" rev-parse HEAD)
+  if [[ "$rc" -ne 0 && "$before" == "$after" && ! -e "$(pin_path)" \
+    && ! -e "$cron_dest" ]] \
+    && printf '%s\n' "$output" | grep -Fq "updater-bootstrap error: $expected_reason"; then
+    pass "bootstrap refuses a foreign owner-named tag without checkout, pin, or wrapper"
+  else
+    fail_case "bootstrap refuses a foreign owner-named tag without checkout, pin, or wrapper" \
+      "foreign replay was accepted: rc=$rc before=$before after=$after pin=$(test -e "$(pin_path)" && echo yes || echo no) wrapper=$(test -e "$cron_dest" && echo yes || echo no) output=$output"
+  fi
+}
+
+validate_fixture_binding() {
+  HOME="$HOME_DIR" bash -c '
+    source "$1"
+    trap updater_cleanup_allowed_signers_snapshot EXIT
+    if updater_validate_allowed_signers "$2" "$3"; then
+      printf "binding-ok:%s\n" "$UPDATER_REPOSITORY_IDENTITY"
+    else
+      printf "%s\n" "$UPDATER_VERIFY_REASON"
+      exit 1
+    fi
+  ' _ "$ROOT/scripts/lib-updater-verify.sh" "$REPO" "$1" 2>&1
+}
+
+normalize_fixture_url() {
+  HOME="$HOME_DIR" bash -c '
+    source "$1"
+    if updater_normalize_repo_url "$2" normalized; then
+      printf "%s\n" "$normalized"
+    else
+      printf "refused\n"
+      exit 1
+    fi
+  ' _ "$ROOT/scripts/lib-updater-verify.sh" "$1" 2>&1
+}
+
+run_issue54_binding_cases() {
+  local identity output rc replacement snapshot_output snapshot_rc
+
+  new_fixture issue54-binding-directive
+  identity=$(cd "$ORIGIN" && pwd -P)
+  output=$(validate_fixture_binding "$ALLOWED"); rc=$?
+  if [[ "$rc" -eq 0 && "$output" == "binding-ok:$identity" ]]; then
+    pass "matching repository directive binds the signer snapshot"
+  else
+    fail_case "matching repository directive binds the signer snapshot" "rc=$rc output=$output"
+  fi
+
+  printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$KEY.pub")" >"$ALLOWED"
+  output=$(validate_fixture_binding "$ALLOWED"); rc=$?
+  if [[ "$rc" -ne 0 && "$output" == "allowed_signers has no repository binding directive (expected '# updater-repo: <identity>'): $ALLOWED" ]]; then
+    pass "signer file without a repository directive is refused"
+  else
+    fail_case "signer file without a repository directive is refused" "rc=$rc output=$output"
+  fi
+
+  write_allowed_signers_for_key "$KEY.pub"
+  printf '# updater-repo: %s\n' "$identity" >>"$ALLOWED"
+  output=$(validate_fixture_binding "$ALLOWED"); rc=$?
+  if [[ "$rc" -ne 0 && "$output" == "allowed_signers has multiple repository binding directives: $ALLOWED" ]]; then
+    pass "multiple repository directives are refused"
+  else
+    fail_case "multiple repository directives are refused" "rc=$rc output=$output"
+  fi
+
+  printf '# updater-repo: %s/other\n' "$identity" >"$ALLOWED"
+  printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$KEY.pub")" >>"$ALLOWED"
+  output=$(validate_fixture_binding "$ALLOWED"); rc=$?
+  if [[ "$rc" -ne 0 && "$output" == "allowed_signers repository binding mismatch: file declares '$identity/other', origin normalizes to '$identity'" ]]; then
+    pass "mismatched repository directive is refused"
+  else
+    fail_case "mismatched repository directive is refused" "rc=$rc output=$output"
+  fi
+
+  printf '# updater-repo: %s\r\n' "$identity" >"$ALLOWED"
+  printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$KEY.pub")" >>"$ALLOWED"
+  output=$(validate_fixture_binding "$ALLOWED"); rc=$?
+  if [[ "$rc" -ne 0 && "$output" == "repository binding directive has trailing whitespace or a CRLF line ending: $ALLOWED" ]]; then
+    pass "CRLF repository directive is refused with the explicit reason"
+  else
+    fail_case "CRLF repository directive is refused with the explicit reason" "rc=$rc output=$output"
+  fi
+
+  printf '# updater-repo: %s \n' "$identity" >"$ALLOWED"
+  printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$KEY.pub")" >>"$ALLOWED"
+  output=$(validate_fixture_binding "$ALLOWED"); rc=$?
+  if [[ "$rc" -ne 0 && "$output" == "repository binding directive has trailing whitespace or a CRLF line ending: $ALLOWED" ]]; then
+    pass "trailing-space repository directive is refused"
+  else
+    fail_case "trailing-space repository directive is refused" "rc=$rc output=$output"
+  fi
+
+  output=$(validate_fixture_binding relative-allowed-signers); rc=$?
+  if [[ "$rc" -ne 0 && "$output" == 'allowed_signers path must be absolute: relative-allowed-signers' ]]; then
+    pass "relative allowed_signers path is refused before filesystem lookup"
+  else
+    fail_case "relative allowed_signers path is refused before filesystem lookup" "rc=$rc output=$output"
+  fi
+
+  new_fixture issue54-signer-snapshot
+  commit_release snapshot-release pass
+  tag_release signed v1.0.0 "$RELEASE_COMMIT"
+  publish_branch_backed_release v1.0.0
+  fetch_local_tag v1.0.0
+  replacement=$BASE/replacement-allowed-signers
+  printf '# updater-repo: %s\n' "$(cd "$ORIGIN" && pwd -P)" >"$replacement"
+  printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$OTHER_KEY.pub")" >>"$replacement"
+  snapshot_output=$(HOME="$HOME_DIR" bash -c '
+    source "$1"
+    trap updater_cleanup_allowed_signers_snapshot EXIT
+    updater_validate_allowed_signers "$2" "$3" || { printf "%s\n" "$UPDATER_VERIFY_REASON"; exit 1; }
+    cp "$4" "$3"
+    updater_capture_verify_and_bind "$2" v1.0.0 "$UPDATER_ALLOWED_SIGNERS_SNAPSHOT" \
+      || { printf "%s\n" "$UPDATER_VERIFY_REASON"; exit 1; }
+    printf "%s\n" "$UPDATER_CAPTURED_COMMIT"
+  ' _ "$ROOT/scripts/lib-updater-verify.sh" "$REPO" "$ALLOWED" "$replacement" 2>&1); snapshot_rc=$?
+  if [[ "$snapshot_rc" -eq 0 && "$snapshot_output" == "$RELEASE_COMMIT" \
+    && ! -e "$HOME_DIR/.claude/state/updater-signers-snapshot" ]]; then
+    pass "verification consumes the validated signer snapshot after source replacement"
+  else
+    fail_case "verification consumes the validated signer snapshot after source replacement" \
+      "rc=$snapshot_rc snapshot-dir=$(test -e "$HOME_DIR/.claude/state/updater-signers-snapshot" && echo yes || echo no) output=$snapshot_output"
+  fi
+}
+
+run_issue54_normalization_cases() {
+  local identity output rc probe_cred token_surface multi_url token_fakebin
+
+  new_fixture issue54-normalization
+  identity=$(cd "$ORIGIN" && pwd -P)
+  for accepted in \
+    'git@GitHub.COM:Org/Repo.git/' \
+    'ssh://git@GitHub.COM:22/Org/Repo.git/' \
+    'https://user:token-value@GitHub.COM:443/Org/Repo.git/'; do
+    output=$(normalize_fixture_url "$accepted"); rc=$?
+    if [[ "$rc" -eq 0 && "$output" == github.com/org/repo && "$output" != *token-value* ]]; then
+      pass "accepted host origin normalizes without userinfo: ${accepted%%:*}"
+    else
+      fail_case "accepted host origin normalizes without userinfo: ${accepted%%:*}" "rc=$rc output=$output"
+    fi
+  done
+  for accepted in "$ORIGIN" "file://$ORIGIN" "file://localhost$ORIGIN"; do
+    output=$(normalize_fixture_url "$accepted"); rc=$?
+    if [[ "$rc" -eq 0 && "$output" == "$identity" ]]; then
+      pass "accepted local origin resolves to its physical path"
+    else
+      fail_case "accepted local origin resolves to its physical path" "rc=$rc output=$output"
+    fi
+  done
+  for refused in \
+    'ssh://git@example.invalid:2222/org/repo.git' \
+    'https://example.invalid:444/org/repo.git' \
+    'ssh://git@[2001:db8::1]:22/org/repo.git' \
+    'git://example.invalid/org/repo.git' \
+    'relative/repo.git' \
+    'file://remotehost/absolute/repo.git' \
+    'https://example.invalid/org/repo.git?mirror=1'; do
+    output=$(normalize_fixture_url "$refused"); rc=$?
+    if [[ "$rc" -ne 0 && "$output" == refused ]]; then
+      pass "unsupported origin shape is refused"
+    else
+      fail_case "unsupported origin shape is refused" "rc=$rc output=$output"
+    fi
+  done
+
+  new_fixture issue54-token-origin
+  probe_cred='issue54-well-formed-token'
+  git -C "$REPO" remote set-url origin "https://user:$probe_cred@example.invalid/org/repo.git"
+  printf '# updater-repo: example.invalid/org/repo\n' >"$ALLOWED"
+  printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$KEY.pub")" >>"$ALLOWED"
+  write_pin v0.0.0 "$BASE_COMMIT"
+  token_fakebin=$BASE/token-fakebin
+  mkdir -p "$token_fakebin"
+  cat >"$token_fakebin/git" <<'TOKEN_GIT_SHIM'
+#!/usr/bin/env bash
+set -u
+if [[ "$*" == *" fetch "* ]]; then
+  printf 'simulated transport failure for %s\n' "$*" >&2
+  exit 71
+fi
+exec "$REAL_GIT" "$@"
+TOKEN_GIT_SHIM
+  chmod +x "$token_fakebin/git"
+  output=$(PATH="$token_fakebin:$PATH" REAL_GIT="$REAL_GIT" run_updater); rc=$?
+  token_surface=$(grep -R -F "$probe_cred" "$HOME_DIR/.claude/state" "$LOGS" 2>/dev/null || true)
+  if [[ "$rc" -ne 0 && "$output" != *"$probe_cred"* && -z "$token_surface" ]] \
+    && printf '%s\n' "$output" | grep -Fq 'branch fetch failed'; then
+    pass "well-formed credential origin is accepted without exposing its token on transport failure"
+  else
+    fail_case "well-formed credential origin is accepted without exposing its token on transport failure" \
+      "rc=$rc output-token=$(case $output in *$probe_cred*) echo yes;; *) echo no;; esac) state-token=$(test -n "$token_surface" && echo yes || echo no)"
+  fi
+
+  new_fixture issue54-malformed-token-origin
+  probe_cred='issue54-secret-token'
+  git -C "$REPO" remote set-url origin "https://user:$probe_cred@[broken/origin.git"
+  write_pin v0.0.0 "$BASE_COMMIT"
+  output=$(run_updater); rc=$?
+  token_surface=$(grep -R -F "$probe_cred" "$HOME_DIR/.claude/state" "$LOGS" 2>/dev/null || true)
+  if [[ "$rc" -ne 0 && "$output" != *"$probe_cred"* && -z "$token_surface" ]] \
+    && printf '%s\n' "$output" | grep -Fq "cannot normalize origin URL for repository binding: $REPO"; then
+    pass "malformed credential origin is refused without exposing its token"
+  else
+    fail_case "malformed credential origin is refused without exposing its token" \
+      "rc=$rc output-token=$(case $output in *$probe_cred*) echo yes;; *) echo no;; esac) state-token=$(test -n "$token_surface" && echo yes || echo no)"
+  fi
+
+  new_fixture issue54-multiple-origin-urls
+  multi_url=$BASE/second-origin.git
+  git init -q --bare "$multi_url"
+  git -C "$REPO" config --add remote.origin.url "$multi_url"
+  output=$(validate_fixture_binding "$ALLOWED"); rc=$?
+  if [[ "$rc" -ne 0 && "$output" == "cannot determine origin URL for repository binding: $REPO" ]]; then
+    pass "multiple origin URLs are refused"
+  else
+    fail_case "multiple origin URLs are refused" "rc=$rc output=$output"
+  fi
+}
+
+run_issue54_reachability_cases() {
+  local candidate_commit expected output rc before anchor_branch
+  local merge_fakebin merge_records wrong_reason revparse_fakebin revparse_records
+  local endpoint_fakebin evil_origin
+
+  new_fixture issue54-tag-only-reachability
+  write_pin v1.0.0 "$BASE_COMMIT"
+  commit_release tag-only-candidate pass
+  candidate_commit=$RELEASE_COMMIT
+  tag_release signed v1.1.0 "$candidate_commit"
+  push_tag_only v1.1.0
+  before=$(git -C "$REPO" rev-parse HEAD)
+  expected="captured commit $candidate_commit is not on release branch origin/$BRANCH"
+  output=$(run_updater); rc=$?
+  if [[ "$rc" -ne 0 && $(git -C "$REPO" rev-parse HEAD) == "$before" \
+    && ! -e "$SENTINEL" ]] && printf '%s\n' "$output" | grep -Fq "$expected"; then
+    pass "tag-only reachable commit is refused"
+  else
+    fail_case "tag-only reachable commit is refused" "rc=$rc output=$output"
+  fi
+
+  new_fixture issue54-pruned-release-anchor
+  write_pin v1.0.0 "$BASE_COMMIT"
+  commit_release anchored-candidate pass
+  candidate_commit=$RELEASE_COMMIT
+  tag_release signed v1.1.0 "$candidate_commit"
+  push_tag_only v1.1.0
+  anchor_branch=release-anchor
+  git -C "$SRC" push -q "$ORIGIN" "HEAD:refs/heads/$anchor_branch"
+  output=$(CATY_UPDATER_RELEASE_BRANCH="$anchor_branch" run_updater --dry-run); rc=$?
+  git -C "$SRC" push -q "$ORIGIN" ":refs/heads/$anchor_branch"
+  output2=$(CATY_UPDATER_RELEASE_BRANCH="$anchor_branch" run_updater --dry-run); rc2=$?
+  if [[ "$rc" -eq 0 && "$rc2" -ne 0 ]] \
+    && printf '%s\n' "$output2" | grep -Fq "release ref refs/remotes/origin/$anchor_branch is unavailable: $REPO" \
+    && ! git -C "$REPO" show-ref --verify --quiet "refs/remotes/origin/$anchor_branch"; then
+    pass "deleted release anchor is pruned and cannot vouch on the next tick"
+  else
+    fail_case "deleted release anchor is pruned and cannot vouch on the next tick" "rc=$rc/$rc2 output=$output output2=$output2"
+  fi
+
+  new_fixture issue54-invalid-release-branch
+  write_pin v1.0.0 "$BASE_COMMIT"
+  commit_release invalid-branch-candidate pass
+  tag_release signed v1.1.0 "$RELEASE_COMMIT"
+  publish_branch_backed_release v1.1.0
+  output=$(CATY_UPDATER_RELEASE_BRANCH='bad..branch' run_updater); rc=$?
+  if [[ "$rc" -ne 0 ]] && printf '%s\n' "$output" | grep -Fq 'invalid release branch name configured' \
+    && printf '%s\n' "$output" | grep -Fqv 'bad..branch'; then
+    pass "invalid release branch config is refused without echoing its value"
+  else
+    fail_case "invalid release branch config is refused without echoing its value" "rc=$rc output=$output"
+  fi
+
+  new_fixture issue54-merge-base-error
+  write_pin v1.0.0 "$BASE_COMMIT"
+  commit_release merge-error-candidate pass
+  candidate_commit=$RELEASE_COMMIT
+  tag_release signed v1.1.0 "$candidate_commit"
+  publish_branch_backed_release v1.1.0
+  merge_fakebin=$BASE/merge-fakebin
+  mkdir -p "$merge_fakebin"
+  cat >"$merge_fakebin/git" <<'MERGE_ERROR_GIT_SHIM'
+#!/usr/bin/env bash
+set -u
+if [[ "$*" == *" merge-base --is-ancestor "* ]]; then
+  exit 71
+fi
+exec "$REAL_GIT" "$@"
+MERGE_ERROR_GIT_SHIM
+  chmod +x "$merge_fakebin/git"
+  expected="reachability check failed (git error) for $candidate_commit against origin/$BRANCH"
+  output=$(PATH="$merge_fakebin:$PATH" REAL_GIT="$REAL_GIT" run_updater); rc=$?
+  merge_records=$(grep -F 'v1.1.0 ' "$(ineligible_path)" 2>/dev/null \
+    | grep -Fc " verification-failure $expected" || true)
+  wrong_reason=$(printf '%s\n' "$output" | grep -Fc 'is not on release branch' || true)
+  if [[ "$rc" -ne 0 && "$merge_records" -eq 1 && "$wrong_reason" -eq 0 ]] \
+    && printf '%s\n' "$output" | grep -Fq "$expected"; then
+    pass "merge-base operational failure has a distinct fatal reason"
+  else
+    fail_case "merge-base operational failure has a distinct fatal reason" \
+      "rc=$rc records=$merge_records wrong-reason=$wrong_reason output=$output"
+  fi
+
+  new_fixture issue54-release-ref-rev-parse-error
+  write_pin v1.0.0 "$BASE_COMMIT"
+  commit_release rev-parse-error-candidate pass
+  candidate_commit=$RELEASE_COMMIT
+  tag_release signed v1.1.0 "$candidate_commit"
+  publish_branch_backed_release v1.1.0
+  revparse_fakebin=$BASE/revparse-fakebin
+  mkdir -p "$revparse_fakebin"
+  cat >"$revparse_fakebin/git" <<'REV_PARSE_ERROR_GIT_SHIM'
+#!/usr/bin/env bash
+set -u
+if [[ "$*" == "-C $REV_PARSE_REPO rev-parse --verify refs/remotes/origin/$REV_PARSE_BRANCH" ]]; then
+  exit 71
+fi
+exec "$REAL_GIT" "$@"
+REV_PARSE_ERROR_GIT_SHIM
+  chmod +x "$revparse_fakebin/git"
+  expected="reachability check failed (git error) for $candidate_commit against origin/$BRANCH"
+  output=$(PATH="$revparse_fakebin:$PATH" REAL_GIT="$REAL_GIT" \
+    REV_PARSE_REPO="$REPO" REV_PARSE_BRANCH="$BRANCH" run_updater); rc=$?
+  revparse_records=$(grep -F 'v1.1.0 ' "$(ineligible_path)" 2>/dev/null \
+    | grep -Fc " verification-failure $expected" || true)
+  wrong_reason=$(printf '%s\n' "$output" | grep -Fc 'release ref refs/remotes/origin/' || true)
+  if [[ "$rc" -ne 0 && "$revparse_records" -eq 1 && "$wrong_reason" -eq 0 ]] \
+    && printf '%s\n' "$output" | grep -Fq "$expected"; then
+    pass "release-ref rev-parse operational failure has the git-error reason"
+  else
+    fail_case "release-ref rev-parse operational failure has the git-error reason" \
+      "rc=$rc records=$revparse_records wrong-reason=$wrong_reason output=$output"
+  fi
+
+  new_fixture issue54-captured-endpoint
+  write_pin v1.0.0 "$BASE_COMMIT"
+  commit_release endpoint-candidate pass
+  candidate_commit=$RELEASE_COMMIT
+  tag_release signed v1.1.0 "$candidate_commit"
+  publish_branch_backed_release v1.1.0
+  evil_origin=$BASE/evil-origin.git
+  git init -q --bare "$evil_origin"
+  endpoint_fakebin=$BASE/endpoint-fakebin
+  mkdir -p "$endpoint_fakebin"
+  cat >"$endpoint_fakebin/git" <<'ENDPOINT_GIT_SHIM'
+#!/usr/bin/env bash
+set -u
+if [[ "$*" == "-C $BIND_REPO remote get-url --all origin" ]]; then
+  output=$($REAL_GIT "$@") || exit $?
+  "$REAL_GIT" -C "$BIND_REPO" remote set-url origin "$EVIL_ORIGIN"
+  printf '%s\n' "$output"
+  exit 0
+fi
+exec "$REAL_GIT" "$@"
+ENDPOINT_GIT_SHIM
+  chmod +x "$endpoint_fakebin/git"
+  output=$(PATH="$endpoint_fakebin:$PATH" REAL_GIT="$REAL_GIT" BIND_REPO="$REPO" \
+    EVIL_ORIGIN="$evil_origin" run_updater); rc=$?
+  if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$candidate_commit" ]]; then
+    pass "network operations stay bound to the endpoint captured at validation"
+  else
+    fail_case "network operations stay bound to the endpoint captured at validation" "rc=$rc output=$output"
+  fi
+}
+
+run_issue54_retry_case() {
+  local candidate_commit expected output rc dedupe_rc recovery_rc
+  local reports failure_heartbeats failure_records clear_records sentinel_lines
+
+  new_fixture issue54-reachability-retry
+  write_pin v1.0.0 "$BASE_COMMIT"
+  commit_release retry-candidate pass
+  candidate_commit=$RELEASE_COMMIT
+  tag_release signed v1.1.0 "$candidate_commit"
+  push_tag_only v1.1.0
+  expected="captured commit $candidate_commit is not on release branch origin/$BRANCH"
+  output=$(run_updater); rc=$?
+  run_updater >/dev/null; dedupe_rc=$?
+  reports=$(grep -Fc 'updater failed: claire repo v1.1.0' "$LOGS/hot-inbox.log" 2>/dev/null || true)
+  failure_heartbeats=$(grep -Fc "job-heartbeat updater-claire fail --reason $expected" \
+    "$LOGS/heartbeats.log" 2>/dev/null || true)
+  git -C "$SRC" push -q "$ORIGIN" "$BRANCH"
+  run_updater >/dev/null; recovery_rc=$?
+  failure_records=$(grep -F 'v1.1.0 ' "$(ineligible_path)" 2>/dev/null \
+    | grep -Fc ' verification-failure captured commit ' || true)
+  clear_records=$(grep -F 'v1.1.0 ' "$(ineligible_path)" 2>/dev/null \
+    | grep -Fc ' verification-failure-cleared' || true)
+  sentinel_lines=0
+  [[ ! -f "$SENTINEL" ]] || sentinel_lines=$(wc -l <"$SENTINEL")
+  if [[ "$rc" -ne 0 && "$dedupe_rc" -ne 0 && "$recovery_rc" -eq 0 \
+    && "$reports" -eq 1 && "$failure_heartbeats" -eq 1 \
+    && "$failure_records" -eq 1 && "$clear_records" -eq 1 \
+    && "$sentinel_lines" -eq 1 && $(git -C "$REPO" rev-parse HEAD) == "$candidate_commit" ]]; then
+    pass "reachability refusal deduplicates, retries, clears, and installs after branch recovery"
+  else
+    fail_case "reachability refusal deduplicates, retries, clears, and installs after branch recovery" \
+      "rc=$rc/$dedupe_rc/$recovery_rc reports=$reports heartbeats=$failure_heartbeats records=$failure_records clears=$clear_records installs=$sentinel_lines output=$output"
+  fi
+}
+
+case "${ISSUE54_REPLAY_CASE:-all}" in
+  updater)
+    run_issue54_updater_replay_case
+    printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+    [[ "$FAIL_COUNT" -eq 0 ]]
+    exit $?
+    ;;
+  bootstrap)
+    run_issue54_bootstrap_replay_case
+    printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+    [[ "$FAIL_COUNT" -eq 0 ]]
+    exit $?
+    ;;
+  binding)
+    run_issue54_binding_cases
+    printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+    [[ "$FAIL_COUNT" -eq 0 ]]
+    exit $?
+    ;;
+  normalization)
+    run_issue54_normalization_cases
+    printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+    [[ "$FAIL_COUNT" -eq 0 ]]
+    exit $?
+    ;;
+  reachability)
+    run_issue54_reachability_cases
+    printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+    [[ "$FAIL_COUNT" -eq 0 ]]
+    exit $?
+    ;;
+  retry)
+    run_issue54_retry_case
+    printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+    [[ "$FAIL_COUNT" -eq 0 ]]
+    exit $?
+    ;;
+  none)
+    ;;
+  all)
+    run_issue54_updater_replay_case
+    run_issue54_bootstrap_replay_case
+    run_issue54_binding_cases
+    run_issue54_normalization_cases
+    run_issue54_reachability_cases
+    run_issue54_retry_case
+    ;;
+  *)
+    printf 'unknown ISSUE54_REPLAY_CASE: %s (expected updater, bootstrap, binding, normalization, reachability, retry, or none)\n' \
+      "$ISSUE54_REPLAY_CASE" >&2
+    exit 2
+    ;;
+esac
+
 new_fixture delta4-startup-pin-dedupe
 tag_release signed v1.0.0 "$BASE_COMMIT"
-push_tag v1.0.0
+publish_branch_backed_release v1.0.0
 fetch_local_tag v1.0.0
 startup_output=
 startup_rcs=
@@ -210,14 +767,14 @@ new_fixture delta4-dry-run-diagnostic
 commit_release installed pass
 installed_commit=$RELEASE_COMMIT
 tag_release signed v1.0.0 "$installed_commit"
-push_tag v1.0.0
+publish_branch_backed_release v1.0.0
 fetch_local_tag v1.0.0
 git -C "$REPO" checkout -q --detach "$installed_commit"
 append_ok_ledger v1.0.0
 ledger_before=$(cksum "$(ledger_path)")
 commit_release rejected pass
 tag_release unsigned v1.1.0 "$RELEASE_COMMIT"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 output=$(run_updater --dry-run); rc=$?
 ledger_after=$(cksum "$(ledger_path)")
 if [[ "$rc" -eq 0 && "$ledger_before" == "$ledger_after" \
@@ -255,7 +812,7 @@ make_candidate() {
       tag_release "$kind" "$CANDIDATE_TAG" "$CANDIDATE_COMMIT"
     fi
   fi
-  push_tag "$CANDIDATE_TAG"
+  publish_branch_backed_release "$CANDIDATE_TAG"
 }
 
 if [[ "${SKIP_DELTA2_CASES:-0}" == 0 ]]; then
@@ -266,17 +823,17 @@ if [[ "${SKIP_DELTA2_CASES:-0}" == 0 ]]; then
     commit_release installed pass
     installed_commit=$RELEASE_COMMIT
     tag_release signed v0.2.3 "$installed_commit"
-    push_tag v0.2.3
+    publish_branch_backed_release v0.2.3
     fetch_local_tag v0.2.3
     git -C "$REPO" checkout -q --detach "$installed_commit"
     append_ok_ledger v0.2.3
     tag_release "$poison_kind" v99.0.0 "$installed_commit"
-    push_tag v99.0.0
+    publish_branch_backed_release v99.0.0
     fetch_local_tag v99.0.0
     commit_release genuine pass
     genuine_commit=$RELEASE_COMMIT
     tag_release signed v0.3.0 "$genuine_commit"
-    push_tag v0.3.0
+    publish_branch_backed_release v0.3.0
     output=$(run_updater); rc=$?
     if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$genuine_commit" ]] \
       && grep -Fq '"version":"v0.3.0"' "$(pin_path)"; then
@@ -288,7 +845,7 @@ if [[ "${SKIP_DELTA2_CASES:-0}" == 0 ]]; then
 
   new_fixture delta2-floor-no-ledger
   tag_release lightweight v99.0.0 "$BASE_COMMIT"
-  push_tag v99.0.0
+  publish_branch_backed_release v99.0.0
   fetch_local_tag v99.0.0
   output=$(run_updater); rc=$?
   if [[ "$rc" -ne 0 && ! -e "$(pin_path)" ]] \
@@ -302,14 +859,14 @@ if [[ "${SKIP_DELTA2_CASES:-0}" == 0 ]]; then
   commit_release installed pass
   installed_commit=$RELEASE_COMMIT
   tag_release signed v1.0.0 "$installed_commit"
-  push_tag v1.0.0
+  publish_branch_backed_release v1.0.0
   fetch_local_tag v1.0.0
   git -C "$REPO" checkout -q --detach "$installed_commit"
   append_ok_ledger v1.0.0
   ledger_before=$(cksum "$(ledger_path)")
   commit_release invalid pass
   tag_release unsigned v1.1.0 "$RELEASE_COMMIT"
-  push_tag v1.1.0
+  publish_branch_backed_release v1.1.0
   output=$(run_updater --dry-run); rc=$?
   ledger_after=$(cksum "$(ledger_path)")
   if [[ "$rc" -eq 0 && "$ledger_before" == "$ledger_after" \
@@ -328,11 +885,11 @@ if [[ "${SKIP_DELTA2_CASES:-0}" == 0 ]]; then
   commit_release genuine pass
   genuine_commit=$RELEASE_COMMIT
   tag_release lightweight latest "$genuine_commit"
-  push_tag latest
+  publish_branch_backed_release latest
   tag_release lightweight v1.2.3-rc1 "$genuine_commit"
-  push_tag v1.2.3-rc1
+  publish_branch_backed_release v1.2.3-rc1
   tag_release signed v0.3.0 "$genuine_commit"
-  push_tag v0.3.0
+  publish_branch_backed_release v0.3.0
   output=$(run_updater); rc=$?
   first_head=$(git -C "$REPO" rev-parse HEAD)
   parse_rcs=$rc
@@ -365,7 +922,7 @@ if [[ "${SKIP_DELTA2_CASES:-0}" == 0 ]]; then
   cat >"$parse_fakebin/git" <<'PARSE_GIT_SHIM'
 #!/usr/bin/env bash
 set -u
-if [[ "$*" == *" ls-remote --refs --tags origin"* ]]; then
+if [[ "$*" == *" ls-remote --refs --tags "* ]]; then
   output=$($REAL_GIT "$@") || exit $?
   printf '%s\n' "$output"
   first=$(printf '%s\n' "$output" | sed -n '1p')
@@ -390,7 +947,7 @@ PARSE_GIT_SHIM
     write_pin v0.0.0 "$BASE_COMMIT"
     commit_release candidate pass
     tag_release signed v1.1.0 "$RELEASE_COMMIT"
-    push_tag v1.1.0
+    publish_branch_backed_release v1.1.0
     before=$(git -C "$REPO" rev-parse HEAD)
     parse_rcs=
     for tick in 1 2 3; do
@@ -421,7 +978,7 @@ PARSE_GIT_SHIM
   commit_release genuine pass
   genuine_commit=$RELEASE_COMMIT
   tag_release signed v0.3.0 "$genuine_commit"
-  push_tag v0.3.0
+  publish_branch_backed_release v0.3.0
   output=$(PATH="$parse_fakebin:$PATH" REAL_GIT="$REAL_GIT" INJECT_NONSEMVER_DUP=1 run_updater); rc=$?
   reports=$(grep -Fc 'latest' "$LOGS/hot-inbox.log" 2>/dev/null || true)
   ineligible_records=$(grep -Fc 'latest' "$(ineligible_path)" 2>/dev/null || true)
@@ -440,14 +997,14 @@ PARSE_GIT_SHIM
   commit_release installed pass
   installed_commit=$RELEASE_COMMIT
   tag_release signed v1.0.0 "$installed_commit"
-  push_tag v1.0.0
+  publish_branch_backed_release v1.0.0
   fetch_local_tag v1.0.0
   git -C "$REPO" checkout -q --detach "$installed_commit"
   write_pin v1.0.0 "$installed_commit"
   commit_release broken fail
   broken_commit=$RELEASE_COMMIT
   tag_release signed v1.1.0 "$broken_commit"
-  push_tag v1.1.0
+  publish_branch_backed_release v1.1.0
   install_rcs=
   for tick in 1 2 3; do
     run_updater >/dev/null
@@ -479,10 +1036,10 @@ PARSE_GIT_SHIM
   new_fixture delta2-atomic-second
   commit_release first pass
   tag_release signed v1.1.0 "$RELEASE_COMMIT"
-  push_tag v1.1.0
+  publish_branch_backed_release v1.1.0
   commit_release second pass
   tag_release signed v1.2.0 "$RELEASE_COMMIT"
-  push_tag v1.2.0
+  publish_branch_backed_release v1.2.0
   write_pin v1.0.0 "$BASE_COMMIT"
   atomic_fakebin=$BASE/atomic-fakebin
   atomic_counter=$BASE/atomic-counter
@@ -537,7 +1094,7 @@ run_side_path_variant() {
     CANDIDATE_COMMIT=$RELEASE_COMMIT
     CANDIDATE_TAG=v1.1.0
     tag_release signed "$CANDIDATE_TAG" "$CANDIDATE_COMMIT"
-    push_tag "$CANDIDATE_TAG"
+    publish_branch_backed_release "$CANDIDATE_TAG"
   else
     make_candidate "$kind"
   fi
@@ -588,7 +1145,7 @@ if [[ "${BASELINE_FOCUSED:-0}" == 1 ]]; then
   commit_release old-moved pass
   old_commit=$RELEASE_COMMIT
   tag_release signed v1.1.0 "$old_commit"
-  push_tag v1.1.0
+  publish_branch_backed_release v1.1.0
   fetch_local_tag v1.1.0
   git -C "$SRC" tag -d v1.1.0 >/dev/null
   commit_release moved pass
@@ -597,7 +1154,7 @@ if [[ "${BASELINE_FOCUSED:-0}" == 1 ]]; then
   commit_release legitimate pass
   legitimate_commit=$RELEASE_COMMIT
   tag_release signed v1.2.0 "$legitimate_commit"
-  push_tag v1.2.0
+  publish_branch_backed_release v1.2.0
   write_pin v1.0.0 "$BASE_COMMIT"
   output=$(run_updater); rc=$?
   if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$legitimate_commit" ]]; then
@@ -610,12 +1167,12 @@ if [[ "${BASELINE_FOCUSED:-0}" == 1 ]]; then
   commit_release rollback-base pass
   rollback_commit=$RELEASE_COMMIT
   tag_release signed v1.0.0 "$rollback_commit"
-  push_tag v1.0.0
+  publish_branch_backed_release v1.0.0
   fetch_local_tag v1.0.0
   git -C "$REPO" checkout -q --detach "$rollback_commit"
   commit_release broken-target fail
   tag_release signed v1.1.0 "$RELEASE_COMMIT"
-  push_tag v1.1.0
+  publish_branch_backed_release v1.1.0
   write_pin v1.0.0 "$rollback_commit"
   baseline_fakebin=$BASE/fakebin
   mismatch_state=$BASE/mismatch-count
@@ -669,7 +1226,7 @@ new_fixture legacy-lightweight
 commit_release legacy pass
 CANDIDATE_COMMIT=$RELEASE_COMMIT
 tag_release lightweight v0.2.2 "$CANDIDATE_COMMIT"
-push_tag v0.2.2
+publish_branch_backed_release v0.2.2
 write_pin v0.1.0 "$BASE_COMMIT"
 before=$(git -C "$REPO" rev-parse HEAD)
 output=$(run_updater); rc=$?
@@ -685,7 +1242,7 @@ new_fixture numeric-floor
 commit_release numeric pass
 numeric_commit=$RELEASE_COMMIT
 tag_release signed v0.10.0 "$numeric_commit"
-push_tag v0.10.0
+publish_branch_backed_release v0.10.0
 write_pin v0.9.0 "$BASE_COMMIT"
 output=$(run_updater); rc=$?
 if [[ "$rc" -eq 0 && $(git -C "$REPO" rev-parse HEAD) == "$numeric_commit" ]]; then
@@ -699,7 +1256,7 @@ new_fixture numeric-floor-reverse
 commit_release lower-numeric pass
 lower_numeric_commit=$RELEASE_COMMIT
 tag_release signed v0.9.0 "$lower_numeric_commit"
-push_tag v0.9.0
+publish_branch_backed_release v0.9.0
 write_pin v0.10.0 "$BASE_COMMIT"
 before=$(git -C "$REPO" rev-parse HEAD)
 output=$(run_updater); rc=$?
@@ -717,7 +1274,7 @@ commit_release old-moved pass
 old_moved_commit=$RELEASE_COMMIT
 tag_release signed v1.1.0 "$old_moved_commit"
 old_moved_oid=$(git -C "$SRC" rev-parse refs/tags/v1.1.0)
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 fetch_local_tag v1.1.0
 git -C "$SRC" tag -d v1.1.0 >/dev/null
 commit_release moved-content pass
@@ -727,7 +1284,7 @@ force_push_tag v1.1.0
 commit_release legitimate pass
 legit_commit=$RELEASE_COMMIT
 tag_release signed v1.2.0 "$legit_commit"
-push_tag v1.2.0
+publish_branch_backed_release v1.2.0
 write_pin v1.0.0 "$BASE_COMMIT"
 output=$(run_updater); rc=$?
 first_reports=$(grep -Fc "updater failed: claire repo v1.1.0" "$LOGS/hot-inbox.log" 2>/dev/null || true)
@@ -747,7 +1304,7 @@ new_fixture two-moved
 for moved_name in v1.1.0 v1.2.0; do
   commit_release "old-$moved_name" pass
   tag_release signed "$moved_name" "$RELEASE_COMMIT"
-  push_tag "$moved_name"
+  publish_branch_backed_release "$moved_name"
   fetch_local_tag "$moved_name"
 done
 for moved_name in v1.1.0 v1.2.0; do
@@ -759,7 +1316,7 @@ done
 commit_release valid-newer pass
 valid_newer_commit=$RELEASE_COMMIT
 tag_release signed v1.3.0 "$valid_newer_commit"
-push_tag v1.3.0
+publish_branch_backed_release v1.3.0
 write_pin v1.0.0 "$BASE_COMMIT"
 run_updater >/dev/null; rc=$?
 run_updater >/dev/null; rc2=$?
@@ -778,14 +1335,14 @@ new_fixture signer-rotation-recovery
 commit_release installed-key-a pass
 floor_commit=$RELEASE_COMMIT
 tag_release signed v0.2.3 "$floor_commit"
-push_tag v0.2.3
+publish_branch_backed_release v0.2.3
 fetch_local_tag v0.2.3
 git -C "$REPO" checkout -q --detach "$floor_commit"
 write_pin v0.2.3 "$floor_commit"
 commit_release rotated-key-b pass
 rotated_commit=$RELEASE_COMMIT
 tag_release unpinned v0.3.0 "$rotated_commit"
-push_tag v0.3.0
+publish_branch_backed_release v0.3.0
 
 output=$(run_updater); rc=$?
 first_reports=$(grep -Fc "updater failed: claire repo v0.3.0" "$LOGS/hot-inbox.log" 2>/dev/null || true)
@@ -800,7 +1357,7 @@ clear_records=$(grep -F 'v0.3.0 ' "$(ineligible_path)" 2>/dev/null | grep -Fc ' 
 
 # Remove key B again: because the successful tick cleared the dedupe state,
 # this later failure must emit a fresh report.
-printf 'fixture@example.invalid %s\n' "$(sed -n '1p' "$KEY.pub")" >"$ALLOWED"
+write_allowed_signers_for_key "$KEY.pub"
 run_updater >/dev/null; rc3=$?
 third_reports=$(grep -Fc "updater failed: claire repo v0.3.0" "$LOGS/hot-inbox.log" 2>/dev/null || true)
 sentinel_lines=0
@@ -846,7 +1403,7 @@ chmod +x "$FAKEBIN/git"
 new_fixture ls-remote-failure
 commit_release candidate pass
 tag_release signed v1.1.0 "$RELEASE_COMMIT"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 write_pin v1.0.0 "$BASE_COMMIT"
 before=$(git -C "$REPO" rev-parse HEAD)
 output=$(PATH="$FAKEBIN:$PATH" REAL_GIT="$REAL_GIT" FAKE_LS_REMOTE=1 run_updater); rc=$?
@@ -862,13 +1419,13 @@ new_fixture rollback-success
 commit_release rollback-base pass
 rollback_commit=$RELEASE_COMMIT
 tag_release signed v1.0.0 "$rollback_commit"
-push_tag v1.0.0
+publish_branch_backed_release v1.0.0
 fetch_local_tag v1.0.0
 git -C "$REPO" checkout -q --detach "$rollback_commit"
 commit_release broken-target fail
 broken_commit=$RELEASE_COMMIT
 tag_release signed v1.1.0 "$broken_commit"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 write_pin v1.0.0 "$rollback_commit"
 output=$(run_updater); rc=$?
 sentinel_lines=$(wc -l <"$SENTINEL" 2>/dev/null || printf '0')
@@ -883,12 +1440,12 @@ new_fixture rollback-identity-mismatch
 commit_release rollback-base pass
 rollback_commit=$RELEASE_COMMIT
 tag_release signed v1.0.0 "$rollback_commit"
-push_tag v1.0.0
+publish_branch_backed_release v1.0.0
 fetch_local_tag v1.0.0
 git -C "$REPO" checkout -q --detach "$rollback_commit"
 commit_release broken-target fail
 tag_release signed v1.1.0 "$RELEASE_COMMIT"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 write_pin v1.0.0 "$rollback_commit"
 MISMATCH_STATE=$BASE/mismatch-count
 output=$(PATH="$FAKEBIN:$PATH" REAL_GIT="$REAL_GIT" MISMATCH_REPO="$REPO" MISMATCH_STATE="$MISMATCH_STATE" run_updater); rc=$?
@@ -904,7 +1461,7 @@ new_fixture stable-soak-skip
 commit_release fresh pass
 fresh_commit=$RELEASE_COMMIT
 tag_release signed v1.1.0 "$fresh_commit" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 write_pin v1.0.0 "$BASE_COMMIT"
 before=$(git -C "$REPO" rev-parse HEAD)
 output=$(HOME="$HOME_DIR" UPDATER_INSTALL_SENTINEL="$SENTINEL" "$UPDATER" \
@@ -945,7 +1502,7 @@ new_fixture stale-lock
 commit_release candidate pass
 stale_lock_commit=$RELEASE_COMMIT
 tag_release signed v1.1.0 "$stale_lock_commit"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 write_pin v1.0.0 "$BASE_COMMIT"
 mkdir "$REPO/.family-updater.lock"
 printf '%s\n' 999999 >"$REPO/.family-updater.lock/pid"
@@ -960,7 +1517,7 @@ fi
 new_fixture dirty-worktree
 commit_release candidate pass
 tag_release signed v1.1.0 "$RELEASE_COMMIT"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 write_pin v1.0.0 "$BASE_COMMIT"
 printf 'local change\n' >>"$REPO/VERSION.fixture"
 before=$(git -C "$REPO" rev-parse HEAD)
@@ -978,7 +1535,7 @@ new_fixture already-current
 commit_release current pass
 current_commit=$RELEASE_COMMIT
 tag_release signed v1.1.0 "$current_commit"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 fetch_local_tag v1.1.0
 git -C "$REPO" checkout -q --detach "$current_commit"
 write_pin v1.1.0 "$current_commit"
@@ -994,7 +1551,7 @@ new_fixture missing-reporter
 commit_release candidate pass
 missing_reporter_commit=$RELEASE_COMMIT
 tag_release signed v1.1.0 "$missing_reporter_commit"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 write_pin v1.0.0 "$BASE_COMMIT"
 FMA=$BASE/missing-fma
 output=$(run_updater); rc=$?
@@ -1009,7 +1566,7 @@ new_fixture failing-reporter
 commit_release candidate pass
 failing_reporter_commit=$RELEASE_COMMIT
 tag_release signed v1.1.0 "$failing_reporter_commit"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 write_pin v1.0.0 "$BASE_COMMIT"
 cat >"$FMA/job-heartbeat" <<'FAILING_REPORTER'
 #!/usr/bin/env bash
@@ -1028,13 +1585,13 @@ new_fixture rollback-also-fails
 commit_release failing-base fail
 failing_base_commit=$RELEASE_COMMIT
 tag_release signed v1.0.0 "$failing_base_commit"
-push_tag v1.0.0
+publish_branch_backed_release v1.0.0
 fetch_local_tag v1.0.0
 git -C "$REPO" checkout -q --detach "$failing_base_commit"
 write_pin v1.0.0 "$failing_base_commit"
 commit_release broken-target fail
 tag_release signed v1.1.0 "$RELEASE_COMMIT"
-push_tag v1.1.0
+publish_branch_backed_release v1.1.0
 output=$(run_updater); rc=$?
 report_lines=$(wc -l <"$LOGS/hot-inbox.log" 2>/dev/null || printf '0')
 if [[ "$rc" -ne 0 && $(git -C "$REPO" rev-parse HEAD) == "$failing_base_commit" \
@@ -1063,11 +1620,11 @@ new_fixture bootstrap-exact
 commit_release owner-initial pass
 owner_commit=$RELEASE_COMMIT
 tag_release signed v1.0.0 "$owner_commit"
-push_tag v1.0.0
+publish_branch_backed_release v1.0.0
 commit_release newer-not-selected pass
 newer_commit=$RELEASE_COMMIT
 tag_release signed v2.0.0 "$newer_commit"
-push_tag v2.0.0
+publish_branch_backed_release v2.0.0
 fetch_local_tag v1.0.0
 fetch_local_tag v2.0.0
 cron_dest=$BASE/cron/family-updater
@@ -1085,7 +1642,7 @@ new_fixture bootstrap-cron-retry
 commit_release retry-owner pass
 retry_commit=$RELEASE_COMMIT
 tag_release signed v1.0.0 "$retry_commit"
-push_tag v1.0.0
+publish_branch_backed_release v1.0.0
 fetch_local_tag v1.0.0
 blocked_parent=$BASE/cron-parent
 printf 'not a directory\n' >"$blocked_parent"
@@ -1109,7 +1666,7 @@ new_fixture bootstrap-different-pin
 commit_release different-pin-owner pass
 different_pin_commit=$RELEASE_COMMIT
 tag_release signed v1.0.0 "$different_pin_commit"
-push_tag v1.0.0
+publish_branch_backed_release v1.0.0
 fetch_local_tag v1.0.0
 write_pin v1.0.0 "$BASE_COMMIT"
 before=$(git -C "$REPO" rev-parse HEAD)
@@ -1127,7 +1684,7 @@ new_fixture bootstrap-substituted
 commit_release attacker-content pass
 attacker_commit=$RELEASE_COMMIT
 tag_release unsigned v1.0.0 "$attacker_commit"
-push_tag v1.0.0
+publish_branch_backed_release v1.0.0
 fetch_local_tag v1.0.0
 before=$(git -C "$REPO" rev-parse HEAD)
 output=$(HOME="$HOME_DIR" "$BOOTSTRAP" --repo-dir "$REPO" --allowed-signers "$ALLOWED" --initial-tag v1.0.0 2>&1); rc=$?
@@ -1144,7 +1701,7 @@ genuine_commit=$RELEASE_COMMIT
 tag_release signed v1.0.0 "$genuine_commit"
 genuine_oid=$(git -C "$SRC" rev-parse refs/tags/v1.0.0)
 git -C "$SRC" update-ref refs/tags/v9.9.9 "$genuine_oid"
-push_tag v9.9.9
+publish_branch_backed_release v9.9.9
 fetch_local_tag v9.9.9
 before=$(git -C "$REPO" rev-parse HEAD)
 rebound_cron_dest=$BASE/cron/family-updater


### PR DESCRIPTION
Closes #54.

This PR exists to collect CI. Per the repository's identity rule the merge is performed locally and pushed; this PR is closed by hand afterwards.

## What was broken

The gate bound a verified tag to a **name** and a **key**, never to a **repository**. A tag from an unrelated repository, signed with the same pinned key and pushed into this origin, passed every check honestly and executed the foreign project's `install.sh`.

Reproduced through both real entry points before the fix (red evidence captured):

- recurring updater: HEAD moved to the foreign commit (`348320e…` instead of the legitimate `0246e0f…`), `installs=1`
- bootstrap: `pin=yes wrapper=yes` — the foreign tree was pinned and its cron wrapper installed

## What ships

**Mechanism A — repository binding (configuration wiring).** `allowed_signers` must declare its repository with a single `# updater-repo: <identity>` directive matched against the clone's normalized origin identity. The signers path must be absolute, which closes a pre-existing split where a relative path resolved against the updater cwd for the shell checks but against the repo for `verify-tag`. The validated file is consumed as an immutable 0600 snapshot, and the effective origin URL is captured once so every later fetch and listing uses that endpoint rather than the mutable remote name.

**Mechanism B — release-ref reachability (the enforcement that closes the attack).** A candidate's captured commit must be reachable from the fetched release branch (`CATY_UPDATER_RELEASE_BRANCH`, default `main`). Refusals are per-candidate and retryable — never a permanent exclusion class, never a run abort — so one foreign tag cannot stop a legitimate release from installing on the same tick. Bootstrap fetches branches and applies the same assertion before checkout, pin write, and wrapper install.

Mechanism A alone does not close #54: it binds a *file* to a clone, not a tag to a repository. That framing was corrected during review, and the security claims in the docs are narrowed to match. Per-repository signing keys remain the cryptographic boundary, now with a migration preflight that checks key disjointness across repositories.

## What did not change

`updater_capture_verify_and_bind`, `updater_check_floor`, `updater_check_capabilities`, and `updater_checkout_captured_commit` are byte-identical to baseline (SHA-256 compared). `.github/workflows/ci-matrix.yml` and `Makefile` are untouched, so the git-2.34 cell's capability assertions stay valid.

Reasons never carry a raw origin URL, so a credential-bearing remote cannot leak into stderr, state logs, heartbeats, or hot-inbox reports.

## Verification

- red evidence: both replay paths accepted the foreign release before the change
- `make test`: 964 PASS / 0 FAIL / zero `SKIP`-prefixed lines (floor is 931); updater suite alone 88 PASS / 0 FAIL
- `make lint`: 64 shell files OK
- credential probe: refusal with the token absent from every output, state, heartbeat, and report surface

## Review record

Design was frozen before implementation (L1-9) across two rounds plus a delta. Round 1: GLM GO with amendments; Fable, Grok, Opus, and Codex NO-GO. Their convergent findings — that Mechanism A does not touch the reproduced attack, that the consumer wiring is in-tree and had to be edited in this lane, that the fixture contract made the original test plan unimplementable, and that refusals needed the retryable class — were adopted in memo v2. Delta round closed the rest (endpoint binding, reconciled report contract, migration preflight).

Final design verdicts: **GLM 5.3, Grok 4.6, Codex Sol, Kimi K3, Qwen 3.8 Max — all GO.** The Opus and Fable seats were lost to a shared session limit mid-lane; Kimi and Qwen were seated as owner-directed substitutes, which made the panel five mutually distinct model families.

Operators must migrate before updating: append the directive to each `allowed_signers` file and publish release tags on commits already on the release branch. `docs/updater-rollout.md` carries the preflight, the recovery procedure, and the list of deployment shapes the gate deliberately refuses.
