### PR TITLE
tests: bash 3.2-compatible unicode escapes + fail-closed lint + full-suite aggregation (fixes #121)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ make test
 make lint
 ```
 
-`make test` runs every shell suite under `tests/`; `make lint` syntax-checks every tracked shell script. All suites must pass before a pull request is reviewed. If your change alters installer, pause, task-runner, or adapter behavior, add or extend a test that pins the new contract.
+`make test` runs every shell suite under `tests/` and reports all failing suites after the run; `make lint` syntax-checks every tracked shell script and rejects Bash 4.2+ Unicode escapes in ANSI-C quoted strings. All suites must pass before a pull request is reviewed. If your change alters installer, pause, task-runner, or adapter behavior, add or extend a test that pins the new contract.
 
 ## Pull requests
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # CI 門番 test-lint.yml の充て先 (#30)。
-# test = CONTRIBUTING「Running the tests」の正式手順そのまま (全 shell スイート)。
-# lint = tracked な shell スクリプト全ファイルの bash -n 構文スイープ (bash 3.2+ 方針に整合。
+# test = CONTRIBUTING「Running the tests」の正式手順そのまま (全 shell スイートを完走後に集計)。
+# lint = tracked な shell スクリプト全ファイルの bash -n 構文スイープ +
+#        ANSI-C quote の Bash 4.2+ Unicode escape 拒否 (bash 3.2+ 方針に整合。
 #        shellcheck 全面採用は別 Issue 候補として本レーンでは見送り)。
 #   - 対象 = *.sh 全域 + shebang が shell の拡張子なしファイル (scripts/attest-wrapper 等)。
 #   - 検査対象が 0 件なら赤 (空振り緑の拒否 — fail-closed)。
@@ -8,17 +9,33 @@
 .PHONY: test lint
 
 test:
-	@set -e; for test_file in tests/*.test.sh; do bash "$$test_file"; done
+	@pass_count=0; fail_count=0; failed_suites=; \
+	for test_file in tests/*.test.sh; do \
+	  if bash "$$test_file"; then \
+	    pass_count=$$((pass_count+1)); \
+	  else \
+	    fail_count=$$((fail_count+1)); \
+	    failed_suites="$$failed_suites $${test_file##*/}"; \
+	  fi; \
+	done; \
+	printf '\nSuite Summary: %s PASS, %s FAIL\n' "$$pass_count" "$$fail_count"; \
+	if [ "$$fail_count" -ne 0 ]; then \
+	  printf 'Failed suites:\n'; \
+	  for failed_suite in $$failed_suites; do printf ' - %s\n' "$$failed_suite"; done; \
+	  exit 1; \
+	fi
 
 lint:
 	@set -e; count=0; \
-	for f in $$( { git ls-files '*.sh'; \
-	               git ls-files | while IFS= read -r p; do \
-	                 case "$$p" in (*.sh) continue;; esac; \
-	                 head -n 1 "$$p" 2>/dev/null | grep -qE '^#!.*sh([[:space:]]|$$)' && echo "$$p"; \
-	               done; } | sort -u ); do \
+	files=$$( { git ls-files '*.sh'; \
+	            git ls-files | while IFS= read -r p; do \
+	              case "$$p" in (*.sh) continue;; esac; \
+	              head -n 1 "$$p" 2>/dev/null | grep -qE '^#!.*sh([[:space:]]|$$)' && echo "$$p"; \
+	            done; } | sort -u ); \
+	for f in $$files; do \
 	  bash -n "$$f" || { echo "syntax error: $$f" >&2; exit 1; }; \
 	  count=$$((count+1)); \
 	done; \
 	[ "$$count" -ge 1 ] || { echo "lint: zero shell files checked - refusing vacuous green (fail-closed)" >&2; exit 1; }; \
+	python3 -B scripts/check-bash32-ansi-c-escapes $$files; \
 	echo "lint: $$count shell files OK"

--- a/scripts/check-bash32-ansi-c-escapes
+++ b/scripts/check-bash32-ansi-c-escapes
@@ -1,0 +1,79 @@
+"""Reject Bash 4.2+ Unicode escapes inside ANSI-C quoted shell strings."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def ansi_c_violations(text: str) -> list[tuple[int, str]]:
+    violations: list[tuple[int, str]] = []
+    index = 0
+    line = 1
+    length = len(text)
+
+    while index < length:
+        if text.startswith("$'", index):
+            index += 2
+            while index < length:
+                char = text[index]
+                if char == "\\" and index + 1 < length:
+                    escape = text[index + 1]
+                    if escape in ("u", "U"):
+                        violations.append((line, escape))
+                    if escape == "\n":
+                        line += 1
+                    index += 2
+                    continue
+                if char == "'":
+                    index += 1
+                    break
+                if char == "\n":
+                    line += 1
+                index += 1
+            continue
+        if text[index] == "\n":
+            line += 1
+        index += 1
+
+    return violations
+
+
+def main(paths: list[str]) -> int:
+    if not paths:
+        print(
+            "bash32 ANSI-C lint: zero shell files checked - refusing vacuous green (fail-closed)",
+            file=sys.stderr,
+        )
+        return 2
+
+    checked = 0
+    found = 0
+    for raw_path in paths:
+        path = Path(raw_path)
+        try:
+            text = path.read_bytes().decode("utf-8", errors="surrogateescape")
+        except OSError as error:
+            print(f"bash32 ANSI-C lint: cannot read {path}: {error}", file=sys.stderr)
+            return 2
+        checked += 1
+        for line, escape in ansi_c_violations(text):
+            found += 1
+            print(
+                f"{path}:{line}: ANSI-C escape \\{escape} requires Bash 4.2+; "
+                "use Bash 3.2-compatible UTF-8 \\xHH bytes",
+                file=sys.stderr,
+            )
+
+    if found:
+        print(
+            f"bash32 ANSI-C lint: {found} violation(s) in {checked} shell file(s)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"bash32 ANSI-C lint: {checked} shell files OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/bash32-unicode-escapes.test.sh
+++ b/tests/bash32-unicode-escapes.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TMP_ROOT=${TMPDIR:-/tmp}/bash32-unicode-escapes-test.$$
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+cleanup() { rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT HUP INT TERM
+mkdir -p "$TMP_ROOT"
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf 'PASS %s\n' "$1"; }
+fail_case() { FAIL_COUNT=$((FAIL_COUNT + 1)); printf 'FAIL %s: %s\n' "$1" "$2"; }
+skip_case() { SKIP_COUNT=$((SKIP_COUNT + 1)); printf 'SKIP %s: %s\n' "$1" "$2"; }
+
+run_system_bash_case() {
+  local name=$1 suite=$2 expected_pass=$3
+  local log=$TMP_ROOT/$(basename "$suite").log
+  local rc summary
+
+  /bin/bash "$suite" >"$log" 2>&1
+  rc=$?
+  summary=$(grep '^Summary:' "$log" | tail -n 1)
+  if [ "$rc" -eq 0 ] && grep -Fqx -- "$expected_pass" "$log"; then
+    pass "$name"
+  else
+    fail_case "$name" "rc=$rc ${summary:-Summary: missing}"
+  fi
+}
+
+if [ -x /bin/bash ]; then
+  run_system_bash_case \
+    'system bash folds four Unicode variants to one intake key' \
+    "$ROOT/tests/flush-intake.test.sh" \
+    'PASS [26] normalization is anchored, mech-check invariant, and key-only across Unicode variants'
+  run_system_bash_case \
+    'system bash presents an NBSP to the pending-dedup normalization' \
+    "$ROOT/tests/pending-dedup.test.sh" \
+    'PASS NBSP maps to an ordinary space in the candidate hash'
+else
+  skip_case 'system bash folds four Unicode variants to one intake key' '/bin/bash is unavailable'
+  skip_case 'system bash presents an NBSP to the pending-dedup normalization' '/bin/bash is unavailable'
+fi
+
+if [ -x /bin/bash ]; then
+  if [ "$SKIP_COUNT" -eq 0 ]; then
+    pass 'an available system bash cannot be silently skipped'
+  else
+    fail_case 'an available system bash cannot be silently skipped' \
+      "$SKIP_COUNT system-bash case(s) were skipped"
+  fi
+else
+  skip_case 'an available system bash cannot be silently skipped' '/bin/bash is unavailable'
+fi
+
+good_fixture=$TMP_ROOT/good.sh
+bad_fixture=$TMP_ROOT/bad.sh
+cat >"$good_fixture" <<'GOOD'
+#!/usr/bin/env bash
+printf '%s\n' $'NBSP: \xc2\xa0' $'literal UTF-8: é' $'literal escape text: \\u00e9'
+GOOD
+printf '%s\n' '#!/usr/bin/env bash' >"$bad_fixture"
+printf '%s' 'lower=$' >>"$bad_fixture"
+printf '%s\n' "'bad: \\u00e9'" >>"$bad_fixture"
+printf '%s' 'upper=$' >>"$bad_fixture"
+printf '%s\n' "'bad: \\U0001f600'" >>"$bad_fixture"
+
+lint_output=$(python3 -B "$ROOT/scripts/check-bash32-ansi-c-escapes" "$good_fixture" 2>&1)
+lint_rc=$?
+if [ "$lint_rc" -eq 0 ] && printf '%s\n' "$lint_output" | grep -Fq '1 shell files OK'; then
+  pass 'bash32 ANSI-C lint accepts byte escapes, literal UTF-8, and escaped backslashes'
+else
+  fail_case 'bash32 ANSI-C lint accepts byte escapes, literal UTF-8, and escaped backslashes' \
+    "rc=$lint_rc output=$lint_output"
+fi
+
+lint_output=$(python3 -B "$ROOT/scripts/check-bash32-ansi-c-escapes" "$bad_fixture" 2>&1)
+lint_rc=$?
+if [ "$lint_rc" -eq 1 ] \
+  && [ "$(printf '%s\n' "$lint_output" | grep -Fc 'requires Bash 4.2+')" -eq 2 ] \
+  && printf '%s\n' "$lint_output" | grep -Fq '2 violation(s) in 1 shell file(s)'; then
+  pass 'bash32 ANSI-C lint rejects lowercase and uppercase Unicode escapes'
+else
+  fail_case 'bash32 ANSI-C lint rejects lowercase and uppercase Unicode escapes' \
+    "rc=$lint_rc output=$lint_output"
+fi
+
+lint_output=$(python3 -B "$ROOT/scripts/check-bash32-ansi-c-escapes" 2>&1)
+lint_rc=$?
+if [ "$lint_rc" -eq 2 ] \
+  && printf '%s\n' "$lint_output" | grep -Fq 'zero shell files checked' \
+  && printf '%s\n' "$lint_output" | grep -Fq 'fail-closed'; then
+  pass 'bash32 ANSI-C lint rejects an empty file set'
+else
+  fail_case 'bash32 ANSI-C lint rejects an empty file set' "rc=$lint_rc output=$lint_output"
+fi
+
+runner_fixture=$TMP_ROOT/runner
+mkdir -p "$runner_fixture/tests"
+cp "$ROOT/Makefile" "$runner_fixture/Makefile"
+cat >"$runner_fixture/tests/a-pass.test.sh" <<'PASS_SUITE'
+#!/usr/bin/env bash
+printf 'a\n' >>run-order
+exit 0
+PASS_SUITE
+cat >"$runner_fixture/tests/b-fail.test.sh" <<'FAIL_SUITE'
+#!/usr/bin/env bash
+printf 'b\n' >>run-order
+exit 9
+FAIL_SUITE
+cat >"$runner_fixture/tests/c-pass.test.sh" <<'LATE_SUITE'
+#!/usr/bin/env bash
+printf 'c\n' >>run-order
+exit 0
+LATE_SUITE
+runner_output=$(cd "$runner_fixture" && make test 2>&1)
+runner_rc=$?
+if [ "$runner_rc" -ne 0 ] \
+  && [ "$(tr -d '\n' <"$runner_fixture/run-order")" = abc ] \
+  && printf '%s\n' "$runner_output" | grep -Fqx 'Suite Summary: 2 PASS, 1 FAIL' \
+  && printf '%s\n' "$runner_output" | grep -Fqx ' - b-fail.test.sh'; then
+  pass 'make test runs later suites, reports failures, and exits nonzero'
+else
+  fail_case 'make test runs later suites, reports failures, and exits nonzero' \
+    "rc=$runner_rc order=$(tr -d '\n' <"$runner_fixture/run-order" 2>/dev/null) output=$runner_output"
+fi
+
+printf 'Summary: %s PASS, %s FAIL, %s SKIP\n' "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]

--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -495,7 +495,7 @@ unicode_ws=$(new_ws case-26-unicode-key)
   printf '%s\n' \
     '- Don’t retry Job A until “ready now”.' \
     "- Don't retry Job A until \"ready now\"." \
-    $'- Don\'t retry Job\u00a0A until "ready now".' \
+    $'- Don\'t retry Job\xc2\xa0A until "ready now".' \
     '- Ｄｏｎ'\''ｔ ｒｅｔｒｙ Ｊｏｂ Ａ ｕｎｔｉｌ "ｒｅａｄｙ ｎｏｗ"．'
 } >"$unicode_ws/loop/pending/flush-2026-07-20.md"
 run_intake "$unicode_ws"

--- a/tests/pending-dedup.test.sh
+++ b/tests/pending-dedup.test.sh
@@ -135,7 +135,7 @@ else
 fi
 
 hash_ascii_space=$(bash -c 'source "$1"; candidate_lesson_hash "$2"' _ "$STATE_FOLD_LIB" '- 2026-07-06 Keep retry budget bounded. (source: distill-audit)')
-hash_nbsp=$(bash -c 'source "$1"; candidate_lesson_hash "$2"' _ "$STATE_FOLD_LIB" $'- 2026-07-06 Keep\u00a0retry budget bounded. (source: distill-audit)')
+hash_nbsp=$(bash -c 'source "$1"; candidate_lesson_hash "$2"' _ "$STATE_FOLD_LIB" $'- 2026-07-06 Keep\xc2\xa0retry budget bounded. (source: distill-audit)')
 if [ "$hash_ascii_space" = "$hash_nbsp" ]; then
   pass "NBSP maps to an ordinary space in the candidate hash"
 else


### PR DESCRIPTION
Fixes #121 — the macOS CI red that blocks every PR merge via T-4.

## Root cause (confirmed by deterministic local repro)

`tests/flush-intake.test.sh:498` and `tests/pending-dedup.test.sh:138` used `$'...\uHHHH...'`. The `\uHHHH` ANSI-C escape is **bash 4.2+ only**; macOS system bash (and the GitHub macOS runner) is 3.2.57, which leaves the escape as a 6-character literal, changing the dedup key. Dev machines run Homebrew bash 5 → green locally, red only on macOS CI. `scripts/lib-state-fold.sh` is innocent (Python-side NFKC is correct); the fix is test-side. Details: #121 (root-cause correction comment + true-baseline comment).

## What changed

- The two sites now use UTF-8 byte escapes (`\xc2\xa0`), which produce **identical bytes on bash 3.2.57 and 5.3.15** (od-verified by orchestrator + 3 seats independently).
- **`scripts/check-bash32-ansi-c-escapes`** (new): fail-closed lint — rejects `\u`/`\U` inside ANSI-C quoted strings in tracked shell files; exit 2 on an empty file set; wired into `make lint` under `set -e`.
- **`tests/bash32-unicode-escapes.test.sh`** (new, T-2 repro): runs both fixed suites under an explicit `/bin/bash` (red before fix, green after — measured), pins lint accept/reject/empty-set behavior, and asserts `make test` runs later suites and exits nonzero. SKIP is explicit and guarded ("an available system bash cannot be silently skipped").
- **Makefile `test`**: runs every suite, aggregates, lists failed suites, exits 1 on any failure. Previously a `set -e` loop stopped at the first failing suite — which is why the second failing site was invisible on macOS CI until now.

## Verification (orchestrator, independent of the writer)

- BEFORE (main `0b96f0e`, `/bin/bash` 3.2.57): flush-intake 33/1, pending-dedup 12/1 — the only 2 failures in the whole suite (564 PASS / 2 FAIL aggregate).
- AFTER (this branch): both suites **0 FAIL under both bashes**; full-suite aggregate under `/bin/bash` 3.2.57 = **573 PASS, 0 FAIL** (all 31 suite files).
- Lint: planted `\u`/`\U` violations detected with file:line (rc=1→make rc=2); empty file set rc=2 fail-closed; 65→66 tracked shell files OK.

## Review (S/M 3 seats, unanimous)

| Seat | Verdict | Notes |
|---|---|---|
| Grok 4.6 | GO | mutation matrix denies worst-forms ①–④; NITs only |
| Kimi K3 | GO | independent 573/0 aggregate reproduction; NITs only |
| GLM 5.3 | GO-WITH-MINOR | MINORs are out-of-scope records / untestable-environment declarations |

All three seats independently mutation-tested: NFKC fold destruction → red; lint stubbed → red (new suite is the unique detector); make-test fail-open → red; SKIP abuse → red. Full seat reports posted as PR comments.

Adjudicated MINORs (recorded, no code change): fixture NBSP→ASCII loosening is undetectable in principle (production mechanism coverage is via NFKC mutation, which is red); lint false-positives in comments/double-quotes are fail-closed-direction and do not fire on the current 66 tracked files; SKIP branch on a /bin/bash-less machine is declared unverified (no such machine available).

Per the standing order on #121: requesting an explicit orchestrator **GO comment on this PR** after CI is green, before any merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
