### PR TITLE
test: tolerate shell-owned numeric SHLVL in the verifier CLI env-exactness cases (#91)

### DIFF
--- a/tests/hermes-verifier-cli.test.sh
+++ b/tests/hermes-verifier-cli.test.sh
@@ -54,6 +54,24 @@ write_sorted_lines() {
   printf '%s\n' "$@" | LC_ALL=C sort >"$destination"
 }
 
+write_env_without_numeric_shlvl() {
+  local destination=$1
+  local grep_rc
+  if [[ ! -e "$env_marker" ]]; then
+    : >"$destination"
+    return 0
+  fi
+  if LC_ALL=C grep -Ev '^SHLVL=[0-9]+$' "$env_marker" >"$destination"; then
+    return 0
+  else
+    grep_rc=$?
+  fi
+  if [[ "$grep_rc" -eq 1 ]]; then
+    return 0
+  fi
+  return "$grep_rc"
+}
+
 cat >"$cli_stub" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -224,6 +242,7 @@ EOF
 
 invoking_dir=$(pwd -P)
 expected_env=$TMP_ROOT/expected-env
+normalized_env=$TMP_ROOT/normalized-env
 stub_reset_markers
 stub_set_mode valid
 set +e
@@ -250,14 +269,14 @@ write_sorted_lines "$expected_env" \
   "HOME=$HOME" \
   "PATH=/usr/bin:/bin" \
   "PWD=$cli_pwd" \
-  'SHLVL=1' \
   "TMPDIR=$cli_pwd" \
   '_=/usr/bin/env'
+write_env_without_numeric_shlvl "$normalized_env"
 fence_count=$(LC_ALL=C grep -Ec '^CATY_UNTRUSTED_BUNDLE_[0-9a-f]{48}$' "$stdin_marker" 2>/dev/null || true)
 fence_unique=$(LC_ALL=C grep -E '^CATY_UNTRUSTED_BUNDLE_[0-9a-f]{48}$' "$stdin_marker" 2>/dev/null \
   | sort -u | wc -l | tr -d '[:space:]')
-unexpected_env=$(comm -13 "$expected_env" "$env_marker" | paste -sd, - || true)
-missing_env=$(comm -23 "$expected_env" "$env_marker" | paste -sd, - || true)
+unexpected_env=$(comm -13 "$expected_env" "$normalized_env" | paste -sd, - || true)
+missing_env=$(comm -23 "$expected_env" "$normalized_env" | paste -sd, - || true)
 if [[ "$valid_rc" -eq 0 ]] \
   && [[ "$valid_output" == 'VERDICT: pass
 stub accepted the verifier request' ]] \
@@ -267,7 +286,7 @@ stub accepted the verifier request' ]] \
   && [[ "$fence_count" -eq 2 && "$fence_unique" -eq 1 ]] \
   && [[ -n "$cli_pwd" && "$cli_pwd" != "$invoking_dir" && ! -e "$cli_pwd" ]] \
   && [[ "$cli_pwd" == "$child_tmp"/caty-verifier-cli.* ]] \
-  && diff -u "$expected_env" "$env_marker" >/dev/null; then
+  && diff -u "$expected_env" "$normalized_env" >/dev/null; then
   pass '[1] wrapper path sends exact isolated argv/stdin/cwd and structurally drops planted parent variables'
 else
   fail_case '[1] wrapper path sends exact isolated argv/stdin/cwd and structurally drops planted parent variables' \
@@ -292,14 +311,14 @@ write_sorted_lines "$expected_env" \
   "HOME=$HOME" \
   "PATH=/usr/bin:/bin" \
   "PWD=$proxy_cli_pwd" \
-  'SHLVL=1' \
   "TMPDIR=$proxy_cli_pwd" \
   '_=/usr/bin/env'
+write_env_without_numeric_shlvl "$normalized_env"
 if [[ "$proxy_rc" -eq 0 ]] \
   && [[ "$proxy_output" == 'VERDICT: pass
 stub accepted the verifier request' ]] \
   && [[ "$proxy_cli_pwd" == "$child_tmp"/caty-verifier-cli.* ]] \
-  && diff -u "$expected_env" "$env_marker" >/dev/null; then
+  && diff -u "$expected_env" "$normalized_env" >/dev/null; then
   pass '[1b] wrapper forwards exactly HTTPS_PROXY when it is set and omits unset HTTP_PROXY and ALL_PROXY'
 else
   fail_case '[1b] wrapper forwards exactly HTTPS_PROXY when it is set and omits unset HTTP_PROXY and ALL_PROXY' \
@@ -323,14 +342,14 @@ write_sorted_lines "$expected_env" \
   "HOME=$HOME" \
   "PATH=/usr/bin:/bin" \
   "PWD=$empty_proxy_cli_pwd" \
-  'SHLVL=1' \
   "TMPDIR=$empty_proxy_cli_pwd" \
   '_=/usr/bin/env'
+write_env_without_numeric_shlvl "$normalized_env"
 if [[ "$empty_proxy_rc" -eq 0 ]] \
   && [[ "$empty_proxy_output" == 'VERDICT: pass
 stub accepted the verifier request' ]] \
   && [[ "$empty_proxy_cli_pwd" == "$child_tmp"/caty-verifier-cli.* ]] \
-  && diff -u "$expected_env" "$env_marker" >/dev/null; then
+  && diff -u "$expected_env" "$normalized_env" >/dev/null; then
   pass '[1c] wrapper treats a set-but-empty proxy variable as present and forwards it unchanged'
 else
   fail_case '[1c] wrapper treats a set-but-empty proxy variable as present and forwards it unchanged' \
@@ -361,14 +380,14 @@ write_sorted_lines "$expected_env" \
   "HTTP_PROXY=$http_proxy_value" \
   "PATH=/usr/bin:/bin" \
   "PWD=$all_proxies_cli_pwd" \
-  'SHLVL=1' \
   "TMPDIR=$all_proxies_cli_pwd" \
   '_=/usr/bin/env'
+write_env_without_numeric_shlvl "$normalized_env"
 if [[ "$all_proxies_rc" -eq 0 ]] \
   && [[ "$all_proxies_output" == 'VERDICT: pass
 stub accepted the verifier request' ]] \
   && [[ "$all_proxies_cli_pwd" == "$child_tmp"/caty-verifier-cli.* ]] \
-  && diff -u "$expected_env" "$env_marker" >/dev/null; then
+  && diff -u "$expected_env" "$normalized_env" >/dev/null; then
   pass '[1d] wrapper forwards distinct HTTPS_PROXY, HTTP_PROXY, and ALL_PROXY values exactly'
 else
   fail_case '[1d] wrapper forwards distinct HTTPS_PROXY, HTTP_PROXY, and ALL_PROXY values exactly' \


### PR DESCRIPTION
Fixes #91 — the main-push CI Matrix `git-2.34` (ubuntu-22.04 container) cell, red since the #75 merge.

## What

Test-only, single file: `tests/hermes-verifier-cli.test.sh` (+29/−10, commit `60d9d6b`). The four proxy/env-allowlist cases ([1][1b][1c][1d]) hardcoded `SHLVL=1` in their byte-exact expected-environment lists. `SHLVL` is written by bash itself at startup, not forwarded by the wrapper under test: jammy bash 5.1 materializes `SHLVL=0` under `env -i`, noble/host 5.2 produce `SHLVL=1`.

Fix shape: drop `SHLVL` from the expected lists; compare against a normalized copy of the captured env that filters **only** lines matching `^SHLVL=[0-9]+$` (helper `write_env_without_numeric_shlvl`; missing capture → empty copy so regressions still report via `fail_case`; grep rc=1 tolerated; rc>1 stays fail-closed under `set -e`). The planted-variable drop, the three proxy variables (exact value / set-but-empty / absence), and all argv/stdin-fence/cwd assertions remain byte-exact `diff -u`. A non-numeric `SHLVL` line still fails.

## Files touched (declared in the #91 WIP, non-intersecting with active lane #63)

- `tests/hermes-verifier-cli.test.sh` — only file (diff照合: PR = exactly this 1 file, 1 commit)

## Evidence (orchestrator first-hand)

- ubuntu:22.04 container: **unfixed e051018 reproduces the exact CI failure** (16 PASS / 4 FAIL, `unexpected=SHLVL=0 missing=SHLVL=1`); **fixed: 20 PASS / 0 FAIL**
- Host bash 5.x and /bin/bash 3.2.57: 20 PASS / 0 FAIL
- Full `make test` on the branch tree: **681 PASS / 0 FAIL / exit 0** (equals the post-#13 main baseline; no case count change)
- Mutation proof the contract still bites: planted-var leak → 4 FAIL (`unexpected=ANTHROPIC_API_KEY=leaked`); HTTPS_PROXY dropped from the forward loop → 2 FAIL; forwarded proxy value mangled → 3 FAIL; provider restored byte-identical after each
- Filter narrowness: `SHLVL=0` filtered; `SHLVL=evil` / `XSHLVL=1` survive and fail
- **Pre-merge real-cell verification**: full 7-cell matrix dispatched on this branch = **all green** including `git-2.34` — run 32032453795. This is also the first time the post-#75 suites (including all #13 additions) executed in the container cell: green.

## Review (S-size, 3 seats, blind, read-only, fresh context)

| seat | requested | actual | verdict |
|---|---|---|---|
| GLM 5.3 (常設) | glm-5.3 | glm-5.3 | **GO** (independently reproduced pre-fix 4-FAIL in jammy docker; mutations; MINOR: numeric-SHLVL forward blind spot = inherent/accepted) |
| Kimi K3 | kimi-code/k3 | kimi-code/k3 | **GO** (mutations + helper edge-path unit probes; MINOR: [1b]-[1d] diagnostic parity = pre-existing, out of scope) |
| Grok 4.6 | grok-4.6 | grok-4.6 | **GO** (docker jammy 5.1 + noble 5.2 runs; 6 mutations incl. SHLVL=evil / XSHLVL=1 injection → red; INFO: helper dest-write failure conflates with rc=1 — judged non-exploitable in this suite) |

Writer = Codex GPT-5.6 Sol (2 passes). No CRITICAL/MAJOR from any seat; all three independently converged on the same mutation-red evidence. Adjudication: adopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
