### PR TITLE
ci: resync make-test recipe drift tripwire via checked-in pin (fixes #133)

### DIFF
--- a/.github/ci/make-test-recipe.pin
+++ b/.github/ci/make-test-recipe.pin
@@ -1,0 +1,15 @@
+	@pass_count=0; fail_count=0; failed_suites=; \
+	for test_file in tests/*.test.sh; do \
+	  if bash "$$test_file"; then \
+	    pass_count=$$((pass_count+1)); \
+	  else \
+	    fail_count=$$((fail_count+1)); \
+	    failed_suites="$$failed_suites $${test_file##*/}"; \
+	  fi; \
+	done; \
+	printf '\nSuite Summary: %s PASS, %s FAIL\n' "$$pass_count" "$$fail_count"; \
+	if [ "$$fail_count" -ne 0 ]; then \
+	  printf 'Failed suites:\n'; \
+	  for failed_suite in $$failed_suites; do printf ' - %s\n' "$$failed_suite"; done; \
+	  exit 1; \
+	fi

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -319,10 +319,18 @@ jobs:
             fi
           fi
 
-          # Drift tripwire: the counted loop below intentionally mirrors the Makefile's
-          # `test` recipe verbatim. Compare the FULL recipe body, not a substring — a
-          # substring grep stayed green when a recipe line was prepended (Codex delta).
-          expected_recipe=$(printf '\t@set -e; for test_file in tests/*.test.sh; do bash "$$test_file"; done')
+          # Drift tripwire: pin the Makefile `test` recipe verbatim. Compare the FULL
+          # recipe body, not a substring — a substring grep stayed green when a recipe
+          # line was prepended (Codex delta). Since #121 the recipe is the run-all +
+          # aggregate loop, so the counted loop below is no longer a verbatim mirror of
+          # the recipe; it is this workflow's own per-suite counting runner. The pin's
+          # job is unchanged: any future Makefile recipe edit must fail here and be
+          # consciously resynced against the checked-in pin (#133).
+          # The pin lives in a data file, not an inline heredoc: bash 3.2 (the b32
+          # matrix cells) collapses backslash-newline inside a quoted heredoc within
+          # $(...), silently corrupting a multi-line expected value (#133, measured).
+          expected_recipe=$(cat .github/ci/make-test-recipe.pin)
+          [ -n "$expected_recipe" ] || fail "make-test-recipe.pin missing or empty - refusing vacuous comparison"
           actual_recipe=$(awk '/^test:/{found=1; next} found && /^\t/{print; next} found{exit}' Makefile)
           if [ "$actual_recipe" != "$expected_recipe" ]; then
             fail "Makefile test recipe drifted from the CI inline loop - resync both"

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -333,7 +333,7 @@ jobs:
           [ -n "$expected_recipe" ] || fail "make-test-recipe.pin missing or empty - refusing vacuous comparison"
           actual_recipe=$(awk '/^test:/{found=1; next} found && /^\t/{print; next} found{exit}' Makefile)
           if [ "$actual_recipe" != "$expected_recipe" ]; then
