### PR TITLE
docs: CONTRIBUTING prerequisites + make test + README Project status (#115)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,8 @@ The tests are plain shell suites, but a few tools must be present:
 - **bash 3.2+** — the macOS default is fine; everything targets it (see Code style)
 - **make** — the test and lint entry points are Makefile targets
 - **git 2.34+** — the updater suite exercises SSH signature verification, which older git cannot do
-- **ssh-keygen with `-Y` support** (OpenSSH 8.1+) — the updater suite generates and verifies ed25519 signing keys; without it those cases cannot run
+- **ssh-keygen with `-Y` support** (OpenSSH 8.2+, the floor git documents for SSH signing) — the updater suite generates and verifies ed25519 signing keys; without it those cases cannot run
+- **python3** — several suites shell out to it for fixtures and checks (any recent 3.x)
 - standard Unix tools (grep, sed, awk, mktemp) as shipped on macOS or Linux
 
 ## Running the tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,18 +8,26 @@ Thanks for your interest in improving Caty Agent Harness.
 - **Stay inside the documented seams.** Integrations must go through the documented plugin seams (`scripts/tr-enqueue`, pinned templates, read-only artifact consumption) and must not bypass runtime-specific installer or verifier requirements. See [docs/plugin-convention.md](docs/plugin-convention.md).
 - **Honest completion.** A change is done when its stated done-conditions pass with evidence, not when it looks done. Pull requests should list which conditions passed and how they were checked.
 
+## Prerequisites
+
+The tests are plain shell suites, but a few tools must be present:
+
+- **bash 3.2+** — the macOS default is fine; everything targets it (see Code style)
+- **make** — the test and lint entry points are Makefile targets
+- **git 2.34+** — the updater suite exercises SSH signature verification, which older git cannot do
+- **ssh-keygen with `-Y` support** (OpenSSH 8.1+) — the updater suite generates and verifies ed25519 signing keys; without it those cases cannot run
+- standard Unix tools (grep, sed, awk, mktemp) as shipped on macOS or Linux
+
 ## Running the tests
 
-From the repository root, run every shell suite:
+From the repository root:
 
 ```sh
-set -e
-for test_file in tests/*.test.sh; do
-  bash "$test_file"
-done
+make test
+make lint
 ```
 
-All suites must pass before a pull request is reviewed. If your change alters installer, pause, task-runner, or adapter behavior, add or extend a test that pins the new contract.
+`make test` runs every shell suite under `tests/`; `make lint` syntax-checks every tracked shell script. All suites must pass before a pull request is reviewed. If your change alters installer, pause, task-runner, or adapter behavior, add or extend a test that pins the new contract.
 
 ## Pull requests
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -171,8 +171,15 @@ workspace としてインストールし、ヘルスチェックを実行し、�
 | [docs/engineering.ja.md](docs/engineering.ja.md) | **技術ガイド全部** — どこで何が強制されるか、ツール別の深さ、pause の意味論、アーキテクチャ、ディレクトリ地図 |
 | [docs/reference.ja.md](docs/reference.ja.md) | **正確な契約** — 全フラグ・全状態・設計文書への索引 |
 | [Runtime 別設定](docs/engineering.ja.md#runtime-setup) | **ツール別の配線** — 5つの AI ツールそれぞれの hook・verifier・スケジュール |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | **変更の提案方法** — Issue 起点のフローとテストスイート20本（1ループで実行可・英語） |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | **変更の提案方法** — Issue 起点のフローとテストスイート20本（`make test` 1発で実行可・英語） |
 | [SECURITY.md](SECURITY.md) | **問題の安全な報告先** — private な脆弱性報告の窓口（英語） |
+
+## プロジェクトの現況
+
+- **CI**: [![CI: Test + Lint](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml) — すべての pull request で `make test` + `make lint` を実行
+- **検証済み環境**: macOS（GitHub Actions `macos-latest`・Apple シリコン）と Linux（`ubuntu-latest`）—「[使うのに必要なもの](#使うのに必要なもの)」の表を参照
+- **成熟度**: public preview — [docs/reference.md](docs/reference.md) の凍結識別子は安定・それ以外は変わり得ます
+- **既知の制約**: Windows 非対応・updater 系スイートの一部は `ssh-keygen` が必要（[CONTRIBUTING の Prerequisites](CONTRIBUTING.md#prerequisites) 参照）
 
 最後に、このツールが属する大きな絵を一言だけ。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -178,7 +178,7 @@ workspace としてインストールし、ヘルスチェックを実行し、�
 
 - **CI**: [![CI: Test + Lint](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml) — すべての pull request で `make test` + `make lint` を実行
 - **検証済み環境**: macOS（GitHub Actions `macos-latest`・Apple シリコン）と Linux（`ubuntu-latest`）—「[使うのに必要なもの](#使うのに必要なもの)」の表を参照
-- **成熟度**: public preview — [docs/reference.md](docs/reference.md) の凍結識別子は安定・それ以外は変わり得ます
+- **成熟度**: public preview — [docs/cli-conventions.md](docs/cli-conventions.md) の FROZEN な CLI 出力契約は安定・それ以外は変わり得ます
 - **既知の制約**: Windows 非対応・updater 系スイートの一部は `ssh-keygen` が必要（[CONTRIBUTING の Prerequisites](CONTRIBUTING.md#prerequisites) 参照）
 
 最後に、このツールが属する大きな絵を一言だけ。

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The page you just read is a map. The substance is real, and it's all documented.
 
 - **CI**: [![CI: Test + Lint](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml) — runs `make test` + `make lint` on every pull request
 - **Verified environments**: macOS (GitHub Actions `macos-latest`, Apple silicon) and Linux (`ubuntu-latest`) — see the table in [What you need](#what-you-need)
-- **Maturity**: public preview — the frozen identifiers in [docs/reference.md](docs/reference.md) are stable; everything else may still move
+- **Maturity**: public preview — the FROZEN CLI output contracts in [docs/cli-conventions.md](docs/cli-conventions.md) are stable; everything else may still move
 - **Known constraints**: Windows is not supported; some updater suites need `ssh-keygen` (see [CONTRIBUTING Prerequisites](CONTRIBUTING.md#prerequisites))
 
 One last thing — the bigger picture this tool belongs to.

--- a/README.md
+++ b/README.md
@@ -171,8 +171,15 @@ The page you just read is a map. The substance is real, and it's all documented.
 | [docs/engineering.md](docs/engineering.md) | **The full technical guide** — what's enforced where, per-tool depth, pause semantics, architecture, directory map |
 | [docs/reference.md](docs/reference.md) | **The exact contracts** — every flag, every state, every pointer to the design documents |
 | [Runtime setup](docs/engineering.md#runtime-setup) | **Per-tool wiring** — hooks, verifiers, and schedules for each of the five AI tools |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | **How to propose changes** — issue-first flow and the test suites (20 of them, one loop to run) |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | **How to propose changes** — issue-first flow and the test suites (20 of them, one `make test` to run) |
 | [SECURITY.md](SECURITY.md) | **How to report issues safely** — private vulnerability reporting |
+
+## Project status
+
+- **CI**: [![CI: Test + Lint](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml) — runs `make test` + `make lint` on every pull request
+- **Verified environments**: macOS (GitHub Actions `macos-latest`, Apple silicon) and Linux (`ubuntu-latest`) — see the table in [What you need](#what-you-need)
+- **Maturity**: public preview — the frozen identifiers in [docs/reference.md](docs/reference.md) are stable; everything else may still move
+- **Known constraints**: Windows is not supported; some updater suites need `ssh-keygen` (see [CONTRIBUTING Prerequisites](CONTRIBUTING.md#prerequisites))
 
 One last thing — the bigger picture this tool belongs to.
 

--- a/README.th.md
+++ b/README.th.md
@@ -178,7 +178,7 @@ flowchart LR
 
 - **CI**: [![CI: Test + Lint](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml) — รัน `make test` + `make lint` ในทุก pull request
 - **สภาพแวดล้อมที่ตรวจสอบแล้ว**: macOS (GitHub Actions `macos-latest`, Apple silicon) และ Linux (`ubuntu-latest`) — ดูตารางใน「[สิ่งที่ต้องมี](#สิ่งที่ต้องมี)」
-- **ระดับความพร้อม**: public preview — ตัวระบุที่ถูกตรึงไว้ใน [docs/reference.md](docs/reference.md) มีความเสถียร ส่วนอื่นอาจเปลี่ยนแปลงได้
+- **ระดับความพร้อม**: public preview — สัญญา output ของ CLI ที่ระบุเป็น FROZEN ใน [docs/cli-conventions.md](docs/cli-conventions.md) มีความเสถียร ส่วนอื่นอาจเปลี่ยนแปลงได้
 - **ข้อจำกัดที่ทราบ**: ไม่รองรับ Windows; ชุดทดสอบ updater บางชุดต้องใช้ `ssh-keygen` (ดู [Prerequisites ใน CONTRIBUTING](CONTRIBUTING.md#prerequisites))
 
 สุดท้ายอีกเรื่องเดียว — ภาพใหญ่ที่เครื่องมือนี้สังกัดอยู่

--- a/README.th.md
+++ b/README.th.md
@@ -171,8 +171,15 @@ flowchart LR
 | [docs/engineering.md](docs/engineering.md) | **คู่มือเทคนิคฉบับเต็ม** — อะไรถูกบังคับใช้ที่ไหน ความลึกราย runtime ความหมายของ pause สถาปัตยกรรม แผนที่ไดเรกทอรี (ภาษาอังกฤษ) |
 | [docs/reference.md](docs/reference.md) | **สัญญาที่แม่นยำ** — ทุกแฟล็ก ทุกสถานะ ดัชนีเอกสารการออกแบบ (ภาษาอังกฤษ) |
 | [ตั้งค่า runtime (ภาษาอังกฤษ)](docs/engineering.md#runtime-setup) | **การเดินสายรายเครื่องมือ** — hooks, verifier และตารางเวลาของ AI ทั้ง 5 ตัว |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | **วิธีเสนอการเปลี่ยนแปลง** — เริ่มจาก issue และชุดทดสอบ 20 ชุด (รันได้ในลูปเดียว, ภาษาอังกฤษ) |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | **วิธีเสนอการเปลี่ยนแปลง** — เริ่มจาก issue และชุดทดสอบ 20 ชุด (รันทั้งหมดได้ด้วย `make test` คำสั่งเดียว, ภาษาอังกฤษ) |
 | [SECURITY.md](SECURITY.md) | **ช่องทางรายงานปัญหาอย่างปลอดภัย** — การรายงานช่องโหว่แบบส่วนตัว (ภาษาอังกฤษ) |
+
+## สถานะโปรเจกต์
+
+- **CI**: [![CI: Test + Lint](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml) — รัน `make test` + `make lint` ในทุก pull request
+- **สภาพแวดล้อมที่ตรวจสอบแล้ว**: macOS (GitHub Actions `macos-latest`, Apple silicon) และ Linux (`ubuntu-latest`) — ดูตารางใน「[สิ่งที่ต้องมี](#สิ่งที่ต้องมี)」
+- **ระดับความพร้อม**: public preview — ตัวระบุที่ถูกตรึงไว้ใน [docs/reference.md](docs/reference.md) มีความเสถียร ส่วนอื่นอาจเปลี่ยนแปลงได้
+- **ข้อจำกัดที่ทราบ**: ไม่รองรับ Windows; ชุดทดสอบ updater บางชุดต้องใช้ `ssh-keygen` (ดู [Prerequisites ใน CONTRIBUTING](CONTRIBUTING.md#prerequisites))
 
 สุดท้ายอีกเรื่องเดียว — ภาพใหญ่ที่เครื่องมือนี้สังกัดอยู่
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -177,7 +177,7 @@ flowchart LR
 
 - **CI**: [![CI: Test + Lint](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml) — 每个 pull request 都会运行 `make test` + `make lint`
 - **已验证环境**: macOS（GitHub Actions `macos-latest`，Apple 芯片）与 Linux（`ubuntu-latest`）— 参见「[使用前提](#使用前提)」中的表格
-- **成熟度**: public preview — [docs/reference.md](docs/reference.md) 中的冻结标识符是稳定的，其余部分仍可能变动
+- **成熟度**: public preview — [docs/cli-conventions.md](docs/cli-conventions.md) 中标记为 FROZEN 的 CLI 输出契约是稳定的，其余部分仍可能变动
 - **已知限制**: 不支持 Windows；部分 updater 测试套件需要 `ssh-keygen`（参见 [CONTRIBUTING 的 Prerequisites](CONTRIBUTING.md#prerequisites)）
 
 最后再讲一句——这个工具所属的更大图景。

--- a/README.zh.md
+++ b/README.zh.md
@@ -170,8 +170,15 @@ flowchart LR
 | [docs/engineering.md](docs/engineering.md) | **完整技术指南** — 哪里强制什么、各工具深度、暂停语义、架构、目录地图（英文） |
 | [docs/reference.md](docs/reference.md) | **精确契约** — 每个参数、每种状态、设计文档索引（英文） |
 | [运行环境设置（英文）](docs/engineering.md#runtime-setup) | **各工具接线** — 5 种 AI 工具各自的 hooks、verifier 与调度 |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | **如何提出变更** — issue 优先的流程与 20 个测试套件（一个循环即可全部运行，英文） |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | **如何提出变更** — issue 优先的流程与 20 个测试套件（一条 `make test` 即可全部运行，英文） |
 | [SECURITY.md](SECURITY.md) | **安全地报告问题** — 私密漏洞报告通道（英文） |
+
+## 项目现状
+
+- **CI**: [![CI: Test + Lint](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/caty-agent-harness/actions/workflows/test-lint.yml) — 每个 pull request 都会运行 `make test` + `make lint`
+- **已验证环境**: macOS（GitHub Actions `macos-latest`，Apple 芯片）与 Linux（`ubuntu-latest`）— 参见「[使用前提](#使用前提)」中的表格
+- **成熟度**: public preview — [docs/reference.md](docs/reference.md) 中的冻结标识符是稳定的，其余部分仍可能变动
+- **已知限制**: 不支持 Windows；部分 updater 测试套件需要 `ssh-keygen`（参见 [CONTRIBUTING 的 Prerequisites](CONTRIBUTING.md#prerequisites)）
 
 最后再讲一句——这个工具所属的更大图景。
 


### PR DESCRIPTION
## What
Campaign B8 (caty-ai/family-os#56).

- **CONTRIBUTING.md**: adds a `## Prerequisites` section — bash 3.2+, make, git 2.34+ (`scripts/lib-updater-verify.sh` requires it for SSH verify), ssh-keygen with `-Y` (the family-updater suite generates/verifies ed25519 keys) — and replaces the for-loop test instructions with `make test` / `make lint`.
- **README ×4**: the CONTRIBUTING table row now says tests run with one `make test` (stale "20 suites" count deliberately untouched — that is #99/#111 scope); new `## Project status` section (CI live badge / verified environments / maturity / known constraints) at the same position in all four languages.

## Done when (from #115)
- [x] CONTRIBUTING has Prerequisites with required tools/versions (no other language versions of CONTRIBUTING exist)
- [x] README ×4 test guidance unified to `make test`
- [x] README ×4 `## Project status` section in the family-standard 4-line form + live badge
- [x] repo-specific note: ssh-keygen named as required (54-case impact confirmed in #116)

## Serialization
Same files as #119 (B4), non-overlapping hunks. **Merges strictly after #119** (lane order B4 → B8), rebasing first. Both currently held on base regression #121 (T-4).

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)