### PR TITLE
test: AGENTS.md claim-drift check — marker-based, fail-closed, PR-gated (#155)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ CI, accurately:
 <!-- claim: workflow-on history-check.yml pull_request -->
 <!-- claim: workflow-on review-labels.yml pull_request -->
 <!-- claim: workflow-on pr-size.yml pull_request -->
-- **Required before merge to `main`**: `test-lint / test`, `test-lint / lint`, `test-lint / test-macos`, `test-lint / test-macos-skip`, `gitleaks / gitleaks`, `history-check / history-check`, `risk-review-gate / risk-review-gate`.
+- **Required before merge to `main`**: `test-lint / test`, `test-lint / lint`, `test-lint / test-macos`, `test-lint / test-macos-skip`, `gitleaks / gitleaks`, `history-check / history-check`, `risk-review-gate / risk-review-gate`. The check names are validated against workflow sources on every PR run and against live branch protection wherever the API is readable (maintainer machines); CI cannot read branch protection.
 <!-- claim: required-check test-lint / test -->
 <!-- claim: required-check test-lint / lint -->
 <!-- claim: required-check test-lint / test-macos -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ This file is a **map**, not an encyclopedia. It routes; the documents it points 
 | Benchmark method and results | [docs/benchmark.md](docs/benchmark.md) |
 | Family adoption governance (R1–R14) | [docs/governance-rules.md](docs/governance-rules.md) — maintainer context: how this family adopts external tools. Not the contribution workflow. **Editing that file is not an ordinary docs change**: its own amendment procedure requires cross-model review, and a Sho gate for its gated sections. |
 
+<!-- claim: contract-scope claude-code hermes openclaw -->
+
 Directories:
 
 - `adapters/` — one directory per runtime: claude-code, codex, hermes, kimi, openclaw. `CONTRACT.md` is normative for claude-code, hermes, and openclaw; the codex and kimi adapters are bootstrap plus Stop hooks and are not bound by it.
@@ -52,6 +54,9 @@ make test    # runs every tests/*.test.sh suite, reports all failing suites
 make lint    # syntax-checks every tracked shell script, rejects bash 4.2+ ANSI-C Unicode escapes
 ```
 
+<!-- claim: make-target test -->
+<!-- claim: make-target lint -->
+
 - Expected: `Suite Summary: <n> PASS, 0 FAIL`. `make lint` refuses a vacuous green — zero files checked is a failure.
 - Prerequisites are listed in [CONTRIBUTING.md](CONTRIBUTING.md) — bash 3.2+, `make`, git 2.34+, `ssh-keygen -Y` (OpenSSH 8.2+), python3, and standard Unix tools.
 - If you edit the Makefile `test` recipe, resync `.github/ci/make-test-recipe.pin` in the same change. That pin is checked after merge, not on your PR, so skipping it turns `main` red.
@@ -59,8 +64,22 @@ make lint    # syntax-checks every tracked shell script, rejects bash 4.2+ ANSI-
 CI, accurately:
 
 - **On every pull request**: `test-lint.yml`, `gitleaks.yml`, `history-check.yml`, `review-labels.yml`, `pr-size.yml`.
+<!-- claim: workflow-on test-lint.yml pull_request -->
+<!-- claim: workflow-on gitleaks.yml pull_request -->
+<!-- claim: workflow-on history-check.yml pull_request -->
+<!-- claim: workflow-on review-labels.yml pull_request -->
+<!-- claim: workflow-on pr-size.yml pull_request -->
 - **Required before merge to `main`**: `test-lint / test`, `test-lint / lint`, `test-lint / test-macos`, `test-lint / test-macos-skip`, `gitleaks / gitleaks`, `history-check / history-check`, `risk-review-gate / risk-review-gate`.
+<!-- claim: required-check test-lint / test -->
+<!-- claim: required-check test-lint / lint -->
+<!-- claim: required-check test-lint / test-macos -->
+<!-- claim: required-check test-lint / test-macos-skip -->
+<!-- claim: required-check gitleaks / gitleaks -->
+<!-- claim: required-check history-check / history-check -->
+<!-- claim: required-check risk-review-gate / risk-review-gate -->
 - **After merge, not a PR gate**: `ci-matrix.yml` runs on pushes to `main`, on a weekly schedule, and on manual dispatch. It is a portability detection net. Do not wait for it on a PR — a pull request event does not start it.
+<!-- claim: workflow-on ci-matrix.yml push schedule workflow_dispatch -->
+<!-- claim: workflow-not-on ci-matrix.yml pull_request -->
 
 "It looks right" is not evidence. The output of those commands is.
 
@@ -112,6 +131,6 @@ The maintainers additionally run the lane discipline in the [Family Dev Handbook
 
 ## 6. Maintaining this file
 
-- Prefer a link over a copied fact. Every concrete detail duplicated here (a trigger, a required check, a directory's contents) is a fact that can drift silently — nothing in CI validates this file today.
+- Prefer a link over a copied fact. Machine-readable claim markers let CI validate selected duplicated mechanics; unmarked facts can still drift silently.
 - Keep it between 50 and 200 lines. When it grows, move content into `docs/` and leave a link.
 - Change it in the same PR that changes the behavior it describes. A stale map is worse than no map.

--- a/tests/agents-md-claims.test.sh
+++ b/tests/agents-md-claims.test.sh
@@ -244,24 +244,29 @@ EOF
           errors=$(( errors + 1 ))
         else
           events=$(workflow_events "$root/.github/workflows/$wfile")
-          for ev in ${args#* }; do
-            found=0
-            case "
+          if [ -z "$events" ]; then
+            log "claim-error: $ctype: cannot parse triggers of $wfile"
+            errors=$(( errors + 1 ))
+          else
+            for ev in ${args#* }; do
+              found=0
+              case "
 $events
 " in
-              *"
+                *"
 $ev
 "*) found=1 ;;
-            esac
-            if [ "$ctype" = "workflow-on" ] && [ "$found" -eq 0 ]; then
-              log "claim-error: workflow-on: $wfile does not trigger on '$ev' (actual: $(printf '%s' "$events" | tr '\n' ' '))"
-              errors=$(( errors + 1 ))
-            fi
-            if [ "$ctype" = "workflow-not-on" ] && [ "$found" -eq 1 ]; then
-              log "claim-error: workflow-not-on: $wfile DOES trigger on '$ev'"
-              errors=$(( errors + 1 ))
-            fi
-          done
+              esac
+              if [ "$ctype" = "workflow-on" ] && [ "$found" -eq 0 ]; then
+                log "claim-error: workflow-on: $wfile does not trigger on '$ev' (actual: $(printf '%s' "$events" | tr '\n' ' '))"
+                errors=$(( errors + 1 ))
+              fi
+              if [ "$ctype" = "workflow-not-on" ] && [ "$found" -eq 1 ]; then
+                log "claim-error: workflow-not-on: $wfile DOES trigger on '$ev'"
+                errors=$(( errors + 1 ))
+              fi
+            done
+          fi
         fi
         ;;
 
@@ -311,13 +316,28 @@ EOF
   local mention
   while IFS= read -r mention; do
     [ -n "$mention" ] || continue
-    if [ -f "$root/.github/workflows/$mention" ] \
-      && ! extract_claims "$agents" | grep -qE "^workflow-(on|not-on) $mention( |$)"; then
+    if [ ! -f "$root/.github/workflows/$mention" ]; then
+      log "claim-error: coverage: $mention is mentioned but no such workflow file exists"
+      errors=$(( errors + 1 ))
+    elif ! extract_claims "$agents" | grep -qE "^workflow-(on|not-on) $mention( |$)"; then
       log "claim-error: coverage: $mention is mentioned but carries no workflow-on/workflow-not-on claim"
       errors=$(( errors + 1 ))
     fi
   done <<EOF
-$({ grep -oE '[A-Za-z0-9_-]+\.yml' "$agents" || true; } | sort -u)
+$(awk '
+  {
+    line = $0
+    while (match(line, /[A-Za-z0-9_-]+\.(yml|yaml)/)) {
+      before = substr(line, 1, RSTART - 1)
+      mention = substr(line, RSTART, RLENGTH)
+      line = substr(line, RSTART + RLENGTH)
+      nextchar = substr(line, 1, 1)
+      if (before !~ /[A-Za-z0-9_.\/-]$/ \
+          && nextchar !~ /[A-Za-z0-9_\/-]/ \
+          && line !~ /^\.[A-Za-z0-9_-]/) print mention
+    }
+  }
+' "$agents" | sort -u)
 EOF
 
   while IFS= read -r mention; do
@@ -327,7 +347,26 @@ EOF
       errors=$(( errors + 1 ))
     fi
   done <<EOF
-$({ grep -oE 'make [a-z][a-z-]*' "$agents" || true; } | sed 's/^make //' | sort -u)
+$({ grep -oE 'make [A-Za-z0-9_.][A-Za-z0-9_.-]*' "$agents" || true; } | sed 's/^make //' | sort -u)
+EOF
+
+  if [ -f "$root/adapters/CONTRACT.md" ] \
+    && grep -qi 'normative for' "$root/adapters/CONTRACT.md" \
+    && ! extract_claims "$agents" | grep -qE '^contract-scope( |$)'; then
+    log "claim-error: coverage: adapters/CONTRACT.md contains a 'normative for' line but AGENTS.md carries no contract-scope claim"
+    errors=$(( errors + 1 ))
+  fi
+
+  while IFS= read -r mention; do
+    [ -n "$mention" ] || continue
+    if ! extract_claims "$agents" | grep -qxF "required-check $mention"; then
+      log "claim-error: coverage: '$mention' is mentioned but carries no required-check claim"
+      errors=$(( errors + 1 ))
+    fi
+  done <<EOF
+$({ grep -oE '`[A-Za-z0-9_-]+[[:space:]]+/[[:space:]]+[A-Za-z0-9_-]+`' "$agents" || true; } \
+  | sed -e 's/^`//' -e 's/`$//' \
+  | awk '{ print $1 " / " $3 }' | sort -u)
 EOF
 
   log "claims-checked=$claims_checked links-checked=$links_checked"
