### PR TITLE
ci: release-sync caller — auto-create Release from v* tag (handbook#113)

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -1,0 +1,12 @@
+name: release-sync
+on:
+  push:
+    tags: ['v*']
+permissions: {}
+concurrency:
+  group: 'release-sync-${{ github.ref }}'
+  cancel-in-progress: false
+jobs:
+  release-sync:
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-release-sync.yml@ci-v1
+    permissions: {contents: write}


### PR DESCRIPTION
Distribution lane [handbook#113](https://github.com/caty-ai/family-dev-handbook/issues/113) (owner-commissioned 2026-08-21). Adds the release-sync caller: annotated SemVer `v*` tag push auto-creates the GitHub Release (reusable @ci-v1; API-only, no checkout). Prevents the tags-without-Releases drift class (2026-08-20 .github incident).

**Byte identity to canon**: sha256 `fb79186fdd514cbc590d0a41523cd3ce7dd652c2e7c45d03ca538d7b0cbf62cf` = `templates/ci/release-sync.yml` at handbook main (a1daca5). No other file touched.

---

## 完了記録（確定 — MERGED; L1-7 + T-5）
- Issue: handbook#113 (tracking) / this PR. Done when: caller present + byte-identical (**PASS** — sha256 above) / batch 3-seat review (**PASS** — GLM 5.3 / Kimi K3 / Grok 4.6 all GO-family, CRITICAL 0, byte identity independently re-measured 9/9; [adjudication](https://github.com/caty-ai/family-dev-handbook/issues/113#issuecomment-5362144055)) / CI green (**PASS** — all required checks green; `risk-reviewed` applied by the owner 2026-08-21).
- diff照合: 1 file (+12), .github/workflows/release-sync.yml only.
- release: **N/A**（T-5 閉じた類型③ CI・開発配線のみ — 挙動・公開API・配布物・規範は不変）
- previous release: **v0.6.0**（この merge は出荷相当でないため連鎖は据置き・実在は gh release list で確認済み）
- merge: local `--no-ff`, noreply identity — **実施済み `a32eb15`**（diff照合: 1 file +12・宣言集合と一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
