### PR TITLE
classify/distill: validate externally-parsed numerics before use (refs #105)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thanks for your interest in improving Caty Agent Harness.
 - **Issue first.** Open a GitHub issue before starting non-trivial work. State *why* the change is needed, *what "done" looks like* (checkable conditions), and *which files you expect to touch*. One-line fixes such as typos are exempt.
 - **Stay inside the documented seams.** Integrations must go through the documented plugin seams (`scripts/tr-enqueue`, pinned templates, read-only artifact consumption) and must not bypass runtime-specific installer or verifier requirements. See [docs/plugin-convention.md](docs/plugin-convention.md).
 - **Honest completion.** A change is done when its stated done-conditions pass with evidence, not when it looks done. Pull requests should list which conditions passed and how they were checked.
+- **Validate external numerics narrowly.** Before using numeric text from an external command or API in arithmetic or comparisons, validate the exact decimal format the code accepts (follow `scripts/tr-enqueue`'s `is_positive_integer()` style). Validation failures must stop processing with an explicit error. The sole exception is an explicitly named conservative fallback that can only restrict processing and cannot broaden permissions, allowances, or budgets; for example, `scripts/lib-classify.sh` uses bounded window reads when evidence size is unreadable or invalid.
 
 ## Prerequisites
 

--- a/adapters/openclaw/distill-audit.sh
+++ b/adapters/openclaw/distill-audit.sh
@@ -13,6 +13,37 @@ infra_fail() {
   exit 3
 }
 
+trim_outer_whitespace() {
+  local value=${1-}
+  value=${value#"${value%%[![:space:]]*}"}
+  value=${value%"${value##*[![:space:]]}"}
+  printf '%s' "$value"
+}
+
+is_nonnegative_integer() {
+  local value
+  value=$(trim_outer_whitespace "${1-}")
+  case "$value" in
+    ''|*[!0-9]*|0[0-9]*) return 1 ;;
+    *) [ "$value" -ge 0 ] 2>/dev/null ;;
+  esac
+}
+
+read_wc_count() {
+  local wc_option=$1
+  local file=$2
+  local count
+
+  if ! count=$(wc "$wc_option" <"$file" 2>/dev/null); then
+    infra_fail "wc $wc_option failed: file='$file'"
+  fi
+  count=$(trim_outer_whitespace "$count")
+  if ! is_nonnegative_integer "$count"; then
+    infra_fail "invalid wc $wc_option count: value='$count' file='$file'"
+  fi
+  WC_COUNT=$count
+}
+
 injection_size_check() {
   local workspace_root=${1:-}
   local pending=${2:-}
@@ -475,7 +506,8 @@ fi
 
 LC_ALL=C sort -n "$candidate_list" >"$work_dir/candidates.sorted.tsv"
 mv "$work_dir/candidates.sorted.tsv" "$candidate_list"
-files_scanned=$(wc -l <"$candidate_list" | tr -d '[:space:]')
+read_wc_count -l "$candidate_list"
+files_scanned=$WC_COUNT
 
 if [[ "$files_scanned" -eq 0 ]]; then
   printf 'nothing to distill\n'
@@ -514,7 +546,8 @@ while :; do
   mv "$work_dir/selected.next.tsv" "$selected_list"
 done
 
-selected_count=$(wc -l <"$selected_list" | tr -d '[:space:]')
+read_wc_count -l "$selected_list"
+selected_count=$WC_COUNT
 dropped_count=$((files_scanned - selected_count))
 # The sorted mtime/size/path list is the deterministic identity of this input batch.
 task_id=$(sha256_file "$selected_list")
@@ -652,8 +685,10 @@ while IFS=$'\t' read -r key line; do
   fi
 done <"$failures_file"
 
-lessons_added=$(wc -l <"$deduped_lessons" | tr -d '[:space:]')
-failures_added=$(wc -l <"$deduped_failures" | tr -d '[:space:]')
+read_wc_count -l "$deduped_lessons"
+lessons_added=$WC_COUNT
+read_wc_count -l "$deduped_failures"
+failures_added=$WC_COUNT
 evicted_by_cap=0
 
 if [[ "$lessons_added" -gt 0 || "$failures_added" -gt 0 ]]; then

--- a/scripts/lib-classify.sh
+++ b/scripts/lib-classify.sh
@@ -1,8 +1,28 @@
 #!/usr/bin/env bash
 
+CLASSIFY_INLINE_MAX_BYTES=131072
+CLASSIFY_WINDOW_BYTES=65536
+
+_classify_trim_outer_whitespace() {
+  local value=${1-}
+  value=${value#"${value%%[![:space:]]*}"}
+  value=${value%"${value##*[![:space:]]}"}
+  printf '%s' "$value"
+}
+
+_classify_is_nonnegative_integer() {
+  local value
+  value=$(_classify_trim_outer_whitespace "${1-}")
+  case "$value" in
+    ''|*[!0-9]*|0[0-9]*) return 1 ;;
+    *) [ "$value" -ge 0 ] 2>/dev/null ;;
+  esac
+}
+
 _classify_read_bounded() {
   local file=$1
   local size=''
+  local size_unknown=0
   local LC_ALL=C
   export LC_ALL
 
@@ -16,11 +36,17 @@ _classify_read_bounded() {
 
   if ! size=$(wc -c <"$file" 2>/dev/null); then
     printf 'classify_failure: unreadable evidence: %s\n' "$file" >&2
-    return 0
+    size_unknown=1
+  else
+    size=$(_classify_trim_outer_whitespace "$size")
+    if ! _classify_is_nonnegative_integer "$size"; then
+      printf "classify_failure: invalid evidence size: value='%s' file='%s'\n" "$size" "$file" >&2
+      size=''
+      size_unknown=1
+    fi
   fi
-  size=$(printf '%s' "$size" | tr -d '[:space:]')
 
-  if (( size <= 131072 )); then
+  if (( size_unknown == 0 && size <= CLASSIFY_INLINE_MAX_BYTES )); then
     if ! cat "$file" 2>/dev/null; then
       printf 'classify_failure: unreadable evidence: %s\n' "$file" >&2
     fi
@@ -28,12 +54,12 @@ _classify_read_bounded() {
   fi
 
   # A marker fully outside the first and last 64 KiB windows is not seen.
-  if ! head -c 65536 "$file" 2>/dev/null; then
+  if ! head -c "$CLASSIFY_WINDOW_BYTES" "$file" 2>/dev/null; then
     printf 'classify_failure: unreadable evidence: %s\n' "$file" >&2
     return 0
   fi
   printf '\n'
-  if ! tail -c 65536 "$file" 2>/dev/null; then
+  if ! tail -c "$CLASSIFY_WINDOW_BYTES" "$file" 2>/dev/null; then
     printf 'classify_failure: unreadable evidence: %s\n' "$file" >&2
   fi
 }

--- a/tests/distill-audit.test.sh
+++ b/tests/distill-audit.test.sh
@@ -309,6 +309,65 @@ ws=$(make_ws cap)
 distiller=$TMP_ROOT/fake-distiller.sh
 write_distiller "$distiller"
 attest_distiller_wrapper "$distiller" fake-distiller
+
+invalid_wc_bin=$TMP_ROOT/invalid-wc-bin
+mkdir -p "$invalid_wc_bin"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'if [ "${1:-}" = "-l" ]; then' \
+  '  case "${ISSUE105_WC_MODE:-invalid}" in' \
+  '    fail) exit 1 ;;' \
+  "    leading-zero) printf '%s\\n' 0200000; exit 0 ;;" \
+  "    internal-space) printf '  12 34  \\n'; exit 0 ;;" \
+  "    invalid) printf '%s\\n' not-a-number; exit 0 ;;" \
+  '  esac' \
+  'fi' \
+  'exec /usr/bin/wc "$@"' >"$invalid_wc_bin/wc"
+chmod +x "$invalid_wc_bin/wc"
+ws=$(make_ws invalid-files-scanned-count)
+output=$(PATH="$invalid_wc_bin:$PATH" DISTILLER_CMD="$distiller" bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)
+rc=$?
+if [ "$rc" -eq 3 ] \
+  && printf '%s\n' "$output" | grep -Fq "distill-audit infra error: invalid wc -l count: value='not-a-number'" \
+  && [ ! -e "$ws/loop/.distill-last-run" ]; then
+  pass "nonnumeric external count is rejected before arithmetic"
+else
+  fail_case "nonnumeric external count is rejected before arithmetic" "rc=$rc output=$output"
+fi
+
+ws=$(make_ws leading-zero-files-scanned-count)
+output=$(PATH="$invalid_wc_bin:$PATH" ISSUE105_WC_MODE=leading-zero DISTILLER_CMD="$distiller" bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)
+rc=$?
+if [ "$rc" -eq 3 ] \
+  && printf '%s\n' "$output" | grep -Fq "distill-audit infra error: invalid wc -l count: value='0200000'" \
+  && [ ! -e "$ws/loop/.distill-last-run" ]; then
+  pass "leading-zero external count is rejected before arithmetic"
+else
+  fail_case "leading-zero external count is rejected before arithmetic" "rc=$rc output=$output"
+fi
+
+ws=$(make_ws internal-space-files-scanned-count)
+output=$(PATH="$invalid_wc_bin:$PATH" ISSUE105_WC_MODE=internal-space DISTILLER_CMD="$distiller" bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)
+rc=$?
+if [ "$rc" -eq 3 ] \
+  && printf '%s\n' "$output" | grep -Fq "distill-audit infra error: invalid wc -l count: value='12 34'" \
+  && [ ! -e "$ws/loop/.distill-last-run" ]; then
+  pass "internal-whitespace external count is rejected before arithmetic"
+else
+  fail_case "internal-whitespace external count is rejected before arithmetic" "rc=$rc output=$output"
+fi
+
+ws=$(make_ws failed-files-scanned-count)
+output=$(PATH="$invalid_wc_bin:$PATH" ISSUE105_WC_MODE=fail DISTILLER_CMD="$distiller" bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)
+rc=$?
+if [ "$rc" -eq 3 ] \
+  && printf '%s\n' "$output" | grep -Fq 'distill-audit infra error: wc -l failed:' \
+  && [ ! -e "$ws/loop/.distill-last-run" ]; then
+  pass "failed external count command stops with an explicit error"
+else
+  fail_case "failed external count command stops with an explicit error" "rc=$rc output=$output"
+fi
+
+ws=$(make_ws cap)
 output=$(DISTILLER_CMD="$distiller" bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)
 rc=$?
 lessons_lines=$(section_count "## Lessons learned" "$ws/STATE.md")

--- a/tests/lib-classify.test.sh
+++ b/tests/lib-classify.test.sh
@@ -166,6 +166,106 @@ middle_suffix=$(( large_size - banner_size - middle_prefix ))
 check_files bounded-tail-window-sees-login 1 "$empty_stderr" "$large_tail_stdout" deterministic-auth
 check_files bounded-middle-window-omits-login 1 "$empty_stderr" "$large_middle_stdout" transient
 
+wc_failure_bin="$test_tmp/wc-failure-bin"
+mkdir -p "$wc_failure_bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$wc_failure_bin/wc"
+chmod +x "$wc_failure_bin/wc"
+wc_failure_diag="$test_tmp/wc-failure.diag"
+set +e
+wc_failure_actual=$(PATH="$wc_failure_bin:$PATH" classify_failure 1 "$empty_stderr" "$large_tail_stdout" 2>"$wc_failure_diag")
+wc_failure_rc=$?
+set -e
+if [[ "$wc_failure_rc" -eq 0 && "$wc_failure_actual" = deterministic-auth ]] \
+  && grep -F -x -q "classify_failure: unreadable evidence: $large_tail_stdout" "$wc_failure_diag"; then
+  pass_count=$(( pass_count + 1 ))
+  printf 'PASS wc-failure-uses-conservative-bounded-read\n'
+else
+  fail_count=$(( fail_count + 1 ))
+  printf 'FAIL wc-failure-uses-conservative-bounded-read: expected deterministic-auth plus unreadable diagnostic, got rc=%s result=%s\n' "$wc_failure_rc" "$wc_failure_actual"
+fi
+
+wc_failure_large_evidence="$test_tmp/wc-failure-large-evidence.stdout"
+wc_failure_large_marker='Not logged in'
+wc_failure_large_expected_bytes=$(( 2 * CLASSIFY_WINDOW_BYTES + 1 ))
+wc_failure_large_size=$(( wc_failure_large_expected_bytes + 1 ))
+fill_bytes $(( wc_failure_large_size - ${#wc_failure_large_marker} )) >"$wc_failure_large_evidence"
+printf '%s' "$wc_failure_large_marker" >>"$wc_failure_large_evidence"
+wc_failure_large_diag="$test_tmp/wc-failure-large.diag"
+set +e
+wc_failure_large_actual=$(PATH="$wc_failure_bin:$PATH" classify_failure 1 "$empty_stderr" "$wc_failure_large_evidence" 2>"$wc_failure_large_diag")
+wc_failure_large_rc=$?
+wc_failure_large_reader_output=$(PATH="$wc_failure_bin:$PATH" _classify_read_bounded "$wc_failure_large_evidence" 2>>"$wc_failure_large_diag")
+wc_failure_large_reader_rc=$?
+set -e
+wc_failure_large_reader_bytes=$(printf '%s' "$wc_failure_large_reader_output" | wc -c)
+wc_failure_large_file_bytes=$(wc -c <"$wc_failure_large_evidence")
+if [[ "$wc_failure_large_rc" -eq 0 && "$wc_failure_large_reader_rc" -eq 0 ]] \
+  && [[ "$wc_failure_large_actual" = deterministic-auth ]] \
+  && [[ "$wc_failure_large_file_bytes" -gt "$CLASSIFY_INLINE_MAX_BYTES" ]] \
+  && [[ "$wc_failure_large_file_bytes" -eq "$wc_failure_large_size" ]] \
+  && [[ "$wc_failure_large_reader_bytes" -eq "$wc_failure_large_expected_bytes" ]] \
+  && [[ "$wc_failure_large_reader_bytes" -lt "$wc_failure_large_file_bytes" ]]; then
+  pass_count=$(( pass_count + 1 ))
+  printf 'PASS wc-failure-with-large-evidence-still-windows\n'
+else
+  fail_count=$(( fail_count + 1 ))
+  printf 'FAIL wc-failure-with-large-evidence-still-windows: expected deterministic-auth and %s-byte window output, got rc=%s reader_rc=%s result=%s reader_bytes=%s file_bytes=%s\n' "$wc_failure_large_expected_bytes" "$wc_failure_large_rc" "$wc_failure_large_reader_rc" "$wc_failure_large_actual" "$wc_failure_large_reader_bytes" "$wc_failure_large_file_bytes"
+fi
+
+wc_invalid_bin="$test_tmp/wc-invalid-bin"
+mkdir -p "$wc_invalid_bin"
+printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' not-a-number" >"$wc_invalid_bin/wc"
+chmod +x "$wc_invalid_bin/wc"
+wc_invalid_diag="$test_tmp/wc-invalid.diag"
+set +e
+wc_invalid_actual=$(PATH="$wc_invalid_bin:$PATH" classify_failure 1 "$empty_stderr" "$large_tail_stdout" 2>"$wc_invalid_diag")
+wc_invalid_rc=$?
+set -e
+if [[ "$wc_invalid_rc" -eq 0 && "$wc_invalid_actual" = deterministic-auth ]] \
+  && grep -F -x -q "classify_failure: invalid evidence size: value='not-a-number' file='$large_tail_stdout'" "$wc_invalid_diag"; then
+  pass_count=$(( pass_count + 1 ))
+  printf 'PASS nonnumeric-size-uses-conservative-bounded-read\n'
+else
+  fail_count=$(( fail_count + 1 ))
+  printf 'FAIL nonnumeric-size-uses-conservative-bounded-read: expected deterministic-auth plus invalid-size diagnostic, got rc=%s result=%s\n' "$wc_invalid_rc" "$wc_invalid_actual"
+fi
+
+wc_leading_zero_bin="$test_tmp/wc-leading-zero-bin"
+mkdir -p "$wc_leading_zero_bin"
+printf '%s\n' '#!/usr/bin/env bash' "printf '%s\\n' 0200000" >"$wc_leading_zero_bin/wc"
+chmod +x "$wc_leading_zero_bin/wc"
+wc_leading_zero_diag="$test_tmp/wc-leading-zero.diag"
+set +e
+wc_leading_zero_actual=$(PATH="$wc_leading_zero_bin:$PATH" classify_failure 1 "$empty_stderr" "$large_tail_stdout" 2>"$wc_leading_zero_diag")
+wc_leading_zero_rc=$?
+set -e
+if [[ "$wc_leading_zero_rc" -eq 0 && "$wc_leading_zero_actual" = deterministic-auth ]] \
+  && grep -F -x -q "classify_failure: invalid evidence size: value='0200000' file='$large_tail_stdout'" "$wc_leading_zero_diag"; then
+  pass_count=$(( pass_count + 1 ))
+  printf 'PASS leading-zero-size-is-rejected-conservatively\n'
+else
+  fail_count=$(( fail_count + 1 ))
+  printf 'FAIL leading-zero-size-is-rejected-conservatively: expected deterministic-auth plus invalid-size diagnostic, got rc=%s result=%s\n' "$wc_leading_zero_rc" "$wc_leading_zero_actual"
+fi
+
+wc_spaced_bin="$test_tmp/wc-spaced-bin"
+mkdir -p "$wc_spaced_bin"
+printf '%s\n' '#!/usr/bin/env bash' "printf '  12 34  \\n'" >"$wc_spaced_bin/wc"
+chmod +x "$wc_spaced_bin/wc"
+wc_spaced_diag="$test_tmp/wc-spaced.diag"
+set +e
+wc_spaced_actual=$(PATH="$wc_spaced_bin:$PATH" classify_failure 1 "$empty_stderr" "$large_tail_stdout" 2>"$wc_spaced_diag")
+wc_spaced_rc=$?
+set -e
+if [[ "$wc_spaced_rc" -eq 0 && "$wc_spaced_actual" = deterministic-auth ]] \
+  && grep -F -x -q "classify_failure: invalid evidence size: value='12 34' file='$large_tail_stdout'" "$wc_spaced_diag"; then
+  pass_count=$(( pass_count + 1 ))
+  printf 'PASS internal-whitespace-size-is-rejected-conservatively\n'
+else
+  fail_count=$(( fail_count + 1 ))
+  printf 'FAIL internal-whitespace-size-is-rejected-conservatively: expected deterministic-auth plus invalid-size diagnostic, got rc=%s result=%s\n' "$wc_spaced_rc" "$wc_spaced_actual"
+fi
+
 if [[ $(id -u) -eq 0 ]]; then
   printf 'SKIP unreadable-stdout-is-degenerate (running as root)\n'
 else


### PR DESCRIPTION
Refs #105 — **deliberately not `Fixes`**: one Done-when bullet is pending an owner decision (see Scope below), so this PR should not auto-close the issue.

## What

An externally-parsed number was used in comparisons without shape validation. Two consequences, both measured:

- `scripts/lib-classify.sh`: an unreadable `wc -c` made the reader treat evidence as **not oversized** and return unread — fail-open on a safety-relevant path. Now: `size_unknown` → bounded window read (conservative). Thresholds became named constants and the guard is a **flag, not a sentinel value**, because all three seats independently demonstrated the `131073` sentinel silently reverting to a full `cat` once the threshold is raised. Leading zeros are rejected before bash arithmetic reads them as **octal** (`0200000` → 65536, measured), and validation now runs **before** whitespace stripping so `  12 34` cannot fuse into `1234` (measured).
- `adapters/openclaw/distill-audit.sh`: a failed `wc` degraded to a count of 0 and exited `rc=0` with "nothing to distill" — the same silent-success shape as the `gh` 503 incident that started this lane. Now it stops with an explicit infra error.
- `CONTRIBUTING.md`: the convention as a peer bullet. Wording tightened so the only permitted default is one that **narrows**; everything else must stop with an explicit error (one seat read a self-judged loophole in the first draft, another did not — ambiguity itself was reason enough to tighten).

## Scope finding (owner decision requested)

The issue names three sites. The third, `.github/workflows/pr-size.yml`, **moved upstream in #114** — this repo now carries a 15-line caller and the implementation lives in `family-dev-handbook`. I fetched the upstream reusable and measured it: the described defect **does not reproduce** (`awk 'END { print total + 0 }'` guarantees an integer; `set -euo pipefail` makes command failure fail-closed). Full evidence on the issue (-5368636018). Recommendation: drop that bullet with the evidence recorded, and keep the weaker residual (0 conflating "genuinely zero" with "nothing measured") upstream where the code lives.

## Review (S/M 3 seats — all GO-WITH-MINOR, full out.md posted below)

| Seat | requested / actual | Note |
|---|---|---|
| Opus 5 | grok-4.6 / **opus-5** | Grok seat unavailable: `402 Payment Required — Grok Build usage balance exhausted`. Substituted per `loom-seats --absent grok-4.6`; recorded in the run ledger. |
| GLM 5.3 | glm-5.3 / glm-5.3 | |
| Kimi K3 | kimi-k3 / kimi-code/k3 | |

**Convergent finding (all 3 seats, three independent breaking demonstrations)**: the sentinel/threshold coupling — fixed in-lane. Opus additionally found the octal and whitespace-fusion paths — both fixed in-lane and pinned by tests.

**One mutation survived the first delta** (removing the `size_unknown` guard was undetected). Rather than accept the writer's manual-measurement compensation, the orchestrator reproduced the gap (guard present → 131,073 bytes read; guard removed → 200,018 bytes = full `cat`), traced it to the test fixture being smaller than the threshold, and had a large-evidence case added. **Independently re-verified: the mutation is now killed** (46/1, only that test red; restored 47/0).

**Deferred with evidence**: the `find -exec sh -c` `wc` path in distill-audit under-counts a prompt budget when `wc` fails silently (measured by two seats). Pre-existing, needs a different POSIX-sh idiom → **#151** with an LC-1 exit trigger.

## Orchestrator measurements (independent of the writer)

`tests/lib-classify.test.sh` **47 PASS / 0 FAIL**, `tests/distill-audit.test.sh` **50 PASS / 0 FAIL** — both under `/bin/bash` 3.2.57 and bash 5.3.15. `make lint`: 68 shell files OK.

Per the per-merge regime: requesting an explicit orchestrator **GO comment** after CI green. No risk paths touched (pr-size.yml is untouched), so no `risk-reviewed` label needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)