@@ -363,6 +402,7 @@ WF
 
 See [docs/guide.md](docs/guide.md). Verify with `make test`.
 The gate runs on every PR via gate.yml.
+The prose-only example path docs/config.yaml is not a workflow mention.
 
 <!-- claim: make-target test -->
 <!-- claim: contract-scope alpha-ad -->
@@ -505,14 +545,15 @@ else
   fi
 fi
 
-# 9. Coverage guard: mentioning a workflow file with no covering claim fails.
+# 9. Coverage guard: mentioning a .yaml workflow file with no covering claim
+#    fails, while the docs/config.yaml path in every fixture remains ignored.
 build_fixture "$FX"
-cp "$FX/.github/workflows/gate.yml" "$FX/.github/workflows/extra.yml"
-printf 'Also see extra.yml for the extra gate.\n' >>"$FX/AGENTS.md"
+cp "$FX/.github/workflows/gate.yml" "$FX/.github/workflows/extra.yaml"
+printf 'Also see extra.yaml for the extra gate.\n' >>"$FX/AGENTS.md"
 if out=$(check_claims "$FX"); then
   fail coverage-unmarked-workflow-fails "unmarked workflow mention passed"
 else
-  if output_has_line "$out" "claim-error: coverage: extra.yml is mentioned but carries no workflow-on/workflow-not-on claim"; then
+  if output_has_line "$out" "claim-error: coverage: extra.yaml is mentioned but carries no workflow-on/workflow-not-on claim"; then
     pass coverage-unmarked-workflow-fails
   else
     fail coverage-unmarked-workflow-fails "failed for the wrong reason: $out"
