### PR TITLE
fix: reason-line hygiene for the verifier reply paths (#76)

### DIFF
--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -189,11 +189,15 @@ The rules there apply in addition to the Hermes-specific wiring below.
 
    Operational contract: the example providers and wrapper forward only the validated
    verdict and reason lines. They normalize each model-reply line by removing a trailing
-   carriage return and trailing whitespace, require exactly one anchored allowed verdict
-   line anywhere in the reply, and require exactly one `VERDICT:` occurrence across the
-   entire model reply. Before line parsing or normalization, they reject any NUL byte
-   anywhere in the provider/model reply. The reason is the first nonempty normalized line
-   after the verdict. Missing or ambiguous verdicts and missing reasons fail closed.
+   carriage return and trailing ASCII whitespace, and remove DEL plus all C0 controls
+   except TAB from the emitted reason; a mid-line TAB is preserved. They require exactly
+   one anchored allowed verdict line anywhere in the reply and exactly one `VERDICT:`
+   occurrence across the entire model reply; before line parsing or normalization, they
+   reject any NUL byte
+   anywhere in the provider/model reply. The reason is the first line after the verdict
+   that is nonempty after ignoring ASCII whitespace and the explicit U+00A0, U+3000, and
+   U+200B sequences; those Unicode sequences remain byte-preserved in an accepted nonempty
+   reason, while missing or ambiguous verdicts and missing reasons fail closed.
    Findings before the verdict and
    content after the selected reason are intentionally discarded to remove an injection
    surface; that body cannot be recovered from these examples. The provider prompts align

--- a/adapters/hermes/examples/verifier-provider-cli.sh
+++ b/adapters/hermes/examples/verifier-provider-cli.sh
@@ -134,6 +134,19 @@ if ! LC_ALL=C awk '
     }
     return count
   }
