### PR TITLE
tests: mode_of GNU-first + fail-closed mode validation (#157)

### DIFF
--- a/tests/hermes-verifier-examples.test.sh
+++ b/tests/hermes-verifier-examples.test.sh
@@ -28,7 +28,9 @@ fail_case() {
 }
 
 mode_of() {
-  stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
+  # GNU first: on GNU coreutils `stat -f` does not fail — it prints filesystem
+  # status — so the BSD-first order silently returns garbage on Linux.
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
 }
 
 fake_provider=$TMP_ROOT/fake-provider.sh
@@ -262,9 +264,14 @@ wrapper_sha=$(shasum -a 256 "$CANONICAL_WRAPPER" | cut -d' ' -f1)
 provider_sha=$(shasum -a 256 "$PROVIDER" | cut -d' ' -f1)
 probe_sha=$(shasum -a 256 "$PROBE" | cut -d' ' -f1)
 modes_ok=1
+mode_diag=
 for example_file in "$CANONICAL_WRAPPER" "$PROVIDER" "$PROBE"; do
   mode=$(mode_of "$example_file")
-  if [ ! -x "$example_file" ] || (( (8#$mode & 8#022) != 0 )); then
+  if ! [[ "$mode" =~ ^[0-7]+$ ]]; then
+    mode_first_line=$(printf '%s\n' "$mode" | sed -n '1p')
+    modes_ok=0
+    mode_diag="${mode_diag}invalid_mode example_file=$example_file mode_first_line=$mode_first_line; "
+  elif [ ! -x "$example_file" ] || (( (8#$mode & 8#022) != 0 )); then
     modes_ok=0
   fi
 done
@@ -273,7 +280,16 @@ if [ "$wrapper_sha" != "$provider_sha" ] && [ "$wrapper_sha" != "$probe_sha" ] \
   pass '[8] example files have distinct content, executable modes, and no group/world write bit'
 else
   fail_case '[8] example files have distinct content, executable modes, and no group/world write bit' \
-    "modes_ok=$modes_ok"
+    "modes_ok=$modes_ok mode_diag=$mode_diag"
+fi
+
+fixture_mode=$(mode_of "$fake_provider")
+if [[ "$fixture_mode" =~ ^[0-7]+$ ]]; then
+  pass '[8a] mode_of returns a pure-octal mode for a known fixture'
+else
+  fixture_mode_first_line=$(printf '%s\n' "$fixture_mode" | sed -n '1p')
+  fail_case '[8a] mode_of returns a pure-octal mode for a known fixture' \
+    "example_file=$fake_provider mode_first_line=$fixture_mode_first_line"
 fi
 
 # The single-quoted text below is an intentional literal source pattern.


### PR DESCRIPTION
Closes #157. Lane record and CI-discrepancy evidence on the issue.

## What

`mode_of()` in tests/hermes-verifier-examples.test.sh was BSD-first; on GNU coreutils `stat -f` is --file-system, so $mode became garbage (WSL2: multi-line starting `File:` → `set -u` abort) or empty (CI containers → arithmetic error → check [8] passed **fail-open**; green main runs carry the line-267 error on every GNU cell — run 32562546259). Fix:

- `mode_of()` GNU-first, both arms stderr-suppressed (task-runner.test.sh precedent), with the trap documented in a comment.
- Check [8] validates pure-octal **before** any arithmetic; invalid mode → explicit fail with named diagnostic (`invalid_mode example_file=… mode_first_line=…`). The fail-open path is gone.
- New [8a] pins mode_of's octal contract on the running platform (no renumbering).

## Inventory (Done when item 3)

14 stat sites swept: **only this one was BSD-first**. tests/pause-contract.test.sh:25-28 is if/else GNU-first (safe); the other 12 are GNU-first `stat -c … || stat -f …` (unambiguous: GNU succeeds, BSD falls through). shasum sites are guarded (`command -v`) or measured-present on both platforms. No other fix needed.

## Evidence

- macOS (BSD stat): 27 PASS, 0 FAIL.
- **WSL2 Ubuntu (GNU, non-root caty, umask 022, Linux FS, win11-test-vm): 27 PASS, 0 FAIL** — first-ever green on a GNU userland. Notably the hardened [8] first **detected a real condition** (example files left 775 by an earlier umask-0002 checkout; git does not rewrite modes for unchanged content) and went green only after `chmod 755` — the guard demonstrably bites now.
- GNU-mimic mutation probe (orchestrator): old mode_of → `File: …` garbage (pin fires); new → clean octal.
- CI-green mystery answered with run-log evidence on the issue (fail-open, not coverage skip).

Writer: Codex GPT-5.6 Sol. Commit by orchestrator (sandbox denies index.lock).
Completion record (L1-7/T-5) will be appended before merge. Review: 3 heterogeneous seats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)