@@ -533,7 +574,89 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 11. The real repository's AGENTS.md passes against its real sources.
+# 11. Coverage guard: a mentioned workflow with no source file fails even when
+#     its workflow claim markers are also gone.
+# ---------------------------------------------------------------------------
+
+build_fixture "$FX"
+rm "$FX/.github/workflows/gate.yml"
+sed -i.bak '/claim: workflow-on gate.yml/d; /claim: workflow-not-on gate.yml/d' "$FX/AGENTS.md" \
+  && rm -f "$FX/AGENTS.md.bak"
+if out=$(check_claims "$FX"); then
+  fail coverage-missing-workflow-fails "missing workflow mention passed"
+else
+  if output_has_line "$out" "claim-error: coverage: gate.yml is mentioned but no such workflow file exists"; then
+    pass coverage-missing-workflow-fails
+  else
+    fail coverage-missing-workflow-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# 12. An unsupported flow-map trigger form fails as unparseable for both
+#     positive and negative trigger claims.
+build_fixture "$FX"
+cat >"$FX/.github/workflows/gate.yml" <<'WF'
+name: Gate
+on: { pull_request: }
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+WF
+if out=$(check_claims "$FX"); then
+  fail workflow-flow-map-fails "flow-map triggers passed"
+else
+  if output_has_line "$out" "claim-error: workflow-on: cannot parse triggers of gate.yml" \
+    && output_has_line "$out" "claim-error: workflow-not-on: cannot parse triggers of gate.yml"; then
+    pass workflow-flow-map-fails
+  else
+    fail workflow-flow-map-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# 13. A normative contract source requires at least one contract-scope marker.
+build_fixture "$FX"
+sed -i.bak '/claim: contract-scope alpha-ad/d' "$FX/AGENTS.md" && rm -f "$FX/AGENTS.md.bak"
+if out=$(check_claims "$FX"); then
+  fail coverage-missing-contract-scope-fails "missing contract-scope marker passed"
+else
+  if output_has_line "$out" "claim-error: coverage: adapters/CONTRACT.md contains a 'normative for' line but AGENTS.md carries no contract-scope claim"; then
+    pass coverage-missing-contract-scope-fails
+  else
+    fail coverage-missing-contract-scope-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# 14. A backticked required-check context in prose requires its marker.
+build_fixture "$FX"
+sed -i.bak '/claim: required-check gate \/ inner/d' "$FX/AGENTS.md" && rm -f "$FX/AGENTS.md.bak"
+printf 'The required context is `gate / inner`.\n' >>"$FX/AGENTS.md"
+if out=$(check_claims "$FX"); then
+  fail coverage-unmarked-required-check-fails "unmarked required-check context passed"
+else
+  if output_has_line "$out" "claim-error: coverage: 'gate / inner' is mentioned but carries no required-check claim"; then
+    pass coverage-unmarked-required-check-fails
+  else
+    fail coverage-unmarked-required-check-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# 15. Uppercase and underscore are part of the make-target mention grammar.
+build_fixture "$FX"
+printf 'Also run `make TEST_ALL` before pushing.\n' >>"$FX/AGENTS.md"
+if out=$(check_claims "$FX"); then
+  fail coverage-unmarked-uppercase-make-fails "uppercase make mention passed"
+else
+  if output_has_line "$out" "claim-error: coverage: 'make TEST_ALL' is mentioned but carries no make-target claim"; then
+    pass coverage-unmarked-uppercase-make-fails
+  else
+    fail coverage-unmarked-uppercase-make-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 16. The real repository's AGENTS.md passes against its real sources.
 # ---------------------------------------------------------------------------
 
 if out=$(check_claims "$ROOT"); then
@@ -542,7 +665,7 @@ else
   fail real-agents-md-consistent "$out"
 fi
 
-# 12. Best effort, maintainer machines only: when the branch-protection API is
+# 17. Best effort, maintainer machines only: when the branch-protection API is
 #     readable, the claimed required-check set must equal the protected
 #     contexts exactly. CI tokens cannot read this endpoint; that is not a
 #     bypass of the suite - the source-level half of the claim ran above.