-            fail "Makefile test recipe drifted from the CI inline loop - resync both"
+            fail "Makefile test recipe drifted from .github/ci/make-test-recipe.pin - update the pin to match the Makefile"
           fi
           # shellcheck disable=SC2012 # Exact Makefile/CONTRIBUTING glob accounting contract.
           expected=$(ls tests/*.test.sh | wc -l | tr -d '[:space:]')

--- a/.github/workflows/flake-50.yml
+++ b/.github/workflows/flake-50.yml
@@ -105,7 +105,7 @@ jobs:
           [ -n "$expected_recipe" ] || fail "make-test-recipe.pin missing or empty - refusing vacuous comparison"
           actual_recipe=$(awk '/^test:/{found=1; next} found && /^\t/{print; next} found{exit}' Makefile)
           if [ "$actual_recipe" != "$expected_recipe" ]; then
-            fail "Makefile test recipe drifted from the CI inline loop - resync both"
+            fail "Makefile test recipe drifted from .github/ci/make-test-recipe.pin - update the pin to match the Makefile"
           fi
           # shellcheck disable=SC2012 # Exact Makefile/CONTRIBUTING glob accounting contract.
           expected=$(ls tests/*.test.sh | wc -l | tr -d '[:space:]')
@@ -253,7 +253,7 @@ jobs:
           [ -n "$expected_recipe" ] || fail "make-test-recipe.pin missing or empty - refusing vacuous comparison"
           actual_recipe=$(awk '/^test:/{found=1; next} found && /^\t/{print; next} found{exit}' Makefile)
           if [ "$actual_recipe" != "$expected_recipe" ]; then
-            fail "Makefile test recipe drifted from the CI inline loop - resync both"
+            fail "Makefile test recipe drifted from .github/ci/make-test-recipe.pin - update the pin to match the Makefile"
           fi
           # shellcheck disable=SC2012 # Exact Makefile/CONTRIBUTING glob accounting contract.
           expected=$(ls tests/*.test.sh | wc -l | tr -d '[:space:]')

--- a/.github/workflows/flake-50.yml
+++ b/.github/workflows/flake-50.yml
@@ -98,8 +98,11 @@ jobs:
           fi
 
           # Full-recipe-body drift tripwire (substring grep passed on prepended lines — Codex delta).
-          # shellcheck disable=SC2016 # Literal Makefile recipe text; $$ is make escaping, not expansion.
-          expected_recipe=$(printf '\t@set -e; for test_file in tests/*.test.sh; do bash "$$test_file"; done')
+          # Pinned to the post-#121 run-all + aggregate recipe via the checked-in data
+          # file (#133) — an inline quoted heredoc inside $(...) is corrupted by bash
+          # 3.2's backslash-newline collapse (measured), so the pin lives in a file.
+          expected_recipe=$(cat .github/ci/make-test-recipe.pin)
+          [ -n "$expected_recipe" ] || fail "make-test-recipe.pin missing or empty - refusing vacuous comparison"
           actual_recipe=$(awk '/^test:/{found=1; next} found && /^\t/{print; next} found{exit}' Makefile)
           if [ "$actual_recipe" != "$expected_recipe" ]; then
             fail "Makefile test recipe drifted from the CI inline loop - resync both"
@@ -243,8 +246,11 @@ jobs:
           fi
 
           # Full-recipe-body drift tripwire (substring grep passed on prepended lines — Codex delta).
-          # shellcheck disable=SC2016 # Literal Makefile recipe text; $$ is make escaping, not expansion.
-          expected_recipe=$(printf '\t@set -e; for test_file in tests/*.test.sh; do bash "$$test_file"; done')
+          # Pinned to the post-#121 run-all + aggregate recipe via the checked-in data
+          # file (#133) — an inline quoted heredoc inside $(...) is corrupted by bash
+          # 3.2's backslash-newline collapse (measured), so the pin lives in a file.
+          expected_recipe=$(cat .github/ci/make-test-recipe.pin)
+          [ -n "$expected_recipe" ] || fail "make-test-recipe.pin missing or empty - refusing vacuous comparison"
           actual_recipe=$(awk '/^test:/{found=1; next} found && /^\t/{print; next} found{exit}' Makefile)
           if [ "$actual_recipe" != "$expected_recipe" ]; then
             fail "Makefile test recipe drifted from the CI inline loop - resync both"


### PR DESCRIPTION
Fixes #133 — CI Matrix (main) has failed fail-closed on every cell since `1ed2f81` (#121 merge): three drift tripwires (ci-matrix.yml ×1, flake-50.yml ×2) still pinned the pre-#121 one-line Makefile test recipe.

## What changed

- **`.github/ci/make-test-recipe.pin`** (new): the post-#121 recipe body, verbatim (15 tab-led lines) — single canonical pin.
- All 3 tripwire sites now `cat` the pin instead of inlining it. Empty/missing pin → fail-closed ("refusing vacuous comparison").
- Tripwire property preserved: any future Makefile recipe edit fails CI until the pin is consciously resynced.

## Why a data file, not an inline heredoc

First attempt inlined the recipe as a quoted heredoc inside `$(…)` — **measured: bash 3.2 collapses backslash-newline inside a quoted heredoc within command substitution** (bash 5 does not). The b32 matrix cells run system bash 3.2, so the inline form silently corrupts the expected value. Minimal repro recorded on #133.

## Verification (orchestrator)

- All 3 sites extracted from the parsed YAML and executed under **both** /bin/bash 3.2.57 and bash 5.3.15 → recipe match (non-vacuous harness: slice asserted non-empty after an earlier vacuous-green harness bug was caught and fixed).
- Mutations, all fail-closed: corrupted pin / empty pin / missing pin / Makefile recipe drift without resync.
- `make lint` unaffected (pin is not a shell file; no shebang).

Per the owner ruling (11:09Z 2026-08-19): requesting an explicit orchestrator **GO comment on this PR** after CI green; workflows are a risk path, so the owner `risk-reviewed` label is also required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)