### PR TITLE
ci: declare stale OUTBOUND/GATES risk paths — hermes verifier example + bash32 lint gate (#136)

### DIFF
--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -13,6 +13,14 @@ jobs:
     permissions: {contents: read, issues: read, pull-requests: write}
     with:
       risk_paths_billing: 'none' # 課金・支出コードなし (#30 で明示宣言)
-      risk_paths_outbound: 'none' # 対外送信コード実在なし — curl/wget/webhook 等 grep 確認 (#30 で明示宣言)
-      risk_paths_gates: 'none' # Makefile は reusable 側 DEFAULT が覆う・tests/** は一級市民コードで通常レビュー対象 (#30 で明示宣言)
+      # OUTBOUND: #30 の 'none' (2026-08-10) は #56 (2026-08-13) の hermes verifier example が
+      # 実 outbound HTTP POST (Anthropic Messages API へ artifact bundle + API key) を持ち込んだ
+      # 時点で不成立 — #136 で宣言。1行1パターン (行内空白は 0 マッチの静かな fail-open)。
+      risk_paths_outbound: |
+        adapters/hermes/examples/verifier-provider.py
+      # GATES: make lint が呼ぶ scripts/check-bash32-ansi-c-escapes は scripts/ 直下で
+      # reusable DEFAULT (Makefile / scripts/ci/**) に覆われない — #136 で宣言。
+      # tests/** は一級市民コードで通常レビュー対象のまま (#30 の判断を維持)。
+      risk_paths_gates: |
+        scripts/check-bash32-ansi-c-escapes
       risk_paths_auth: 'none' # 認証コードなし (handbook#31 v0.9.2 同期の明示宣言)

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -18,9 +18,11 @@ jobs:
       # 時点で不成立 — #136 で宣言。1行1パターン (行内空白は 0 マッチの静かな fail-open)。
       risk_paths_outbound: |
         adapters/hermes/examples/verifier-provider.py
-      # GATES: make lint が呼ぶ scripts/check-bash32-ansi-c-escapes は scripts/ 直下で
-      # reusable DEFAULT (Makefile / scripts/ci/**) に覆われない — #136 で宣言。
+      # GATES: make lint が呼ぶ scripts/check-bash32-ansi-c-escapes と、ci-matrix.yml が
+      # source する scripts/lib-updater-verify.sh は scripts/ 直下で reusable DEFAULT
+      # (Makefile / scripts/ci/**) に覆われない — #136 で宣言 (後者は #175 GLM 席指摘)。
       # tests/** は一級市民コードで通常レビュー対象のまま (#30 の判断を維持)。
       risk_paths_gates: |
         scripts/check-bash32-ansi-c-escapes
+        scripts/lib-updater-verify.sh
       risk_paths_auth: 'none' # 認証コードなし (handbook#31 v0.9.2 同期の明示宣言)

--- a/adapters/hermes/examples/verifier-provider.py
+++ b/adapters/hermes/examples/verifier-provider.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Single-call Anthropic Messages verifier provider for the Hermes example."""
+# Declared OUTBOUND risk path (review-labels.yml, #136): this file performs real
+# outbound HTTP to the Anthropic API — changes here require the risk-review gate.
 
 import json
 import os

--- a/scripts/check-bash32-ansi-c-escapes
+++ b/scripts/check-bash32-ansi-c-escapes
@@ -1,4 +1,6 @@
 """Reject Bash 4.2+ Unicode escapes inside ANSI-C quoted shell strings."""
+# Declared GATES risk path (review-labels.yml, #136): `make lint` calls this file —
+# changes here require the risk-review gate (a 1-file PR could defang the linter).
 
 from __future__ import annotations
 


### PR DESCRIPTION
Closes #136.

## What this changes

PR #135's seat review found two risk-path declarations in `review-labels.yml` that had gone stale against the tree (both pre-existing on main, adjudicated as follow-up = this issue):

1. **OUTBOUND**: `risk_paths_outbound: 'none'` (#30, declared 2026-08-10) stopped being true when #56 (2026-08-13) added `adapters/hermes/examples/verifier-provider.py` — a real outbound HTTP caller (Anthropic Messages API, artifact bundle + API key). Now declared, so PRs touching it require the risk-review gate.
2. **GATES**: `make lint` executes `scripts/check-bash32-ansi-c-escapes`, which sits directly under `scripts/` — outside the reusable DEFAULT (`Makefile`, `scripts/ci/**`). A one-file PR could have defanged the linter outside the human-review net. Now declared.

Both declarations use the one-pattern-per-line block form (an inline space-separated list silently matches zero files — the reusable's own documented trap). Side-note comments updated to record the history (#30 judgment kept for `tests/**`; staleness cause and #136 referenced).

Each newly declared file also gains a two-line header comment marking it as a declared risk path — this makes the declaration discoverable at the file itself, and (deliberately) makes this PR touch both declared paths so the PR's own `detect-risk-paths` run is the live detection evidence the Done-when asks for.

## Files changed

- `.github/workflows/review-labels.yml` — 2 declarations + side-note comments
- `adapters/hermes/examples/verifier-provider.py` — 2-line comment (inert; `py_compile` clean)
- `scripts/check-bash32-ansi-c-escapes` — 2-line comment (inert; the script lints itself clean)

The issue predicted only `review-labels.yml`; the two comment files were added to produce in-PR detection evidence and were declared in the WIP before writing (collision-checked: `verifier-provider.py` is outside lane #145's frozen file list; #148 holds no WIP). This PR touches `.github/workflows/**` (a DEFAULT risk path), so the gate's human checkpoint applies to this PR itself — by design.

## Done when → evidence (completion record L1-7)

**Candidate SHA**: `22127e6bbb3694e5c49f3b61df0036d4638fbfc2` (supersedes `121a306` — +1 GATES pattern from GLM seat finding, seats re-verified with cumulative GO ×3)

| Done when | Verdict | Evidence |
| --- | --- | --- |
| `risk_paths_outbound` declares the hermes example | PASS | Diff: block-form pattern `adapters/hermes/examples/verifier-provider.py` |
| `risk_paths_gates` declares the lint gate script | PASS | Diff: block-form pattern `scripts/check-bash32-ansi-c-escapes` |
| `detect-risk-paths` actually detects changes on those paths (log = evidence) | PASS | This PR touches both declared files; detect run on this PR lists them — log link recorded below at review close |
| Old 'none' side-notes updated | PASS | Diff: OUTBOUND note cites #56 staleness cause; GATES note keeps #30's `tests/**` judgment, both cite #136 |
| `make test` / `make lint` green | PASS | `make lint` → 71 shell files OK, exit 0; claim suite 18/18; `make test` full run recorded before merge; `py_compile` clean on the touched example |
| CI | recorded at merge | `risk-review-gate` stays red until the roster human applies `risk-reviewed` for the final head — that red is the gate working, not a failure of this PR |

**Detection evidence (filled at review close)**: round-1 head 121a306: https://github.com/caty-ai/caty-agent-harness/actions/runs/32771868949/job/97573814567 (`risk_hit=true`, all 3 files listed); final head 22127e6: https://github.com/caty-ai/caty-agent-harness/actions/runs/32774648520/job/97582795560 — full excerpt in the #136 review-record comment

**Declared files vs diff**: 3 files above = exactly the WIP-declared set.

**Identity**: writer Alpha (claude-fable-5; CI wiring + 2 inert comments — S-size direct edit, nudge allow-list declared for the .py). Review seats (heterogeneous 3, writer-distinct): recorded on #136.

**release**: N/A — closed type ③: CI wiring only (no behavior, API, or distribution change; the gate's coverage widens, the harness itself is unchanged).

**previous release**: v0.14.0 (#147 merge) — fulfilled (annotated tag + GitHub Release, `Latest`; verified 2026-08-25). The intervening #174 merge recorded N/A type ①. No deferred chain.

