### PR TITLE
docs: rename PENDING_SHO to PENDING_OWNER (#113)

### DIFF
--- a/docs/governance-rules.md
+++ b/docs/governance-rules.md
@@ -86,7 +86,7 @@ parentheticals from #26 are uniformly omitted (provenance lives in #26), and R6'
   (normalized subject+vendor, NOT feed item id). Alpha's runtime is the writer of record;
   other agents submit proposals/results via Task Packets (existing vault round-trip route).
   Kills the 3-writer append race.
-- **R2 — Complete state machine.** RETRY, PENDING_SHO, per-stage DLQ, per-arrow
+- **R2 — Complete state machine.** RETRY, PENDING_OWNER, per-stage DLQ, per-arrow
   owner+timeout, defined EXPIRED semantics (stale vs superseded vs no-response).
 - **R3 — Lint actuates, not just detects.** The growth-lint WRITES `self-growth-queue.md`
   (state counts, overdue items, pending-Sho queue, next action + owner) into vault


### PR DESCRIPTION
## What
Campaign B11 (caty-ai/family-os#56): rename the one remaining `PENDING_SHO` to `PENDING_OWNER` at docs/governance-rules.md:89, matching the family-wide terminology rename (self-growth-loop runs its own 98-occurrence rename; the two repos are file-disjoint).

## Done when (from #113)
- [x] `grep -n "PENDING_SHO" docs/governance-rules.md` = 0 hits
- [x] the occurrence now reads `PENDING_OWNER`

Repo-wide grep confirms no other occurrence in any tracked file.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)