### PR TITLE
learning loop: enforce Verified facts (120) / General rules (80) caps in code (#170)

### DIFF
--- a/scripts/flush-intake.sh
+++ b/scripts/flush-intake.sh
@@ -103,12 +103,13 @@ write_receipt() {
   local timestamp
 
   timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-  printf 'ts=%s files_scanned=%s blocks=%s candidates=%s folded=%s deduped=%s evicted_by_cap=%s eviction_archive=%s dropped_oversize=%s deferred=%s headerless_bullets=%s torn_lines=%s quarantined=%s lock=%s marker=%s error=%s%s%s\n' \
+  printf 'ts=%s files_scanned=%s blocks=%s candidates=%s folded=%s deduped=%s evicted_by_cap=%s eviction_archive=%s dropped_oversize=%s deferred=%s headerless_bullets=%s torn_lines=%s quarantined=%s lock=%s marker=%s error=%s%s%s%s\n' \
     "$timestamp" "$files_scanned" "$blocks" "$candidates" "$folded" "$deduped" \
     "$evicted_by_cap" "$eviction_archive" "$dropped_oversize" "$deferred" \
     "$headerless_bullets" "$torn_lines" \
     "$quarantined" "$lock_status" "$marker_status" "$receipt_error" "$quarantined_paths" \
     "$last_session_receipt" \
+    "$caps_receipt" \
     >>"$receipt_file"
 }
 
@@ -259,12 +260,14 @@ quarantined=0
 quarantined_paths=
 receipt_error=none
 last_session_receipt=' last_session_fold=failed reason=not-run'
+caps_receipt=' caps_vf_evicted=0 caps_gr_evicted=0 caps_fold=failed caps_fold_reason=not-run'
 
 # Only old debris is swept so a concurrent process cannot lose a live temp file.
 find "$pending_dir" -maxdepth 1 -type f -name '.intake-*.tmp.*' -mtime +1 -delete
 
 if ! take_state_lock "$workspace" "$adapter_identity" "$lock_attempts" "$lock_sleep"; then
   last_session_receipt=' last_session_fold=failed reason=lock-busy'
+  caps_receipt=' caps_vf_evicted=0 caps_gr_evicted=0 caps_fold=failed caps_fold_reason=lock-busy'
   write_receipt busy untouched
   exit 0
 fi
@@ -284,7 +287,8 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-if fold_last_session_index "$workspace" "$state_file" "$work_dir" "$(date -u '+%Y-%m-%d')"; then
+today=$(date -u '+%Y-%m-%d')
+if fold_last_session_index "$workspace" "$state_file" "$work_dir" "$today"; then
   last_session_receipt=" last_session_entries=$LAST_SESSION_ENTRIES evicted=$LAST_SESSION_EVICTED synthesized_handoffs=$LAST_SESSION_SYNTHESIZED_HANDOFFS"
 else
   case "$LAST_SESSION_FOLD_REASON" in
@@ -296,6 +300,23 @@ else
       ;;
     *)
       last_session_receipt=" last_session_fold=skipped reason=$LAST_SESSION_FOLD_REASON"
+      ;;
+  esac
+fi
+
+if fold_declared_state_caps "$workspace" "$state_file" "$work_dir" \
+  "$adapter_identity" "$today"; then
+  caps_receipt=" caps_vf_evicted=$STATE_CAPS_VERIFIED_EVICTED caps_gr_evicted=$STATE_CAPS_RULES_EVICTED caps_fold=ok caps_fold_reason=none"
+else
+  case "$STATE_CAPS_FOLD_REASON" in
+    missing-sections|missing-verified-facts|missing-general-rules)
+      caps_receipt=" caps_vf_evicted=0 caps_gr_evicted=0 caps_fold=skipped caps_fold_reason=$STATE_CAPS_FOLD_REASON"
+      ;;
+    *)
+      caps_receipt=" caps_vf_evicted=0 caps_gr_evicted=0 caps_fold=failed caps_fold_reason=$STATE_CAPS_FOLD_REASON"
+      receipt_error=state-caps-fold
+      write_receipt acquired untouched
+      exit 1
       ;;
   esac
 fi
@@ -323,7 +344,6 @@ snapshot_state_normalized_candidates "$state_file" "$normalized_failures_state" 
 
 find "$pending_dir" -maxdepth 1 -type f -name 'flush-*.md' -print \
   | LC_ALL=C sort >"$files_file"
-today=$(date -u '+%Y-%m-%d')
 budget_used=0
 
 while IFS= read -r flush_file || [[ -n "$flush_file" ]]; do

--- a/scripts/flush-intake.sh
+++ b/scripts/flush-intake.sh
@@ -309,7 +309,7 @@ if fold_declared_state_caps "$workspace" "$state_file" "$work_dir" \
   caps_receipt=" caps_vf_evicted=$STATE_CAPS_VERIFIED_EVICTED caps_gr_evicted=$STATE_CAPS_RULES_EVICTED caps_fold=ok caps_fold_reason=none"
 else
   case "$STATE_CAPS_FOLD_REASON" in
-    missing-sections|missing-verified-facts|missing-general-rules)
+    duplicate-heading|missing-sections|missing-verified-facts|missing-general-rules)
       caps_receipt=" caps_vf_evicted=0 caps_gr_evicted=0 caps_fold=skipped caps_fold_reason=$STATE_CAPS_FOLD_REASON"
       ;;
     *)