+  function sanitize_reason(line) {
+    gsub(/[\001-\010\013-\037\177]/, "", line)
+    sub(/[[:space:]]+$/, "", line)
+    return line
+  }
+  function reason_is_empty(line, scratch) {
+    scratch = line
+    gsub(/[[:space:]]/, "", scratch)
+    gsub(/\302\240/, "", scratch)
+    gsub(/\343\200\200/, "", scratch)
+    gsub(/\342\200\213/, "", scratch)
+    return scratch == ""
+  }
   {
     sub(/\r$/, "")
     sub(/[[:space:]]+$/, "")
@@ -150,9 +163,10 @@ if ! LC_ALL=C awk '
       exit 1
     }
     for (line = verdict_number + 1; line <= NR; line++) {
-      if (lines[line] != "") {
+      reason = sanitize_reason(lines[line])
+      if (!reason_is_empty(reason)) {
         print verdict
-        print lines[line]
+        print reason
         exit 0
       }
     }

--- a/adapters/hermes/examples/verifier-provider.py
+++ b/adapters/hermes/examples/verifier-provider.py
@@ -17,11 +17,30 @@ SYSTEM_PROMPT = """You are an independent artifact verifier. The user message co
 VERDICT_PATTERN = re.compile(
     r"^VERDICT: (pass|fail|inconclusive|rubric-invalid|needs-human|blocked-missing-artifact)$"
 )
+REASON_CONTROL_PATTERN = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+EMPTY_REASON_BYTES = (
+    b" ",
+    b"\t",
+    b"\v",
+    b"\f",
+    b"\r",
+    b"\xc2\xa0",
+    b"\xe3\x80\x80",
+    b"\xe2\x80\x8b",
+)
 
 
 def fail(message: str) -> NoReturn:
     print(message, file=sys.stderr)
     raise SystemExit(1)
+
+
+def normalize_reason(line: str) -> str:
+    reason = REASON_CONTROL_PATTERN.sub("", line).rstrip("\r\t\v\f ")
+    scratch = reason.encode("utf-8")
+    for empty_bytes in EMPTY_REASON_BYTES:
+        scratch = scratch.replace(empty_bytes, b"")
+    return "" if not scratch else reason
 
 
 class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
@@ -131,10 +150,11 @@ if marker_count != 1 or len(verdict_indexes) != 1:
     fail("provider returned malformed output")
 
 verdict_index = verdict_indexes[0]
-reason = next(
-    (line for line in normalized_lines[verdict_index + 1 :] if line),
-    "",
-)
+reason = ""
+for line in normalized_lines[verdict_index + 1 :]:
+    reason = normalize_reason(line)
+    if reason:
+        break
 if not reason:
     fail("provider returned malformed output")
 

--- a/adapters/hermes/examples/verifier-wrapper.sh
+++ b/adapters/hermes/examples/verifier-wrapper.sh
@@ -47,6 +47,19 @@ if ! LC_ALL=C awk '
     }
     return count
   }
+  function sanitize_reason(line) {
+    gsub(/[\001-\010\013-\037\177]/, "", line)
+    sub(/[[:space:]]+$/, "", line)
+    return line
+  }
+  function reason_is_empty(line, scratch) {
+    scratch = line
+    gsub(/[[:space:]]/, "", scratch)
+    gsub(/\302\240/, "", scratch)
+    gsub(/\343\200\200/, "", scratch)
+    gsub(/\342\200\213/, "", scratch)
+    return scratch == ""
+  }
   {
     sub(/\r$/, "")
     sub(/[[:space:]]+$/, "")
@@ -63,9 +76,10 @@ if ! LC_ALL=C awk '
       exit 1
     }
     for (line = verdict_number + 1; line <= NR; line++) {
-      if (lines[line] != "") {
+      reason = sanitize_reason(lines[line])
+      if (!reason_is_empty(reason)) {
         print verdict
-        print lines[line]
+        print reason
         exit 0
       }
     }

--- a/adapters/hermes/verify-job.sh
+++ b/adapters/hermes/verify-job.sh
@@ -14,7 +14,24 @@ infra_fail() {
 }
 
 trim_line() {
-  printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+  printf '%s' "$1" \
+    | LC_ALL=C tr -d '\001-\010\013-\037\177' \
+    | LC_ALL=C sed 's/[[:space:]]*$//'
+}
+
+reason_is_empty() {
+  local scratch
+
+  scratch=$(trim_line "$1")
+  scratch=$(printf '%s' "$scratch" | LC_ALL=C tr -d '[:space:]' | LC_ALL=C awk '
+    {
+      gsub(/\302\240/, "")
+      gsub(/\343\200\200/, "")
+      gsub(/\342\200\213/, "")
+      printf "%s", $0
+    }
+  ')
+  [[ -z "$scratch" ]]
 }
 
 ensure_log() {
@@ -351,7 +368,7 @@ else
     verdict=${verdict_line#VERDICT: }
     case "$verdict" in
       pass|fail|inconclusive|rubric-invalid|needs-human|blocked-missing-artifact)
-        if [[ -z "$(trim_line "$reason")" ]]; then
+        if reason_is_empty "$reason"; then
           reason="verifier response missing one-line reason"
         fi
         ;;

--- a/tests/hermes-verifier-cli.test.sh
+++ b/tests/hermes-verifier-cli.test.sh
@@ -146,6 +146,33 @@ case "$mode" in
   no-following-reason)
     printf 'VERDICT: pass\n \t \n'
     ;;
+  nbsp-only-reason)
+    printf 'VERDICT: pass\n\302\240\n'
+    ;;
+  ideographic-space-only-reason)
+    printf 'VERDICT: pass\n\343\200\200\n'
+    ;;
+  zwsp-only-reason)
+    printf 'VERDICT: pass\n\342\200\213\n'
+    ;;
+  unicode-ascii-space-only-reason)
+    printf 'VERDICT: pass\n\302\240\t \302\240\n'
+    ;;
+  japanese-reason)
+    printf 'VERDICT: pass\n\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261\n'
+    ;;
+  unicode-spaces-between)
+    printf 'VERDICT: pass\nleft\302\240middle\343\200\200right\342\200\213end\n'
+    ;;
+  ansi-embedded-reason)
+    printf 'VERDICT: pass\nvisible\033[31m reason\177\n'
+    ;;
+  control-only-reason)
+    printf 'VERDICT: pass\n\033\007\177\n'
+    ;;
+  unicode-blank-before-reason)
+    printf 'VERDICT: pass\n\302\240\t\343\200\200\n\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261\n'
+    ;;
   one-line)
     printf 'VERDICT: pass\n'
     ;;
@@ -429,7 +456,9 @@ fi
 failure_matrix_ok=1
 for cli_mode in nonzero empty zero-anchor duplicate-anchored anchored-extra \
   extra-before-anchor same-line-double no-following-reason one-line lowercase-anchor \
-  malformed-anchor malformed-spacing-anchor leading-space-anchor; do
+  malformed-anchor malformed-spacing-anchor leading-space-anchor nbsp-only-reason \
+  ideographic-space-only-reason zwsp-only-reason unicode-ascii-space-only-reason \
+  control-only-reason; do
   stub_reset_markers
   stub_set_mode "$cli_mode"
   set +e
@@ -521,6 +550,84 @@ if [[ "$benign_matrix_ok" -eq 1 ]]; then
 else
   fail_case '[7] verdict-first, benign blanks, CRLF/trailing space, and extra findings normalize to two lines' \
     'one or more benign CLI reply shapes were rejected'
+fi
+
+reason_hygiene_ok=1
+for hygiene_case in \
+  'japanese-reason|VERDICT: pass|\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261' \
+  'unicode-spaces-between|VERDICT: pass|left\302\240middle\343\200\200right\342\200\213end' \
+  'ansi-embedded-reason|VERDICT: pass|visible[31m reason' \
+  'unicode-blank-before-reason|VERDICT: pass|\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261'; do
+  cli_mode=${hygiene_case%%|*}
+  expected_encoded=${hygiene_case#*|}
+  expected_encoded=${expected_encoded/|/\\n}
+  expected_output=$(printf '%b' "$expected_encoded")
+  stub_reset_markers
+  stub_set_mode "$cli_mode"
+  set +e
+  hygiene_output=$(FABLE_CONFORMING_PROVIDER_PATH="$CLI_PROVIDER" \
+    VERIFIER_BUNDLE_MIN_BYTES=64 VERIFIER_CLI_BIN="$cli_stub" \
+    "$WRAPPER" "$bundle" 2>"$TMP_ROOT/$cli_mode.err")
+  hygiene_rc=$?
+  set -e
+  if [[ "$hygiene_rc" -ne 0 || "$hygiene_output" != "$expected_output" ]]; then
+    reason_hygiene_ok=0
+  fi
+done
+if [[ "$reason_hygiene_ok" -eq 1 ]]; then
+  pass '[7b] Unicode reasons survive byte-for-byte while C0 and DEL bytes are removed before output'
+else
+  fail_case '[7b] Unicode reasons survive byte-for-byte while C0 and DEL bytes are removed before output' \
+    'one or more valid reason hygiene shapes diverged from the byte contract'
+fi
+
+direct_provider_hygiene_ok=1
+
+stub_reset_markers
+stub_set_mode zwsp-only-reason
+set +e
+VERIFIER_CLI_BIN="$cli_stub" "$CLI_PROVIDER" "$bundle" \
+  >"$TMP_ROOT/direct-zwsp.out" 2>"$TMP_ROOT/direct-zwsp.err"
+direct_zwsp_rc=$?
+set -e
+if [[ "$direct_zwsp_rc" -ne 1 || -s "$TMP_ROOT/direct-zwsp.out" ]] \
+  || ! grep -Fqx 'CLI verifier provider: CLI returned malformed output' \
+    "$TMP_ROOT/direct-zwsp.err"; then
+  direct_provider_hygiene_ok=0
+fi
+
+stub_reset_markers
+stub_set_mode japanese-reason
+printf 'VERDICT: pass\n\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261\n' \
+  >"$TMP_ROOT/direct-japanese.expected"
+set +e
+VERIFIER_CLI_BIN="$cli_stub" "$CLI_PROVIDER" "$bundle" \
+  >"$TMP_ROOT/direct-japanese.out" 2>"$TMP_ROOT/direct-japanese.err"
+direct_japanese_rc=$?
+set -e
+if [[ "$direct_japanese_rc" -ne 0 ]] \
+  || ! cmp -s "$TMP_ROOT/direct-japanese.expected" "$TMP_ROOT/direct-japanese.out"; then
+  direct_provider_hygiene_ok=0
+fi
+
+stub_reset_markers
+stub_set_mode ansi-embedded-reason
+printf 'VERDICT: pass\nvisible[31m reason\n' >"$TMP_ROOT/direct-controls.expected"
+set +e
+VERIFIER_CLI_BIN="$cli_stub" "$CLI_PROVIDER" "$bundle" \
+  >"$TMP_ROOT/direct-controls.out" 2>"$TMP_ROOT/direct-controls.err"
+direct_controls_rc=$?
+set -e
+if [[ "$direct_controls_rc" -ne 0 ]] \
+  || ! cmp -s "$TMP_ROOT/direct-controls.expected" "$TMP_ROOT/direct-controls.out"; then
+  direct_provider_hygiene_ok=0
+fi
+
+if [[ "$direct_provider_hygiene_ok" -eq 1 ]]; then
+  pass '[7c] direct CLI provider rejects ZWSP-only reasons and preserves Japanese while stripping C0/DEL bytes'
+else
+  fail_case '[7c] direct CLI provider rejects ZWSP-only reasons and preserves Japanese while stripping C0/DEL bytes' \
+    'one or more direct provider stdout or malformed-output byte contracts diverged'
 fi
 
 verdict_matrix_ok=1

--- a/tests/hermes-verifier-examples.test.sh
+++ b/tests/hermes-verifier-examples.test.sh
@@ -494,6 +494,72 @@ else
     'one or more ambiguous model replies escaped validation'
 fi
 
+reason_parity_ok=1
+for parity_case in \
+  'nbsp-only|reject|VERDICT: pass\n\302\240\n|' \
+  'ideographic-space-only|reject|VERDICT: pass\n\343\200\200\n|' \
+  'zwsp-only|reject|VERDICT: pass\n\342\200\213\n|' \
+  'unicode-ascii-space-only|reject|VERDICT: pass\n\302\240\t \302\240\n|' \
+  'japanese|accept|VERDICT: pass\n\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261\n|VERDICT: pass\n\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261' \
+  'unicode-spaces-between|accept|VERDICT: pass\nleft\302\240middle\343\200\200right\342\200\213end\n|VERDICT: pass\nleft\302\240middle\343\200\200right\342\200\213end' \
+  'midline-tab|accept|VERDICT: pass\nvisible\treason\n|VERDICT: pass\nvisible\treason' \
+  'trailing-nbsp|accept|VERDICT: pass\nreason\302\240\n|VERDICT: pass\nreason\302\240' \
+  'embedded-sgr|accept|VERDICT: pass\nvisible\033[31m reason\177\n|VERDICT: pass\nvisible[31m reason' \
+  'control-only|reject|VERDICT: pass\n\033\007\177\n|' \
+  'unicode-blank-before-reason|accept|VERDICT: pass\n\302\240\t\343\200\200\n\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261\n|VERDICT: pass\n\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261'; do
+  parity_name=${parity_case%%|*}
+  parity_rest=${parity_case#*|}
+  parity_outcome=${parity_rest%%|*}
+  parity_rest=${parity_rest#*|}
+  parity_reply_encoded=${parity_rest%%|*}
+  parity_expected_encoded=${parity_rest#*|}
+  parity_reply_with_sentinel=$(printf '%b_' "$parity_reply_encoded")
+  parity_reply=${parity_reply_with_sentinel%_}
+  printf '%s' "$parity_reply" >"$TMP_ROOT/parity-$parity_name.fixture"
+  printf '%b' "$parity_reply_encoded" >"$TMP_ROOT/parity-$parity_name.fixture-expected"
+  printf '%b\n' "$parity_expected_encoded" >"$TMP_ROOT/parity-$parity_name.expected"
+
+  set +e
+  FABLE_CONFORMING_PROVIDER_PATH="$fake_provider" \
+    PROVIDER_MARKER="$provider_marker" PROVIDER_OUTPUT="$parity_reply" \
+    VERIFIER_BUNDLE_MIN_BYTES=64 "$WRAPPER" "$bundle" \
+    >"$TMP_ROOT/wrapper-parity-$parity_name.out" \
+    2>"$TMP_ROOT/wrapper-parity-$parity_name.err"
+  wrapper_parity_rc=$?
+  VERIFIER_API_KEY=fixture STUB_REPLY_TEXT="$parity_reply" \
+    REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+    REQUEST_COUNT_MARKER="$request_count_marker" \
+    python3 "$opener_stub" "$PROVIDER" "$bundle" \
+    >"$TMP_ROOT/api-parity-$parity_name.out" \
+    2>"$TMP_ROOT/api-parity-$parity_name.err"
+  api_parity_rc=$?
+  set -e
+
+  if ! cmp -s "$TMP_ROOT/parity-$parity_name.fixture" \
+    "$TMP_ROOT/parity-$parity_name.fixture-expected"; then
+    reason_parity_ok=0
+  fi
+  if [ "$parity_outcome" = accept ]; then
+    if [ "$wrapper_parity_rc" -ne 0 ] || [ "$api_parity_rc" -ne 0 ] \
+      || ! cmp -s "$TMP_ROOT/wrapper-parity-$parity_name.out" \
+        "$TMP_ROOT/api-parity-$parity_name.out" \
+      || ! cmp -s "$TMP_ROOT/wrapper-parity-$parity_name.out" \
+        "$TMP_ROOT/parity-$parity_name.expected"; then
+      reason_parity_ok=0
+    fi
+  elif [ "$wrapper_parity_rc" -ne 65 ] || [ "$api_parity_rc" -ne 1 ] \
+    || [ -s "$TMP_ROOT/wrapper-parity-$parity_name.out" ] \
+    || [ -s "$TMP_ROOT/api-parity-$parity_name.out" ]; then
+    reason_parity_ok=0
+  fi
+done
+if [ "$reason_parity_ok" -eq 1 ]; then
+  pass '[11cb] wrapper awk and API python have byte-identical Unicode-empty and C0/DEL reason semantics'
+else
+  fail_case '[11cb] wrapper awk and API python have byte-identical Unicode-empty and C0/DEL reason semantics' \
+    'one or more shared byte fixtures produced divergent outcomes or normalized bytes'
+fi
+
 api_nul_matrix_ok=1
 for api_nul_mode in nul-before-anchor nul-after-verdict nul-inside-anchor \
   nul-in-reason nul-trailing; do

--- a/tests/verify-job.test.sh
+++ b/tests/verify-job.test.sh
@@ -51,6 +51,41 @@ SH
   chmod +x "$path"
 }
 
+write_reason_hygiene_verifier() {
+  path=$1
+  cat >"$path" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'VERDICT: pass'
+case "${VERIFY_REASON_MODE:-japanese}" in
+  unicode-empty)
+    printf '\302\240\t \343\200\200\342\200\213\n'
+    ;;
+  nbsp-only)
+    printf '\302\240\n'
+    ;;
+  ideographic-space-only)
+    printf '\343\200\200\n'
+    ;;
+  zwsp-only)
+    printf '\342\200\213\n'
+    ;;
+  japanese)
+    printf '\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261\n'
+    ;;
+  embedded-controls)
+    printf '  visible\033[31m reason\007\177   \n'
+    ;;
+  control-only)
+    printf '\033\007\177\n'
+    ;;
+  *)
+    exit 98
+    ;;
+esac
+SH
+  chmod +x "$path"
+}
+
 write_auth_failure_verifier() {
   path=$1
   cat >"$path" <<'SH'
@@ -126,6 +161,86 @@ if [ "$(sed -n '1p' "$TMP_ROOT/ws-pass/loop/VERIFY.log.md")" = "$VERIFY_HEADER" 
 else
   fail_case "verify-job creates the append-only verifier history header" \
     "header=$(sed -n '1p' "$TMP_ROOT/ws-pass/loop/VERIFY.log.md")"
+fi
+
+reason_hygiene_verifier=$TMP_ROOT/reason-hygiene-verifier.sh
+write_reason_hygiene_verifier "$reason_hygiene_verifier"
+attest_verifier_wrapper "$reason_hygiene_verifier" reason-hygiene
+
+bundle=$(make_bundle unicode-empty-reason)
+unicode_empty_log=$TMP_ROOT/ws-unicode-empty-reason/loop/VERIFY.log.md
+output=$(VERIFY_REASON_MODE=unicode-empty VERIFIER_CMD="$reason_hygiene_verifier" \
+  VERIFIER_ID=reason-hygiene bash "$SCRIPT" "$bundle" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ] \
+  && grep -Fq 'verdict=pass | verifier response missing one-line reason' "$unicode_empty_log"; then
+  pass "Unicode-space-only verifier reasons log the explicit missing-reason fallback"
+else
+  fail_case "Unicode-space-only verifier reasons log the explicit missing-reason fallback" \
+    "rc=$rc output=$output log=$(cat "$unicode_empty_log" 2>/dev/null)"
+fi
+
+single_unicode_empty_ok=1
+for unicode_empty_case in nbsp-only ideographic-space-only zwsp-only; do
+  bundle=$(make_bundle "$unicode_empty_case-reason")
+  single_unicode_empty_log=$TMP_ROOT/ws-$unicode_empty_case-reason/loop/VERIFY.log.md
+  output=$(VERIFY_REASON_MODE="$unicode_empty_case" VERIFIER_CMD="$reason_hygiene_verifier" \
+    VERIFIER_ID=reason-hygiene bash "$SCRIPT" "$bundle" 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ] \
+    || ! grep -Fq 'verdict=pass | verifier response missing one-line reason' \
+      "$single_unicode_empty_log"; then
+    single_unicode_empty_ok=0
+  fi
+done
+if [ "$single_unicode_empty_ok" -eq 1 ]; then
+  pass "NBSP-only, U+3000-only, and ZWSP-only reasons each log the missing-reason fallback"
+else
+  fail_case "NBSP-only, U+3000-only, and ZWSP-only reasons each log the missing-reason fallback" \
+    "one or more single-sequence reasons escaped the empty-reason check"
+fi
+
+bundle=$(make_bundle japanese-reason)
+japanese_log=$TMP_ROOT/ws-japanese-reason/loop/VERIFY.log.md
+japanese_reason=$(printf '\346\227\245\346\234\254\350\252\236\343\201\256\347\220\206\347\224\261')
+output=$(VERIFY_REASON_MODE=japanese VERIFIER_CMD="$reason_hygiene_verifier" \
+  VERIFIER_ID=reason-hygiene bash "$SCRIPT" "$bundle" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ] && grep -Fq "verdict=pass | $japanese_reason" "$japanese_log"; then
+  pass "fully Japanese verifier reasons reach the log unchanged"
+else
+  fail_case "fully Japanese verifier reasons reach the log unchanged" \
+    "rc=$rc output=$output log=$(cat "$japanese_log" 2>/dev/null)"
+fi
+
+bundle=$(make_bundle embedded-control-reason)
+embedded_control_log=$TMP_ROOT/ws-embedded-control-reason/loop/VERIFY.log.md
+embedded_control_clean=$TMP_ROOT/embedded-control-clean.log
+output=$(VERIFY_REASON_MODE=embedded-controls VERIFIER_CMD="$reason_hygiene_verifier" \
+  VERIFIER_ID=reason-hygiene bash "$SCRIPT" "$bundle" 2>&1)
+rc=$?
+LC_ALL=C tr -d '\000-\010\013-\037\177' \
+  <"$embedded_control_log" >"$embedded_control_clean"
+if [ "$rc" -eq 0 ] \
+  && grep -Fq 'verdict=pass |   visible[31m reason' "$embedded_control_log" \
+  && cmp -s "$embedded_control_log" "$embedded_control_clean"; then
+  pass "reason logging removes C0 and DEL bytes, preserves printable SGR suffixes, and keeps leading space"
+else
+  fail_case "reason logging removes C0 and DEL bytes, preserves printable SGR suffixes, and keeps leading space" \
+    "rc=$rc output=$output log=$(cat "$embedded_control_log" 2>/dev/null)"
+fi
+
+bundle=$(make_bundle control-only-reason)
+control_only_log=$TMP_ROOT/ws-control-only-reason/loop/VERIFY.log.md
+output=$(VERIFY_REASON_MODE=control-only VERIFIER_CMD="$reason_hygiene_verifier" \
+  VERIFIER_ID=reason-hygiene bash "$SCRIPT" "$bundle" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ] \
+  && grep -Fq 'verdict=pass | verifier response missing one-line reason' "$control_only_log"; then
+  pass "control-only verifier reasons become empty and log the missing-reason fallback"
+else
+  fail_case "control-only verifier reasons become empty and log the missing-reason fallback" \
+    "rc=$rc output=$output log=$(cat "$control_only_log" 2>/dev/null)"
 fi
 
 bundle=$(make_bundle existing-log)


### PR DESCRIPTION
Closes #76.

## What
Unified reason-line hygiene across the four reply paths (wrapper awk / CLI provider awk / API provider python / verify-job):
- **Unicode-aware emptiness**: a reason line with only whitespace incl. U+00A0 / U+3000 / U+200B (byte-level denylist, LC_ALL=C parity-safe) is treated as empty → invisible reasons can no longer reach `loop/VERIFY.log.md`.
- **Sanitization**: C0 (except tab) + DEL stripped from emitted reasons; mid-line TAB and legitimate Unicode spaces inside non-empty reasons are byte-preserved. **Fully Japanese reasons pass unchanged** (the issue's hard constraint).
- Verdict-uniqueness / anchor parsing untouched. INSTALL.md normalization contract updated.

## Tests
cli 20 / examples 25 / verify-job 27 / wrapper-conformance 41 — all green; `make test` rc=0. Parity pinned by shared-fixture byte-compares through both engines, incl. direct (wrapper-bypassing) provider-cli cases; per-sequence pinning in verify-job.

## Review (S/M floor 3, writer=Codex Sol)
GLM 5.3 / Kimi K3 / Grok 4.6 — fresh-context, read-only, blind. **3/3 GO, zero CRITICAL/MAJOR.** Adopted findings (per-sequence pinning, wrapper-masking lock, TAB/trailing-space fixtures, INSTALL.md refresh) applied by writer delta → **3/3 cumulative GO**, each seat re-verified its own mutation lock red. Recorded residual: denylist is scoped to the issue's three named sequences (e.g. U+2003 em-space still counts as non-empty, identically in both engines) — stated in INSTALL.md. mawk-sensitivity of the new awk literals recorded on #84. Full ledger on #76.

## pr-size
389 lines, majority test fixtures/parity matrices — requesting owner `size-exempt` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)