--- a/tests/agents-md-claims.test.sh
+++ b/tests/agents-md-claims.test.sh
@@ -1,0 +1,570 @@
+#!/bin/bash
+# AGENTS.md claim-drift check (#155).
+#
+# AGENTS.md duplicates a small number of facts whose sources live elsewhere in
+# the repository (workflow triggers, the adapter-contract scope, make targets,
+# the required-check list). Each such fact carries a machine-readable marker:
+#
+#   <!-- claim: <type> <args...> -->
+#
+# This suite evaluates every marker against its source and fails when they
+# disagree. It is fail-closed: zero evaluated claims is a failure, an unknown
+# claim type is a failure, and a workflow file or make target mentioned in the
+# prose without a covering marker is a failure.
+#
+# Claim vocabulary:
+#   make-target <name>              Makefile defines <name> as a target
+#   contract-scope <adapter>...     adapters/CONTRACT.md names exactly these
+#                                   adapters in its normative-scope sentence
+#   workflow-on <file> <event>...   each event is a top-level trigger of
+#                                   .github/workflows/<file>
+#   workflow-not-on <file> <event>... each event is NOT a trigger of <file>
+#   required-check <job> / <check>  <job> is a job id in a pull_request-
+#                                   triggered workflow of this repository.
+#                                   When the branch-protection API is readable
+#                                   (maintainer machines), the full claimed set
+#                                   must equal the protected contexts exactly.
+#
+# Bash 3.2+; no dependencies beyond what the repository already requires.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+pass_count=0
+fail_count=0
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/agents-md-claims-test.XXXXXX")
+
+log() {
+  printf '%s\n' "$*"
+}
+
+pass() {
+  pass_count=$(( pass_count + 1 ))
+  log "PASS $1"
+}
+
+fail() {
+  fail_count=$(( fail_count + 1 ))
+  log "FAIL $1: $2"
+}
+
+cleanup() {
+  rm -rf "$TMP"
+}
+trap cleanup EXIT HUP INT TERM
+
+# ---------------------------------------------------------------------------
+# Checker core. Everything below operates on a repository root passed as $1 so
+# the same code path runs against throwaway fixtures and the real repository.
+# ---------------------------------------------------------------------------
+
+# Top-level trigger events of a workflow file, one per line.
+# Handles the three forms used here: block map, inline list, bare scalar.
+workflow_events() {
+  awk '
+    /^on:[[:space:]]*$/ { inon = 1; next }
+    /^on:[[:space:]]*\[/ {
+      line = $0
+      sub(/^on:[[:space:]]*\[/, "", line); sub(/\].*/, "", line)
+      count = split(line, items, ",")
+      for (i = 1; i <= count; i++) {
+        gsub(/[[:space:]]/, "", items[i])
+        if (items[i] != "") print items[i]
+      }
+      exit
+    }
+    /^on:[[:space:]]+[a-z_]+[[:space:]]*(#.*)?$/ {
+      line = $0; sub(/^on:[[:space:]]+/, "", line)
+      sub(/[[:space:]]*#.*/, "", line); gsub(/[[:space:]]/, "", line)
+      print line; exit
+    }
+    inon && /^[^[:space:]#]/ { inon = 0 }
+    inon && /^[[:space:]]+[a-z_]+:/ {
+      match($0, /^[[:space:]]*/)
+      if (! event_indent) event_indent = RLENGTH
+      if (RLENGTH == event_indent) {
+        k = $1; sub(/:.*/, "", k); print k
+      }
+    }
+  ' "$1"
+}
+
+# Job ids of a workflow file, one per line.
+workflow_jobs() {
+  awk '
+    /^jobs:[[:space:]]*$/ { injobs = 1; next }
+    injobs && /^[^[:space:]#]/ { injobs = 0 }
+    injobs && /^[[:space:]]+[A-Za-z0-9_-]+:/ {
+      match($0, /^[[:space:]]*/)
+      if (! job_indent) job_indent = RLENGTH
+      if (RLENGTH == job_indent) {
+        k = $1; sub(/:.*/, "", k); print k
+      }
+    }
+  ' "$1"
+}
+
+# All claim markers of an AGENTS.md, with the wrapper stripped.
+extract_claims() {
+  awk '
+    /^<!-- claim: [a-z-]+( [^ ].*)? -->$/ {
+      line = $0
+      sub(/^<!-- claim: /, "", line)
+      sub(/ -->$/, "", line)
+      print line
+    }
+  ' "$1"
+}
+
+output_has_line() {
+  local output=$1
+  local expected=$2
+  printf '%s\n' "$output" | grep -qxF -- "$expected"
+}
+
+# check_claims <root> — evaluates every claim in <root>/AGENTS.md.
+# Prints one "claim-error: ..." line per violation; returns 1 if any.
+check_claims() {
+  local root=$1
+  local agents="$root/AGENTS.md"
+  local errors=0
+  local claims_checked=0
+
+  if [ ! -f "$agents" ]; then
+    log "claim-error: $agents does not exist"
+    return 1
+  fi
+
+  # --- relative links resolve (global, no marker needed) ------------------
+  local links_checked=0
+  local link target
+  while IFS= read -r link; do
+    case "$link" in
+      http://*|https://*|mailto:*|'#'*) continue ;;
+    esac
+    target=${link%%#*}
+    [ -n "$target" ] || continue
+    links_checked=$(( links_checked + 1 ))
+    if [ ! -e "$root/$target" ]; then
+      log "claim-error: relative link does not resolve: $link"
+      errors=$(( errors + 1 ))
+    fi
+  done <<EOF
+$({ grep -oE '\]\([^)]+\)' "$agents" || true; } | sed -e 's/^](//' -e 's/)$//')
+EOF
+  if [ "$links_checked" -eq 0 ]; then
+    log "claim-error: zero relative links found - refusing vacuous green"
+    errors=$(( errors + 1 ))
+  fi
+
+  # --- marked claims ------------------------------------------------------
+  local malformed
+  while IFS= read -r malformed; do
+    [ -n "$malformed" ] || continue
+    log "claim-error: malformed claim marker: $malformed"
+    errors=$(( errors + 1 ))
+  done <<EOF
+$(awk 'index($0, "<!-- claim:") && $0 !~ /^<!-- claim: [a-z-]+( [^ ].*)? -->$/ { print }' "$agents")
+EOF
+
+  local claim ctype args
+  while IFS= read -r claim; do
+    [ -n "$claim" ] || continue
+    claims_checked=$(( claims_checked + 1 ))
+    case "$claim" in
+      *' '*) ctype=${claim%% *}; args=${claim#* } ;;
+      *) ctype=$claim; args= ;;
+    esac
+    case "$ctype" in
+
+      make-target)
+        if ! printf '%s\n' "$args" | grep -qE '^[A-Za-z0-9_.-]+$'; then
+          log "claim-error: make-target: invalid arguments: $args"
+          errors=$(( errors + 1 ))
+        elif ! grep -qE "^${args}([[:space:]]+[^:]*)?:" "$root/Makefile" 2>/dev/null; then
+          log "claim-error: make-target '$args' not defined in Makefile"
+          errors=$(( errors + 1 ))
+        fi
+        ;;
+
+      contract-scope)
+        local sentence scope_words adapter dir dirname listed
+        if ! printf '%s\n' "$args" \
+          | grep -qE '^[A-Za-z0-9_.-]+( [A-Za-z0-9_.-]+)*$'; then
+          log "claim-error: contract-scope: invalid arguments: $args"
+          errors=$(( errors + 1 ))
+          continue
+        fi
+        sentence=$(awk 'tolower($0) ~ /normative for/ { print; exit }' \
+          "$root/adapters/CONTRACT.md" 2>/dev/null \
+          | tr 'A-Z' 'a-z' | sed 's/claude code/claude-code/g')
+        if [ -z "$sentence" ]; then
+          log "claim-error: contract-scope: no 'normative for' sentence in adapters/CONTRACT.md"
+          errors=$(( errors + 1 ))
+        else
+          scope_words=$(printf '%s\n' "$sentence" | tr -cs 'a-z0-9_-' '\n')
+          for adapter in $args; do
+            if [ ! -d "$root/adapters/$adapter" ]; then
+              log "claim-error: contract-scope: claimed adapter directory does not exist: $adapter"
+              errors=$(( errors + 1 ))
+            fi
+            if ! printf '%s\n' "$scope_words" | grep -qxF "$adapter"; then
+              log "claim-error: contract-scope: '$adapter' claimed but absent from CONTRACT.md scope sentence"
+              errors=$(( errors + 1 ))
+            fi
+          done
+          for dir in "$root"/adapters/*/; do
+            dirname=$(basename "$dir")
+            listed=0
+            for adapter in $args; do
+              [ "$adapter" = "$dirname" ] && listed=1
+            done
+            if [ "$listed" -eq 0 ]; then
+              if printf '%s\n' "$scope_words" | grep -qxF "$dirname"; then
+                log "claim-error: contract-scope: '$dirname' appears in CONTRACT.md scope sentence but is not claimed"
+                errors=$(( errors + 1 ))
+              fi
+            fi
+          done
+        fi
+        ;;
+
+      workflow-on|workflow-not-on)
+        local wfile events ev found
+        if ! printf '%s\n' "$args" \
+          | grep -qE '^[A-Za-z0-9_.-]+( [a-z_]+)+$'; then
+          log "claim-error: $ctype: invalid arguments: $args"
+          errors=$(( errors + 1 ))
+          continue
+        fi
+        wfile=${args%% *}
+        if [ ! -f "$root/.github/workflows/$wfile" ]; then
+          log "claim-error: $ctype: no such workflow file: $wfile"
+          errors=$(( errors + 1 ))
+        else
+          events=$(workflow_events "$root/.github/workflows/$wfile")
+          for ev in ${args#* }; do
+            found=0
+            case "
+$events
+" in
+              *"
+$ev
+"*) found=1 ;;
+            esac
+            if [ "$ctype" = "workflow-on" ] && [ "$found" -eq 0 ]; then
+              log "claim-error: workflow-on: $wfile does not trigger on '$ev' (actual: $(printf '%s' "$events" | tr '\n' ' '))"
+              errors=$(( errors + 1 ))
+            fi
+            if [ "$ctype" = "workflow-not-on" ] && [ "$found" -eq 1 ]; then
+              log "claim-error: workflow-not-on: $wfile DOES trigger on '$ev'"
+              errors=$(( errors + 1 ))
+            fi
+          done
+        fi
+        ;;
+
+      required-check)
+        local caller_job wf wf_ok
+        if ! printf '%s\n' "$args" \
+          | grep -qE '^[A-Za-z0-9_-]+[[:space:]]+/[[:space:]]+[A-Za-z0-9_-]+$'; then
+          log "claim-error: required-check: invalid arguments: $args"
+          errors=$(( errors + 1 ))
+          continue
+        fi
+        caller_job=$(printf '%s' "$args" | sed 's|[[:space:]]*/.*||')
+        wf_ok=0
+        for wf in "$root"/.github/workflows/*.yml; do
+          [ -f "$wf" ] || continue
+          if workflow_jobs "$wf" | grep -qxF "$caller_job"; then
+            if workflow_events "$wf" | grep -qxF "pull_request"; then
+              wf_ok=1
+              break
+            fi
+          fi
+        done
+        if [ "$wf_ok" -eq 0 ]; then
+          log "claim-error: required-check: '$caller_job' is not a job id of any pull_request-triggered workflow"
+          errors=$(( errors + 1 ))
+        fi
+        ;;
+
+      *)
+        log "claim-error: unknown claim type '$ctype' - add it to the checker or remove the marker"
+        errors=$(( errors + 1 ))
+        ;;
+    esac
+  done <<EOF
+$(extract_claims "$agents")
+EOF
+
+  # --- fail closed --------------------------------------------------------
+  if [ "$claims_checked" -eq 0 ]; then
+    log "claim-error: zero claims checked - refusing vacuous green (fail-closed)"
+    errors=$(( errors + 1 ))
+  fi
+
+  # --- coverage guard: prose mentions without a marker --------------------
+  # A workflow file named in the prose is a trigger claim; a `make <target>`
+  # in the prose is an existence claim. Naming one without a marker fails.
+  local mention
+  while IFS= read -r mention; do
+    [ -n "$mention" ] || continue
+    if [ -f "$root/.github/workflows/$mention" ] \
+      && ! extract_claims "$agents" | grep -qE "^workflow-(on|not-on) $mention( |$)"; then
+      log "claim-error: coverage: $mention is mentioned but carries no workflow-on/workflow-not-on claim"
+      errors=$(( errors + 1 ))
+    fi
+  done <<EOF
+$({ grep -oE '[A-Za-z0-9_-]+\.yml' "$agents" || true; } | sort -u)
+EOF
+
+  while IFS= read -r mention; do
+    [ -n "$mention" ] || continue
+    if ! extract_claims "$agents" | grep -qxF "make-target $mention"; then
+      log "claim-error: coverage: 'make $mention' is mentioned but carries no make-target claim"
+      errors=$(( errors + 1 ))
+    fi
+  done <<EOF
+$({ grep -oE 'make [a-z][a-z-]*' "$agents" || true; } | sed 's/^make //' | sort -u)
+EOF
+
+  log "claims-checked=$claims_checked links-checked=$links_checked"
+  [ "$errors" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Fixture builder for negative cases.
+# ---------------------------------------------------------------------------
+
+build_fixture() {
+  local dir=$1
+  rm -rf "$dir"
+  mkdir -p "$dir/.github/workflows" "$dir/adapters/alpha-ad" "$dir/adapters/beta-ad" "$dir/docs"
+  printf 'This contract is normative for the Alpha-Ad adapter.\n' >"$dir/adapters/CONTRACT.md"
+  printf 'placeholder\n' >"$dir/docs/guide.md"
+  cat >"$dir/Makefile" <<'MK'
+test:
+	@true
+MK
+  cat >"$dir/.github/workflows/gate.yml" <<'WF'
+name: Gate
+on:
+  pull_request:
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+WF
+  cat >"$dir/AGENTS.md" <<'MD'
+# fixture map
+
+See [docs/guide.md](docs/guide.md). Verify with `make test`.
+The gate runs on every PR via gate.yml.
+
+<!-- claim: make-target test -->
+<!-- claim: contract-scope alpha-ad -->
+<!-- claim: workflow-on gate.yml pull_request -->
+<!-- claim: workflow-not-on gate.yml push -->
+<!-- claim: required-check gate / inner -->
+MD
+}
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+FX="$TMP/fixture"
+
+# 1. A consistent fixture passes.
+build_fixture "$FX"
+if out=$(check_claims "$FX"); then
+  pass fixture-consistent-passes
+else
+  fail fixture-consistent-passes "expected pass, got: $out"
+fi
+
+# 2. Inline-list and scalar workflow trigger forms are parsed explicitly. The
+#    real repository covers the block-map form.
+cat >"$FX/.github/workflows/inline.yml" <<'WF'
+name: Inline
+on: [pull_request, workflow_dispatch]
+WF
+cat >"$FX/.github/workflows/scalar.yml" <<'WF'
+name: Scalar
+on: push
+WF
+inline_events=$(workflow_events "$FX/.github/workflows/inline.yml")
+scalar_events=$(workflow_events "$FX/.github/workflows/scalar.yml")
+if [ "$inline_events" = "$(printf 'pull_request\nworkflow_dispatch')" ] \
+  && [ "$scalar_events" = "push" ]; then
+  pass workflow-trigger-syntaxes-supported
+else
+  fail workflow-trigger-syntaxes-supported \
+    "inline=[$(printf '%s' "$inline_events" | tr '\n' ';')] scalar=[$scalar_events]"
+fi
+
+# 3. Trigger drift: the workflow moves off pull_request; the claim still says
+#    pull_request. Both the workflow-on claim and the required-check claim
+#    must catch it.
+build_fixture "$FX"
+sed -i.bak 's/^  pull_request:/  push:/' "$FX/.github/workflows/gate.yml" && rm -f "$FX/.github/workflows/gate.yml.bak"
+if out=$(check_claims "$FX"); then
+  fail drift-trigger-fails "trigger drift passed undetected"
+else
+  if output_has_line "$out" "claim-error: workflow-on: gate.yml does not trigger on 'pull_request' (actual: push)" \
+    && output_has_line "$out" "claim-error: workflow-not-on: gate.yml DOES trigger on 'push'" \
+    && output_has_line "$out" "claim-error: required-check: 'gate' is not a job id of any pull_request-triggered workflow"; then
+    pass drift-trigger-fails
+  else
+    fail drift-trigger-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# 4. Contract-scope drift, both directions.
+build_fixture "$FX"
+printf 'This contract is normative for the Alpha-Ad and Beta-Ad adapters.\n' >"$FX/adapters/CONTRACT.md"
+if out=$(check_claims "$FX"); then
+  fail drift-scope-widened-fails "scope widening passed undetected"
+else
+  if output_has_line "$out" "claim-error: contract-scope: 'beta-ad' appears in CONTRACT.md scope sentence but is not claimed"; then
+    pass drift-scope-widened-fails
+  else
+    fail drift-scope-widened-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+build_fixture "$FX"
+printf 'This contract is normative for the Beta-Ad adapter.\n' >"$FX/adapters/CONTRACT.md"
+if out=$(check_claims "$FX"); then
+  fail drift-scope-narrowed-fails "scope narrowing passed undetected"
+else
+  if output_has_line "$out" "claim-error: contract-scope: 'alpha-ad' claimed but absent from CONTRACT.md scope sentence"; then
+    pass drift-scope-narrowed-fails
+  else
+    fail drift-scope-narrowed-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# 5. Fail-closed: an AGENTS.md with no markers at all is a failure even
+#    though nothing it says is wrong.
+build_fixture "$FX"
+cat >"$FX/AGENTS.md" <<'MD'
+# fixture map
+
+See [docs/guide.md](docs/guide.md).
+MD
+if out=$(check_claims "$FX"); then
+  fail fail-closed-zero-claims "zero claims passed"
+else
+  if output_has_line "$out" "claim-error: zero claims checked - refusing vacuous green (fail-closed)"; then
+    pass fail-closed-zero-claims
+  else
+    fail fail-closed-zero-claims "failed for the wrong reason: $out"
+  fi
+fi
+
+# 6. Unknown claim type fails loudly.
+build_fixture "$FX"
+printf '<!-- claim: sha-of-truth abc123 -->\n' >>"$FX/AGENTS.md"
+if out=$(check_claims "$FX"); then
+  fail unknown-claim-type-fails "unknown claim type passed"
+else
+  if output_has_line "$out" "claim-error: unknown claim type 'sha-of-truth' - add it to the checker or remove the marker"; then
+    pass unknown-claim-type-fails
+  else
+    fail unknown-claim-type-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# 7. A dead relative link fails.
+build_fixture "$FX"
+rm "$FX/docs/guide.md"
+if out=$(check_claims "$FX"); then
+  fail dead-link-fails "dead relative link passed"
+else
+  if output_has_line "$out" "claim-error: relative link does not resolve: docs/guide.md"; then
+    pass dead-link-fails
+  else
+    fail dead-link-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# 8. Missing make target fails.
+build_fixture "$FX"
+printf 'all:\n\t@true\n' >"$FX/Makefile"
+if out=$(check_claims "$FX"); then
+  fail missing-make-target-fails "missing make target passed"
+else
+  if output_has_line "$out" "claim-error: make-target 'test' not defined in Makefile"; then
+    pass missing-make-target-fails
+  else
+    fail missing-make-target-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# 9. Coverage guard: mentioning a workflow file with no covering claim fails.
+build_fixture "$FX"
+cp "$FX/.github/workflows/gate.yml" "$FX/.github/workflows/extra.yml"
+printf 'Also see extra.yml for the extra gate.\n' >>"$FX/AGENTS.md"
+if out=$(check_claims "$FX"); then
+  fail coverage-unmarked-workflow-fails "unmarked workflow mention passed"
+else
+  if output_has_line "$out" "claim-error: coverage: extra.yml is mentioned but carries no workflow-on/workflow-not-on claim"; then
+    pass coverage-unmarked-workflow-fails
+  else
+    fail coverage-unmarked-workflow-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# 10. Coverage guard: mentioning `make <target>` with no covering claim fails.
+build_fixture "$FX"
+printf 'Also run `make lint` before pushing.\n' >>"$FX/AGENTS.md"
+if out=$(check_claims "$FX"); then
+  fail coverage-unmarked-make-fails "unmarked make mention passed"
+else
+  if output_has_line "$out" "claim-error: coverage: 'make lint' is mentioned but carries no make-target claim"; then
+    pass coverage-unmarked-make-fails
+  else
+    fail coverage-unmarked-make-fails "failed for the wrong reason: $out"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 11. The real repository's AGENTS.md passes against its real sources.
+# ---------------------------------------------------------------------------
+
+if out=$(check_claims "$ROOT"); then
+  pass real-agents-md-consistent
+else
+  fail real-agents-md-consistent "$out"
+fi
+
+# 12. Best effort, maintainer machines only: when the branch-protection API is
+#     readable, the claimed required-check set must equal the protected
+#     contexts exactly. CI tokens cannot read this endpoint; that is not a
+#     bypass of the suite - the source-level half of the claim ran above.
+repo_url=$(git -C "$ROOT" config --get remote.origin.url 2>/dev/null || true)
+repo_slug=$(printf '%s\n' "$repo_url" \
+  | sed -e 's|^.*github.com[:/]||' -e 's|\.git$||')
+if [ -n "$repo_slug" ] && command -v gh >/dev/null 2>&1 \
+  && protected=$(gh api "repos/$repo_slug/branches/main/protection/required_status_checks" \
+      --jq '.contexts[]' 2>/dev/null); then
+  claimed=$(extract_claims "$ROOT/AGENTS.md" \
+    | awk '/^required-check / { sub(/^required-check /, ""); print }' | sort)
+  if [ "$(printf '%s\n' "$protected" | sort)" = "$claimed" ]; then
+    pass required-checks-match-branch-protection
+  else
+    fail required-checks-match-branch-protection \
+      "claimed [$(printf '%s' "$claimed" | tr '\n' ';')] != protected [$(printf '%s' "$protected" | sort | tr '\n' ';')]"
+  fi
+else
+  log "note: branch-protection API not readable here; required-check claims validated against workflow sources only"
+fi
+
+log "TOTAL pass=$pass_count fail=$fail_count"
+if [ "$fail_count" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Closes #155.

## What this adds

`AGENTS.md` duplicates a handful of facts whose sources live elsewhere in the repository, and #153's review showed every one of them was wrong in the first draft. This PR makes those duplicated facts machine-checked: each checkable claim in `AGENTS.md` now carries a marker —

```
<!-- claim: <type> <args...> -->
```

— and a new test suite evaluates every marker against its source on each PR (`make test` runs it; `test-lint / test` is a required check, so it is a PR gate). The prose stays free; the checked surface is explicit.

Claim vocabulary: `make-target`, `contract-scope`, `workflow-on`, `workflow-not-on`, `required-check` — plus unmarked global checks: every relative link resolves; a workflow file or `make <target>` mentioned in the prose without a covering marker fails loudly; a mentioned workflow file that does not exist fails loudly; a backticked `job / check` context in prose without a `required-check` marker fails loudly; a CONTRACT.md with a normative-scope sentence but no `contract-scope` claim fails loudly.

Fail-closed, per the issue: zero evaluated claims is a failure; an unknown claim type is a failure; an unparseable `on:` block is a failure for both trigger claim types — in the style of `make lint`'s vacuous-green refusal.

On the required-check list (the Done-when alternative "matches branch protection or is not stated as a list"): the list stays, with its validation disclosed in the map itself. Each named context is always validated source-level (the caller job must exist in a `pull_request`-triggered workflow); on machines whose token can read the branch-protection API (maintainer machines — CI tokens cannot), the claimed set must additionally equal the protected contexts exactly. This equality ran and passed on the review machine for this candidate. The disclosed residual: a coordinated rewrite of both prose list and markers passes in CI and is caught on the next maintainer run; the true check names live in the pinned reusable workflow (`@ci-v1`, foreign repo), which no PR in this repo can drift.

## Files changed

- `tests/agents-md-claims.test.sh` (new) — checker + 16 fixture cases + real-repo case + branch-protection equality case (18 total where the API is readable; the equality case degrades to an explicit `note:` line elsewhere, never a silent pass)
- `AGENTS.md` (136 lines) — 16 claim markers adjacent to the claims they check; section 6's "nothing in CI validates this file today" sentence updated; one disclosure sentence on the required-check bullet

Declared WIP file set was `tests/agents-md-claims.test.sh`, `AGENTS.md`, `Makefile`; `Makefile` is untouched — `make test` discovers `tests/*.test.sh` by glob, so no entry point was needed.

**pr-size**: 739 added lines total — a single-concern test suite that cannot be meaningfully split (handbook L2-3 splitting targets multi-concern PRs); `size-exempt` applied with this justification, consistent with repo precedent (#124, #135, #137, #161).

## Implementation

Writer: codex-sol (GPT-5.6, two sitter-run delegations — initial + seat-review delta; both runs delivered files then died streaming the final report; deliveries were verified independently by the orchestrator). Orchestrator/design/adjudication: Alpha (claude-fable-5). No Anthropic model wrote the shipped code.

## Review record (heterogeneous 3 seats, size M, writer-distinct)

Blind identical briefs, read-only, fresh context, launched independently; no OpenAI seat because the writer is codex-sol (L1-10). Full seat outputs + adjudication: #155 comment (posted at merge).

| requested | actual | family | round 1 | after delta (66a3dc9) |
| --- | --- | --- | --- | --- |
| kimi-k3 | kimi-k2.6 (self-reported; Kimi Code CLI) | Moonshot | GO-WITH-COMMENTS — 3 MINOR, 2 NIT | **GO** |
| glm-5.3 | glm-5.3 | Zhipu | GO-WITH-COMMENTS — 1 MAJOR, 1 MINOR, 2 NIT | **GO** |
| grok-4.6 | grok-4.6 | xAI | GO-WITH-COMMENTS — 1 MAJOR, 2 MINOR | **GO-WITH-COMMENTS** (comments = accepted residuals) |

Round-1 MAJORs, both fixed and probe-verified by their finding seats in delta: (GLM) coverage guard was silent when a prose-mentioned workflow file was deleted — now its own claim-error; (Grok) `required-check` inner names unvalidated in CI — disposed as in-map disclosure per the Done-when's stated alternative, plus a new prose-context guard that kills the marker-tamper probe Grok ran in round 1. Seat-transport notes: GLM and Grok each needed the known continuation-task re-order after mid-run process deaths; verdicts are from their own delivered files, no transcript reconstruction.

## Completion record (L1-7)

**Candidate SHA**: `66a3dc9fc7e5b81f071a396ba3a89c16dee7066b` (= PR head at review close)

| Done when | Verdict | Evidence (2026-08-25, local, on the candidate) |
| --- | --- | --- |
| A check exists that fails when a claim no longer matches its source | PASS | `bash tests/agents-md-claims.test.sh` → `TOTAL pass=18 fail=0`, exit 0 (bash 5.3); `/bin/bash` 3.2.57 → same; 14 drift fixtures assert failure *for the right reason* (exact `claim-error:` line via `output_has_line`) |
| Covers link resolution, make targets, contract scope, workflow triggers, required-check list | PASS | Cases 5–16 incl. `dead-link-fails`, `missing-make-target-fails`, `drift-scope-widened/narrowed-fails`, `drift-trigger-fails`, `workflow-flow-map-fails`, `coverage-missing-workflow-fails`, `coverage-missing-contract-scope-fails`, `coverage-unmarked-required-check-fails`; `required-checks-match-branch-protection` equality ran locally and passed against live branch protection |
| Runs as a PR gate, not post-merge only | PASS | Suite lives in `tests/*.test.sh`, discovered by `make test` (Makefile:13 glob); `test-lint / test` runs on `pull_request` and is a required context — both facts validated by the suite itself |
| Fails closed: zero claims checked is a failure | PASS | Case `fail-closed-zero-claims`: markerless AGENTS.md → `claim-error: zero claims checked - refusing vacuous green (fail-closed)`, exit 1 |
| Targets bash 3.2+, no new dependencies | PASS | `make lint` green incl. new file (`bash32 ANSI-C lint: 69 shell files OK`); explicit `/bin/bash` 3.2.57 run green (3 independent runs: orchestrator, Kimi, Grok); no `mapfile/readarray/declare -A/${var^^}/&>`; tools: bash/awk/sed/grep/sort/git + optional `gh` (guarded by `command -v`, degrades to a `note:` line) |
| `make test` and `make lint` green; CI green | PASS | `make lint` → 69 files OK, exit 0; `make test` on 66a3dc9 → `Suite Summary: 31 PASS, 0 FAIL`, exit 0; CI: all required contexts green on `66a3dc9` (checks tab; pr-size green via size-exempt, justification above) |

**Orchestrator mutation spot-checks** (real-repo copies, candidate 9e3d4ef→66a3dc9): trigger claim flipped → fails; marker deleted with prose intact → coverage guard fails; link broken → fails; GLM rot-path (workflow file deleted + markers removed) → fails with both new errors; flow-map `on:` → both trigger claim types error; `make TEST_ALL` phrasing → fails. Independently reproduced by the finding seats in their deltas.

**Declared files vs diff**: `git diff --stat origin/main...66a3dc9` → `AGENTS.md`, `tests/agents-md-claims.test.sh` only — subset of the WIP declaration; `Makefile` difference explained above.

**Identity**: writer codex-sol (OpenAI); reviewers Kimi (Moonshot) / GLM (Zhipu) / Grok (xAI) — all model-distinct from the writer and from each other (L1-3 / L1-10 / L1-11 S/M=3席).

**CI status**: all required contexts (`test-lint / test`, `test-lint / lint`, `test-lint / test-macos`, `test-lint / test-macos-skip`, `gitleaks / gitleaks`, `history-check / history-check`, `risk-review-gate / risk-review-gate`) green on `66a3dc9`.

**release**: v0.13.0 — a new PR-gate check is ship-equivalent (it changes what contributors' PRs must pass = a norm they follow; "when in doubt, ship-equivalent"). MINOR: new checking surface, no behavior change to the harness itself.

**previous release**: the #154 merge (`ee33269`) recorded `N/A` (docs-only type ①) and is not in the ship-equivalent chain; the most recent ship-equivalent merge released **v0.12.2** — fulfilled (annotated tag + GitHub Release exist, `Latest`, verified 2026-08-24/25). No deferred chain in effect.