--- a/scripts/lib-state-fold.sh
+++ b/scripts/lib-state-fold.sh
@@ -606,19 +606,28 @@ fold_declared_state_caps() {
   local verified_evictions="$work_dir/state-caps.verified"
   local rules_evictions="$work_dir/state-caps.rules"
   local archive_payload="$work_dir/state-caps.archive"
+  local archived_payload="$work_dir/state-caps.archived"
   local summary_file="$work_dir/state-caps.summary"
   local summary
   local has_verified
   local has_rules
   local archive_file
   local timestamp
+  local payload_lines_before
+  local payload_lines_after
+  local archive_payload_lines
+  local verified_archived_lines=0
+  local rules_archived_lines=0
 
   STATE_CAPS_VERIFIED_EVICTED=0
   STATE_CAPS_RULES_EVICTED=0
   STATE_CAPS_FOLD_REASON=none
   : >"$verified_evictions"
   : >"$rules_evictions"
-  : >"$archive_payload"
+  : >"$archive_payload" || {
+    STATE_CAPS_FOLD_REASON=archive-payload
+    return 1
+  }
   cp "$state_file" "$snapshot" || {
     STATE_CAPS_FOLD_REASON=snapshot
     return 1
@@ -639,7 +648,7 @@ fold_declared_state_caps() {
       start = 1
       if (section_count > cap) start = section_count - cap + 1
       for (i = 1; i < start; i++) {
-        print section_lines[i] > eviction_file
+        print section_lines[i] >> eviction_file
         if (section == "verified") verified_evicted++
         else rules_evicted++
       }
@@ -655,13 +664,13 @@ fold_declared_state_caps() {
         print
         if (index($0, "## Verified facts") == 1) {
           section = "verified"
-          has_verified = 1
+          has_verified++
           preamble = 1
           next
         }
         if (index($0, "## General rules") == 1) {
           section = "rules"
-          has_rules = 1
+          has_rules++
           preamble = 1
           next
         }
@@ -693,6 +702,10 @@ fold_declared_state_caps() {
     STATE_CAPS_RULES_EVICTED <<EOF
 $summary
 EOF
+  if [[ "$has_verified" -gt 1 || "$has_rules" -gt 1 ]]; then
+    STATE_CAPS_FOLD_REASON=duplicate-heading
+    return 1
+  fi
   if [[ "$has_verified" -ne 1 && "$has_rules" -ne 1 ]]; then
     STATE_CAPS_FOLD_REASON=missing-sections
     return 1
@@ -714,24 +727,71 @@ EOF
     return 1
   fi
 
+  archive_file="$workspace/loop/archive/intake-evictions-$fold_date.md"
+  if [[ -e "$archive_file" || -L "$archive_file" ]]; then
+    if [[ ! -f "$archive_file" || -L "$archive_file" ]]; then
+      STATE_CAPS_FOLD_REASON=archive-target
+      return 1
+    fi
+  fi
   timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
   if [[ "$STATE_CAPS_VERIFIED_EVICTED" -gt 0 ]]; then
-    printf '<!-- caps eviction section=verified-facts adapter=%s ts=%s -->\n' \
-      "$adapter" "$timestamp" >>"$archive_payload"
-    cat "$verified_evictions" >>"$archive_payload"
+    payload_lines_before=$(wc -l <"$archive_payload" | tr -d '[:space:]') || {
+      STATE_CAPS_FOLD_REASON=archive-payload
+      return 1
+    }
+    if ! printf '<!-- caps eviction section=verified-facts adapter=%s ts=%s -->\n' \
+      "$adapter" "$timestamp" >>"$archive_payload"; then
+      STATE_CAPS_FOLD_REASON=archive-payload
+      return 1
+    fi
+    if ! cat "$verified_evictions" >>"$archive_payload"; then
+      STATE_CAPS_FOLD_REASON=archive-payload
+      return 1
+    fi
+    payload_lines_after=$(wc -l <"$archive_payload" | tr -d '[:space:]') || {
+      STATE_CAPS_FOLD_REASON=archive-payload
+      return 1
+    }
+    verified_archived_lines=$((payload_lines_after - payload_lines_before - 1))
   fi
   if [[ "$STATE_CAPS_RULES_EVICTED" -gt 0 ]]; then
-    printf '<!-- caps eviction section=general-rules adapter=%s ts=%s -->\n' \
-      "$adapter" "$timestamp" >>"$archive_payload"
-    cat "$rules_evictions" >>"$archive_payload"
+    payload_lines_before=$(wc -l <"$archive_payload" | tr -d '[:space:]') || {
+      STATE_CAPS_FOLD_REASON=archive-payload
+      return 1
+    }
+    if ! printf '<!-- caps eviction section=general-rules adapter=%s ts=%s -->\n' \
+      "$adapter" "$timestamp" >>"$archive_payload"; then
+      STATE_CAPS_FOLD_REASON=archive-payload
+      return 1
+    fi
+    if ! cat "$rules_evictions" >>"$archive_payload"; then
+      STATE_CAPS_FOLD_REASON=archive-payload
+      return 1
+    fi
+    payload_lines_after=$(wc -l <"$archive_payload" | tr -d '[:space:]') || {
+      STATE_CAPS_FOLD_REASON=archive-payload
+      return 1
+    }
+    rules_archived_lines=$((payload_lines_after - payload_lines_before - 1))
   fi
-  archive_file="$workspace/loop/archive/intake-evictions-$fold_date.md"
   if ! state_fold_atomic_archive_append "$archive_payload" "$archive_file"; then
     STATE_CAPS_FOLD_REASON=archive-append
     return 1
   fi
   if ! cmp -s "$snapshot" "$state_file"; then
     STATE_CAPS_FOLD_REASON=concurrent-writer
+    return 1
+  fi
+  archive_payload_lines=$(wc -l <"$archive_payload" | tr -d '[:space:]') || {
+    STATE_CAPS_FOLD_REASON=archive-integrity
+    return 1
+  }
+  if ! tail -n "$archive_payload_lines" "$archive_file" >"$archived_payload" \
+    || ! cmp -s "$archive_payload" "$archived_payload" \
+    || [[ "$verified_archived_lines" -ne "$STATE_CAPS_VERIFIED_EVICTED" ]] \
+    || [[ "$rules_archived_lines" -ne "$STATE_CAPS_RULES_EVICTED" ]]; then
+    STATE_CAPS_FOLD_REASON=archive-integrity
     return 1
   fi
   if ! atomic_write_file "$rebuilt" "$state_file"; then

--- a/scripts/lib-state-fold.sh
+++ b/scripts/lib-state-fold.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 STATE_FOLD_LESSONS_CAP_DEFAULT=60
 STATE_FOLD_FAILURES_CAP_DEFAULT=100
+STATE_FOLD_VERIFIED_CAP_DEFAULT=120
+STATE_FOLD_RULES_CAP_DEFAULT=80
 STATE_FOLD_LOCK_DIR=
 STATE_FOLD_LOCK_OWNED=0
 STATE_FOLD_LOCK_STALE_S=${DISTILL_STATE_LOCK_STALE_S:-1800}
@@ -10,6 +12,9 @@ LAST_SESSION_ENTRIES=0
 LAST_SESSION_EVICTED=0
 LAST_SESSION_SYNTHESIZED_HANDOFFS=0
 LAST_SESSION_FOLD_REASON=none
+STATE_CAPS_VERIFIED_EVICTED=0
+STATE_CAPS_RULES_EVICTED=0
+STATE_CAPS_FOLD_REASON=none
 
 file_mtime_epoch() {
   local path=$1
@@ -556,7 +561,7 @@ last_session_create_handoff() {
   done
 }
 
-last_session_atomic_archive_append() {
+state_fold_atomic_archive_append() {
   local source_file=$1
   local archive_file=$2
   local archive_dir
@@ -588,6 +593,152 @@ last_session_atomic_archive_append() {
     return 1
   fi
   mv -f "$tmp_file" "$archive_file"
+}
+
+fold_declared_state_caps() {
+  local workspace=$1
+  local state_file=$2
+  local work_dir=$3
+  local adapter=$4
+  local fold_date=${5:-$(date -u '+%Y-%m-%d')}
+  local snapshot="$work_dir/state-caps.snapshot"
+  local rebuilt="$work_dir/state-caps.rebuilt"
+  local verified_evictions="$work_dir/state-caps.verified"
+  local rules_evictions="$work_dir/state-caps.rules"
+  local archive_payload="$work_dir/state-caps.archive"
+  local summary_file="$work_dir/state-caps.summary"
+  local summary
+  local has_verified
+  local has_rules
+  local archive_file
+  local timestamp
+
+  STATE_CAPS_VERIFIED_EVICTED=0
+  STATE_CAPS_RULES_EVICTED=0
+  STATE_CAPS_FOLD_REASON=none
+  : >"$verified_evictions"
+  : >"$rules_evictions"
+  : >"$archive_payload"
+  cp "$state_file" "$snapshot" || {
+    STATE_CAPS_FOLD_REASON=snapshot
+    return 1
+  }
+  if ! awk -v verified_cap="$STATE_FOLD_VERIFIED_CAP_DEFAULT" \
+    -v rules_cap="$STATE_FOLD_RULES_CAP_DEFAULT" \
+    -v verified_evictions="$verified_evictions" -v rules_evictions="$rules_evictions" \
+    -v summary_file="$summary_file" '
+    function flush_section(    cap,eviction_file,start,i) {
+      if (section == "") return
+      if (section == "verified") {
+        cap = verified_cap
+        eviction_file = verified_evictions
+      } else {
+        cap = rules_cap
+        eviction_file = rules_evictions
+      }
+      start = 1
+      if (section_count > cap) start = section_count - cap + 1
+      for (i = 1; i < start; i++) {
+        print section_lines[i] > eviction_file
+        if (section == "verified") verified_evicted++
+        else rules_evicted++
+      }
+      close(eviction_file)
+      for (i = start; i <= section_count; i++) print section_lines[i]
+      delete section_lines
+      section_count = 0
+      section = ""
+    }
+    {
+      if (/^## /) {
+        flush_section()
+        print
+        if (index($0, "## Verified facts") == 1) {
+          section = "verified"
+          has_verified = 1
+          preamble = 1
+          next
+        }
+        if (index($0, "## General rules") == 1) {
+          section = "rules"
+          has_rules = 1
+          preamble = 1
+          next
+        }
+        next
+      }
+      if (section != "") {
+        if (preamble && ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*<!--.*-->[[:space:]]*$/)) {
+          print
+        } else {
+          preamble = 0
+          section_lines[++section_count] = $0
+        }
+      } else {
+        print
+      }
+    }
+    END {
+      flush_section()
+      printf "%d %d %d %d\n", has_verified + 0, has_rules + 0, \
+        verified_evicted + 0, rules_evicted + 0 > summary_file
+      close(summary_file)
+    }
+  ' "$snapshot" >"$rebuilt"; then
+    STATE_CAPS_FOLD_REASON=parse
+    return 1
+  fi
+  summary=$(cat "$summary_file")
+  read -r has_verified has_rules STATE_CAPS_VERIFIED_EVICTED \
+    STATE_CAPS_RULES_EVICTED <<EOF
+$summary
+EOF
+  if [[ "$has_verified" -ne 1 && "$has_rules" -ne 1 ]]; then
+    STATE_CAPS_FOLD_REASON=missing-sections
+    return 1
+  fi
+  if [[ "$has_verified" -ne 1 ]]; then
+    STATE_CAPS_FOLD_REASON=missing-verified-facts
+    return 1
+  fi
+  if [[ "$has_rules" -ne 1 ]]; then
+    STATE_CAPS_FOLD_REASON=missing-general-rules
+    return 1
+  fi
+  if [[ "$STATE_CAPS_VERIFIED_EVICTED" -eq 0 \
+    && "$STATE_CAPS_RULES_EVICTED" -eq 0 ]]; then
+    return 0
+  fi
+  if ! cmp -s "$snapshot" "$state_file"; then
+    STATE_CAPS_FOLD_REASON=concurrent-writer
+    return 1
+  fi
+
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  if [[ "$STATE_CAPS_VERIFIED_EVICTED" -gt 0 ]]; then
+    printf '<!-- caps eviction section=verified-facts adapter=%s ts=%s -->\n' \
+      "$adapter" "$timestamp" >>"$archive_payload"
+    cat "$verified_evictions" >>"$archive_payload"
+  fi
+  if [[ "$STATE_CAPS_RULES_EVICTED" -gt 0 ]]; then
+    printf '<!-- caps eviction section=general-rules adapter=%s ts=%s -->\n' \
+      "$adapter" "$timestamp" >>"$archive_payload"
+    cat "$rules_evictions" >>"$archive_payload"
+  fi
+  archive_file="$workspace/loop/archive/intake-evictions-$fold_date.md"
+  if ! state_fold_atomic_archive_append "$archive_payload" "$archive_file"; then
+    STATE_CAPS_FOLD_REASON=archive-append
+    return 1
+  fi
+  if ! cmp -s "$snapshot" "$state_file"; then
+    STATE_CAPS_FOLD_REASON=concurrent-writer
+    return 1
+  fi
+  if ! atomic_write_file "$rebuilt" "$state_file"; then
+    STATE_CAPS_FOLD_REASON=state-rename
+    return 1
+  fi
+  return 0
 }
 
 fold_last_session_index() {
@@ -737,7 +888,7 @@ EOF
   if [[ -s "$archive_entries" ]]; then
     archive_week=$(date -u '+%G-W%V')
     archive_file="$workspace/loop/archive/last-session-$archive_week.md"
-    if ! last_session_atomic_archive_append "$archive_entries" "$archive_file"; then
+    if ! state_fold_atomic_archive_append "$archive_entries" "$archive_file"; then
       while IFS= read -r LAST_SESSION_CREATED_HANDOFF; do
         [[ -n "$LAST_SESSION_CREATED_HANDOFF" ]] && rm -f "$LAST_SESSION_CREATED_HANDOFF"
       done <"$created_files"

--- a/tests/state-caps-fold.test.sh
+++ b/tests/state-caps-fold.test.sh
@@ -37,6 +37,16 @@ run_intake() {
     >"$TMP_ROOT/intake.out" 2>"$TMP_ROOT/intake.err"
 }
 
+run_intake_with_cat_failure() {
+  local ws=$1
+  local shim_dir=$2
+  local mode=${3:-fail}
+  env INTAKE_LOCK_SLEEP_S=0 STATE_CAPS_REAL_CAT="$REAL_CAT" \
+    STATE_CAPS_CAT_MODE="$mode" \
+    PATH="$shim_dir:$PATH" "$INTAKE" "$ws" \
+    >"$TMP_ROOT/intake.out" 2>"$TMP_ROOT/intake.err"
+}
+
 receipt_value() {
   local ws=$1
   local key=$2
@@ -134,12 +144,162 @@ else
     "receipt=$(tail -n 1 "$ws/loop/pending/intake-runs.log") archive=$(cat "$archive" 2>/dev/null)"
 fi
 
-if [ "$(wc -c <"$archive" | tr -d '[:space:]')" -gt 0 ] \
+ws=$(new_ws mutation-guard)
+write_state "$ws/STATE.md" 121 80 1
+run_intake "$ws"
+archive="$ws/loop/archive/intake-evictions-$TODAY.md"
+archive_bytes=0
+if [ -f "$archive" ]; then
+  archive_bytes=$(wc -c <"$archive" | tr -d '[:space:]')
+fi
+if [ "$archive_bytes" -gt 0 ] \
   && [ "$(body_count "$ws/STATE.md" '## Verified facts')" -eq 120 ]; then
   pass '[3] mutation guard requires both STATE shrinkage and archive growth'
 else
   fail_case '[3] mutation guard requires both STATE shrinkage and archive growth' \
     'oversized STATE did not shrink with a recoverable archive append'
+fi
+
+ws=$(new_ws duplicate-heading)
+write_state "$ws/STATE.md" 121 80 1
+awk '
+  index($0, "## General rules") == 1 && !inserted {
+    print "## Verified facts      (cap 120 lines)"
+    for (i = 1; i <= 121; i++) printf "- duplicate-verified-%03d\n", i
+    inserted = 1
+  }
+  {print}
+' "$ws/STATE.md" >"$TMP_ROOT/duplicate.state"
+mv "$TMP_ROOT/duplicate.state" "$ws/STATE.md"
+cp "$ws/STATE.md" "$TMP_ROOT/duplicate.before"
+run_intake "$ws"
+rc=$?
+archive="$ws/loop/archive/intake-evictions-$TODAY.md"
+if [ "$rc" -eq 0 ] \
+  && cmp -s "$TMP_ROOT/duplicate.before" "$ws/STATE.md" \
+  && [ ! -e "$archive" ] \
+  && [ "$(receipt_value "$ws" caps_fold)" = skipped ] \
+  && [ "$(receipt_value "$ws" caps_fold_reason)" = duplicate-heading ] \
+  && [ "$(receipt_value "$ws" files_scanned)" -eq 0 ] \
+  && [ -e "$ws/loop/.deadman/distill.marker" ]; then
+  pass '[7] duplicate capped headings skip the fold without touching STATE or archive'
+else
+  fail_case '[7] duplicate capped headings skip the fold without touching STATE or archive' \
+    "rc=$rc receipt=$(tail -n 1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+raw_ws=$(new_ws multi-flush)
+write_state "$raw_ws/STATE.md" 121 80 0
+awk '
+  index($0, "## General rules") == 1 && !inserted {
+    print "## Verified facts      (cap 120 lines)"
+    for (i = 1; i <= 121; i++) printf "- duplicate-verified-%03d\n", i
+    inserted = 1
+  }
+  {print}
+' "$raw_ws/STATE.md" >"$TMP_ROOT/multi-flush.state"
+mv "$TMP_ROOT/multi-flush.state" "$raw_ws/STATE.md"
+raw_work="$TMP_ROOT/multi-flush-work"
+raw_reason="$TMP_ROOT/multi-flush.reason"
+mkdir -p "$raw_work"
+if bash -c '
+  source "$1"
+  if fold_declared_state_caps "$2" "$3" "$4" test-adapter "$5"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  printf "%s\n" "$STATE_CAPS_FOLD_REASON" >"$6"
+  exit "$rc"
+' _ "$ROOT/scripts/lib-state-fold.sh" "$raw_ws" "$raw_ws/STATE.md" "$raw_work" \
+  "$TODAY" "$raw_reason"; then
+  raw_rc=0
+else
+  raw_rc=$?
+fi
+STATE_CAPS_FOLD_REASON=$(cat "$raw_reason")
+if [ "$(wc -l <"$raw_work/state-caps.verified" | tr -d '[:space:]')" -eq 2 ] \
+  && grep -Fqx -- '- verified-001' "$raw_work/state-caps.verified" \
+  && grep -Fqx -- '- duplicate-verified-001' "$raw_work/state-caps.verified"; then
+  pass '[8] sequential eviction flushes append without losing earlier lines'
+else
+  fail_case '[8] sequential eviction flushes append without losing earlier lines' \
+    "rc=$raw_rc reason=$STATE_CAPS_FOLD_REASON payload=$(tr '\n' '|' <"$raw_work/state-caps.verified" 2>/dev/null)"
+fi
+
+ws=$(new_ws archive-target-directory)
+write_state "$ws/STATE.md" 121 80 0
+cp "$ws/STATE.md" "$TMP_ROOT/archive-target.before"
+archive="$ws/loop/archive/intake-evictions-$TODAY.md"
+mkdir "$archive"
+run_intake "$ws"
+rc=$?
+if [ "$rc" -ne 0 ] \
+  && cmp -s "$TMP_ROOT/archive-target.before" "$ws/STATE.md" \
+  && [ -d "$archive" ] \
+  && [ -z "$(find "$archive" -mindepth 1 -print -quit)" ] \
+  && [ "$(receipt_value "$ws" caps_fold)" = failed ] \
+  && [ "$(receipt_value "$ws" caps_fold_reason)" = archive-target ] \
+  && [ ! -e "$ws/loop/.deadman/distill.marker" ]; then
+  pass '[9] a directory at the archive path fails before the STATE rename'
+else
+  fail_case '[9] a directory at the archive path fails before the STATE rename' \
+    "rc=$rc receipt=$(tail -n 1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+REAL_CAT=$(command -v cat)
+cat_shim="$TMP_ROOT/cat-shim"
+mkdir -p "$cat_shim"
+cat >"$cat_shim/cat" <<'EOF'
+#!/usr/bin/env bash
+case ${1:-} in
+  */state-caps.verified)
+    [ "${STATE_CAPS_CAT_MODE:-fail}" = drop ] && exit 0
+    exit 73
+    ;;
+esac
+exec "$STATE_CAPS_REAL_CAT" "$@"
+EOF
+chmod 755 "$cat_shim/cat"
+
+ws=$(new_ws archive-payload-failure)
+write_state "$ws/STATE.md" 121 80 0
+cp "$ws/STATE.md" "$TMP_ROOT/archive-payload.before"
+archive="$ws/loop/archive/intake-evictions-$TODAY.md"
+run_intake_with_cat_failure "$ws" "$cat_shim"
+rc=$?
+if [ "$rc" -ne 0 ] \
+  && cmp -s "$TMP_ROOT/archive-payload.before" "$ws/STATE.md" \
+  && grep -Fqx -- '- verified-001' "$ws/STATE.md" \
+  && [ ! -e "$archive" ] \
+  && [ "$(receipt_value "$ws" caps_fold)" = failed ] \
+  && [ "$(receipt_value "$ws" caps_fold_reason)" = archive-payload ] \
+  && [ "$(receipt_value "$ws" caps_vf_evicted)" -eq 0 ] \
+  && [ ! -e "$ws/loop/.deadman/distill.marker" ]; then
+  pass '[10] archive payload append failure aborts before the STATE rename'
+else
+  fail_case '[10] archive payload append failure aborts before the STATE rename' \
+    "rc=$rc receipt=$(tail -n 1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+ws=$(new_ws archive-integrity-failure)
+write_state "$ws/STATE.md" 121 80 0
+cp "$ws/STATE.md" "$TMP_ROOT/archive-integrity.before"
+archive="$ws/loop/archive/intake-evictions-$TODAY.md"
+run_intake_with_cat_failure "$ws" "$cat_shim" drop
+rc=$?
+if [ "$rc" -ne 0 ] \
+  && cmp -s "$TMP_ROOT/archive-integrity.before" "$ws/STATE.md" \
+  && grep -Fqx -- '- verified-001' "$ws/STATE.md" \
+  && [ -f "$archive" ] \
+  && [ "$(receipt_value "$ws" caps_fold)" = failed ] \
+  && [ "$(receipt_value "$ws" caps_fold_reason)" = archive-integrity ] \
+  && [ "$(receipt_value "$ws" caps_vf_evicted)" -eq 0 ] \
+  && [ ! -e "$ws/loop/.deadman/distill.marker" ]; then
+  pass '[11] archived line-count mismatch aborts before the STATE rename'
+else
+  fail_case '[11] archived line-count mismatch aborts before the STATE rename' \
+    "rc=$rc receipt=$(tail -n 1 "$ws/loop/pending/intake-runs.log")"
 fi
 
 ws=$(new_ws both-overflow)

--- a/tests/state-caps-fold.test.sh
+++ b/tests/state-caps-fold.test.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+INTAKE=$ROOT/adapters/claude-code/flush-intake.sh
+TMP_ROOT=${TMPDIR:-/tmp}/state-caps-fold-test.$$
+PASS_COUNT=0
+FAIL_COUNT=0
+TODAY=$(date -u '+%Y-%m-%d')
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+mkdir -p "$TMP_ROOT"
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+fail_case() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL %s: %s\n' "$1" "$2"
+}
+
+new_ws() {
+  local name=$1
+  local ws=$TMP_ROOT/$name
+  "$ROOT/scripts/loop-init" --workspace "$ws" >/dev/null
+  printf '%s\n' "$ws"
+}
+
+run_intake() {
+  local ws=$1
+  env INTAKE_LOCK_SLEEP_S=0 "$INTAKE" "$ws" \
+    >"$TMP_ROOT/intake.out" 2>"$TMP_ROOT/intake.err"
+}
+
+receipt_value() {
+  local ws=$1
+  local key=$2
+  tail -n 1 "$ws/loop/pending/intake-runs.log" | tr ' ' '\n' \
+    | sed -n "s/^$key=//p" | head -n 1
+}
+
+write_state() {
+  local path=$1
+  local verified_count=$2
+  local rules_count=$3
+  local with_preamble=${4:-0}
+  local i
+
+  {
+    printf '%s\n' '## Verified facts      (cap 120 lines)'
+    if [ "$with_preamble" -eq 1 ]; then
+      printf '%s\n' '<!-- verified preamble must never count or move -->'
+    fi
+    i=1
+    while [ "$i" -le "$verified_count" ]; do
+      printf -- '- verified-%03d\n' "$i"
+      i=$((i + 1))
+    done
+    printf '%s\n' '## General rules       (cap 80)'
+    if [ "$with_preamble" -eq 1 ]; then
+      printf '%s\n' '<!-- rules preamble must never count or move -->'
+    fi
+    i=1
+    while [ "$i" -le "$rules_count" ]; do
+      printf -- '- rule-%03d\n' "$i"
+      i=$((i + 1))
+    done
+    printf '%s\n' \
+      '## Open failures       (cap 100)' \
+      '<!-- failures preamble -->' \
+      '## Lessons learned     (cap 60)' \
+      '<!-- lessons preamble -->' \
+      '## Last session        (cap 20 entries — newest first)' \
+      '<!-- last-session preamble -->'
+  } >"$path"
+}
+
+body_count() {
+  local path=$1
+  local heading=$2
+  awk -v heading="$heading" '
+    index($0, heading) == 1 {in_section = 1; preamble = 1; next}
+    in_section && /^## / {exit}
+    in_section {
+      if (preamble && ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*<!--.*-->[[:space:]]*$/)) next
+      preamble = 0
+      count++
+    }
+    END {print count + 0}
+  ' "$path"
+}
+
+ws=$(new_ws exact-boundary)
+write_state "$ws/STATE.md" 120 80 1
+cp "$ws/STATE.md" "$TMP_ROOT/exact.before"
+run_intake "$ws"
+archive="$ws/loop/archive/intake-evictions-$TODAY.md"
+if cmp -s "$TMP_ROOT/exact.before" "$ws/STATE.md" \
+  && [ ! -e "$archive" ] \
+  && [ "$(receipt_value "$ws" caps_vf_evicted)" -eq 0 ] \
+  && [ "$(receipt_value "$ws" caps_gr_evicted)" -eq 0 ] \
+  && [ "$(receipt_value "$ws" caps_fold)" = ok ] \
+  && [ "$(receipt_value "$ws" caps_fold_reason)" = none ]; then
+  pass '[1] exact cap boundaries leave STATE byte-identical'
+else
+  fail_case '[1] exact cap boundaries leave STATE byte-identical' \
+    "receipt=$(tail -n 1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+ws=$(new_ws verified-overflow)
+write_state "$ws/STATE.md" 121 80 1
+printf '%s\n' '- verified-001' >"$TMP_ROOT/verified.evicted.expected"
+run_intake "$ws"
+archive="$ws/loop/archive/intake-evictions-$TODAY.md"
+tail -n +2 "$archive" >"$TMP_ROOT/verified.evicted.actual"
+if [ "$(receipt_value "$ws" files_scanned)" -eq 0 ] \
+  && [ "$(body_count "$ws/STATE.md" '## Verified facts')" -eq 120 ] \
+  && [ "$(body_count "$ws/STATE.md" '## General rules')" -eq 80 ] \
+  && ! grep -Fqx -- '- verified-001' "$ws/STATE.md" \
+  && grep -Fqx -- '- verified-121' "$ws/STATE.md" \
+  && grep -Fqx -- '<!-- verified preamble must never count or move -->' "$ws/STATE.md" \
+  && ! grep -Fq 'preamble must never count or move' "$archive" \
+  && cmp -s "$TMP_ROOT/verified.evicted.expected" "$TMP_ROOT/verified.evicted.actual" \
+  && grep -Eq '^<!-- caps eviction section=verified-facts adapter=[^ ]+ ts=[^ ]+ -->$' "$archive" \
+  && [ "$(receipt_value "$ws" caps_vf_evicted)" -eq 1 ]; then
+  pass '[2] cap+1 evicts the oldest body line verbatim and zero-candidate intake still folds'
+else
+  fail_case '[2] cap+1 evicts the oldest body line verbatim and zero-candidate intake still folds' \
+    "receipt=$(tail -n 1 "$ws/loop/pending/intake-runs.log") archive=$(cat "$archive" 2>/dev/null)"
+fi
+
+if [ "$(wc -c <"$archive" | tr -d '[:space:]')" -gt 0 ] \
+  && [ "$(body_count "$ws/STATE.md" '## Verified facts')" -eq 120 ]; then
+  pass '[3] mutation guard requires both STATE shrinkage and archive growth'
+else
+  fail_case '[3] mutation guard requires both STATE shrinkage and archive growth' \
+    'oversized STATE did not shrink with a recoverable archive append'
+fi
+
+ws=$(new_ws both-overflow)
+write_state "$ws/STATE.md" 122 82 1
+run_intake "$ws"
+archive="$ws/loop/archive/intake-evictions-$TODAY.md"
+if [ "$(body_count "$ws/STATE.md" '## Verified facts')" -eq 120 ] \
+  && [ "$(body_count "$ws/STATE.md" '## General rules')" -eq 80 ] \
+  && [ "$(receipt_value "$ws" caps_vf_evicted)" -eq 2 ] \
+  && [ "$(receipt_value "$ws" caps_gr_evicted)" -eq 2 ] \
+  && [ "$(grep -c '^<!-- caps eviction section=verified-facts ' "$archive")" -eq 1 ] \
+  && [ "$(grep -c '^<!-- caps eviction section=general-rules ' "$archive")" -eq 1 ] \
+  && grep -Fqx -- '- verified-001' "$archive" \
+  && grep -Fqx -- '- verified-002' "$archive" \
+  && grep -Fqx -- '- rule-001' "$archive" \
+  && grep -Fqx -- '- rule-002' "$archive"; then
+  pass '[4] one fold archives both overflows under distinct section markers'
+else
+  fail_case '[4] one fold archives both overflows under distinct section markers' \
+    "receipt=$(tail -n 1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+ws=$(new_ws missing-section)
+write_state "$ws/STATE.md" 121 80 1
+awk 'index($0, "## Verified facts") != 1 {print}' "$ws/STATE.md" \
+  >"$TMP_ROOT/missing.state"
+mv "$TMP_ROOT/missing.state" "$ws/STATE.md"
+cp "$ws/STATE.md" "$TMP_ROOT/missing.before"
+run_intake "$ws"
+rc=$?
+if [ "$rc" -eq 0 ] \
+  && cmp -s "$TMP_ROOT/missing.before" "$ws/STATE.md" \
+  && [ "$(receipt_value "$ws" caps_fold)" = skipped ] \
+  && [ "$(receipt_value "$ws" caps_fold_reason)" = missing-verified-facts ] \
+  && [ "$(receipt_value "$ws" files_scanned)" -eq 0 ] \
+  && [ -e "$ws/loop/.deadman/distill.marker" ]; then
+  pass '[5] a missing capped heading records SKIP and intake continues without touching STATE'
+else
+  fail_case '[5] a missing capped heading records SKIP and intake continues without touching STATE' \
+    "rc=$rc receipt=$(tail -n 1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+ws=$(new_ws archive-failure)
+write_state "$ws/STATE.md" 121 80 0
+cp "$ws/STATE.md" "$TMP_ROOT/archive-failure.before"
+chmod 500 "$ws/loop/archive"
+run_intake "$ws"
+rc=$?
+chmod 700 "$ws/loop/archive"
+if [ "$rc" -ne 0 ] \
+  && cmp -s "$TMP_ROOT/archive-failure.before" "$ws/STATE.md" \
+  && [ ! -e "$ws/loop/archive/intake-evictions-$TODAY.md" ] \
+  && [ "$(receipt_value "$ws" caps_fold)" = failed ] \
+  && [ "$(receipt_value "$ws" caps_fold_reason)" = archive-append ] \
+  && [ "$(receipt_value "$ws" caps_vf_evicted)" -eq 0 ] \
+  && [ ! -e "$ws/loop/.deadman/distill.marker" ]; then
+  pass '[6] real archive write failure aborts before the STATE rename'
+else
+  fail_case '[6] real archive write failure aborts before the STATE rename' \
+    "rc=$rc receipt=$(tail -n 1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
Closes #170. Prerequisite for #148 (#144 adjudication: caps must be enforced at the promotion layer's write targets before the promotion layer exists).

## What

`templates/STATE.md` declares caps for `## Verified facts` (120) and `## General rules` (80); no code enforced them (#144 Opus seat CRITICAL — the only cap-less sections left after #145/v0.15.0). This PR enforces both in the intake fold:

- Runs on **every** intake under the distill lock, unconditionally — zero flush files still fold (same precedent as the Last session fold, #145 v0.2.2 §4.1), because these sections can overflow via model CHECKPOINT writes without any intake candidates.
- Eviction is **archival, never deletion**: overflow head lines (oldest-first, keep the tail — same direction as the Lessons fold) are appended verbatim to `loop/archive/intake-evictions-<UTC-date>.md` under section-specific markers.
- **Fail-closed ordering** (#145 v0.2.2 §4.2 mirror): archive append (guarded, integrity-checked) completes before STATE.md's atomic rename; any failure aborts with STATE.md untouched. Missing or duplicated section headings are a SKIP with reason (recorded, intake continues), not an abort.
- Section preambles never counted, never evicted. Receipt gains `caps_vf_evicted= caps_gr_evicted= caps_fold= caps_fold_reason=` (appended; old parsers unaffected). No new env fault-injection hooks in production code.

## Files touched (= WIP declaration, L0-6)

- `scripts/lib-state-fold.sh` / `scripts/flush-intake.sh` / `tests/state-caps-fold.test.sh` (new, 11 cases)

`git diff --stat origin/main...a343a7c` = exactly these 3 files (verified 2026-08-25; diff にあって一覧にないファイルなし).

## 完了記録 (L1-7)

**Candidate SHA: `a343a7c`**（レビュー時点の PR head と一致）

### Done when 対応表

1. **cap が intake の fold と同系の機構でコード強制される（超過分は削除せず退避）** — **PASS**。`fold_declared_state_caps`（awk section walk・Lessons fold と同系）。証拠: `tests/state-caps-fold.test.sh` [2] cap+1 で oldest 1行が verbatim 退避・[4] 両セクション同時退避・zero-candidate intake でも発火（2026-08-25 実測 11 PASS / 0 FAIL）。手動 E2E: 125/85 行 seed → intake 後 120/80 行・退避行はアーカイブに verbatim・receipt `caps_vf_evicted=5 caps_gr_evicted=5 caps_fold=ok`（writer 転写・2026-08-25）。
2. **退避先と順序が #145 v0.2 §4.2 と同じ fail-closed パターン** — **PASS**。archive append（ガード+行数整合検査）→ STATE atomic rename の順。証拠: テスト [6] chmod 500 で abort・STATE 不変 / [9] dir-at-path abort / [10] append 失敗 abort / [11] 行数不一致 abort（すべて 2026-08-25 実測 PASS・[9][10][11] は未修正コードで FAIL する赤証明を writer + Grok 席が独立実測）。
3. **テストがあり緑（cap 境界 + 退避検証 + mutation で fold 殺し検出）** — **PASS**。11ケース。mutation 感度は GLM 席が6種の変異で実測（fold 無効化→5 FAIL・方向逆転→2 FAIL・preamble 算入→3 FAIL・off-by-one→3 FAIL・順序逆転→1 FAIL・always-true アサーションなし）。full `make test`: Suite Summary 34 PASS, 0 FAIL（writer / Alpha / GLM 席の3者が独立実測・2026-08-25）。
4. **異種3席レビュー完了** — **PASS**。round 1 全席 NO-GO（収束 CRITICAL 1 + Kimi CRITICAL 1 + Grok MAJOR 1）→ 修正 `a343a7c` → delta 全席 GO。記録: [round 1](https://github.com/caty-ai/caty-agent-harness/pull/181#issuecomment-5409455227) / [delta](https://github.com/caty-ai/caty-agent-harness/pull/181#issuecomment-5410067689)。
5. **T-5: release / previous release 欄** — **PASS**（下記）。

### 身元（L1-3 / L1-10）

実装 writer = **Codex GPT-5.6 Sol**（発注・検品 = Alpha, Fable 5・独立票に数えない）。レビュー席 = GLM 5.3 (Zhipu) / Kimi K3 (Moonshot) / Grok 4.6 (xAI) — 相互異系統かつ writer (OpenAI) と異種。requested = actual（全席・各レビュー記録に記載）。

### CI

candidate `a343a7c` 時点: gitleaks / history-check / risk-review-gate / test-lint(lint) / pr-size(strip) = pass、test / test-macos = merge 時に緑確認（ローカル full suite は3者実測緑）。pr-size は size-exempt ラベル（オーナー付与）で pass。

### release 欄

- **release: v0.16.0**（出荷相当 — 全 STATE.md ワークスペースの fold 挙動が変わる。annotated tag を merge commit に切り、release-sync green run で Release 実在まで確認して MERGED）
- **previous release: v0.15.0 — 履行済み**（https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.15.0 実在・#145 MERGED コメントに tag URL あり・2026-08-25 実測）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
