### PR TITLE
docs: engineering quickstart prerequisites gain the WSL2 tier (#163)

### DIFF
--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -83,7 +83,7 @@ Harness は各ツールが支えられる範囲で同じように役立ちます
 
 > AI エージェント経由で導入する場合は [agent-guide.md](agent-guide.md)（英語）を渡してください。runtime の選択・ヘルスチェック・必要な後続配線まで一本道で案内します。
 
-installer、scaffold、pause command の前提は、Git と bash 3.2+ が動く macOS または Linux を使っていることです。runtime hook、`task-runner`、adapter integration、fully operational な runtime 配線には Python 3 が必要です。
+installer、scaffold、pause command の前提は、Git と bash 3.2+ が動く macOS、Linux、または [WSL2 サポートメモ](wsl2-support.md)の条件を満たす WSL2（Ubuntu on Windows）を使っていることです。native Windows は非対応です。runtime hook、`task-runner`、adapter integration、fully operational な runtime 配線には Python 3 が必要です。
 
 ```sh
 git clone https://github.com/caty-ai/caty-agent-harness.git

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -83,7 +83,7 @@ The implementation is intentionally asymmetric. The Harness does not claim that 
 
 > Installing via your AI agent instead? Hand it [agent-guide.md](agent-guide.md) — it covers runtime selection, the health check, and required follow-up wiring.
 
-Prerequisites for the installer, scaffold, and pause commands: Git and bash 3.2+ on macOS or Linux. Python 3 is required for runtime hooks, `task-runner`, adapter integrations, and fully operational runtime wiring.
+Prerequisites for the installer, scaffold, and pause commands: Git and bash 3.2+ on macOS, Linux, or WSL2 (Ubuntu on Windows, under the conditions in the [WSL2 support note](wsl2-support.md)); native Windows is unsupported. Python 3 is required for runtime hooks, `task-runner`, adapter integrations, and fully operational runtime wiring.
 
 ```sh
 git clone https://github.com/caty-ai/caty-agent-harness.git


### PR DESCRIPTION
Closes #163. 2-line parity fix (EN+JA) found by the post-v0.12.0 cross-repo audit — the quickstart prerequisites still said 'macOS or Linux'. Now: macOS, Linux, or WSL2 (linking docs/wsl2-support.md), native Windows named unsupported. Repo re-grep clean (CONTRIBUTING:20 judgment recorded in the commit). Writer: Alpha (md-only S lane). Review: 3 seats. Completion record before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)