### PR TITLE
feat: overflow sentinel v1 — opt-in measured per-turn firing for the claude-code runtime (#180)

### DIFF
--- a/adapters/claude-code/INSTALL.md
+++ b/adapters/claude-code/INSTALL.md
@@ -227,10 +227,18 @@ Start in shadow mode:
 
 ```sh
 export TR_SPAWN_STEP=/path/to/caty-agent-harness/adapters/claude-code/spawn_step.sh
+export TR_STEP_TIMEOUT_S=600
 export OVF_SENTINEL=shadow
 export OVF_COMPACTION_OWNER=sentinel
+export CLAUDE_MODEL=claude-sonnet-4-5
 scripts/task-runner.sh "$WS"
 ```
+
+`TR_STEP_TIMEOUT_S` must be exported; a shell-local task-runner setting is not
+visible to this child adapter. Set `CLAUDE_MODEL` to the actual model identifier
+so the context-window catalog and TTFB floor can select a known entry. If it is
+unset, the adapter records `claude-unknown`, which deliberately uses the default
+context window and conservative 240-second TTFB floor.
 
 After inspecting `sentinel-events.jsonl`, select `OVF_SENTINEL=active` to allow
 the adapter to prepare a five-point delta nudge. The nudge is shown at the next
@@ -244,6 +252,12 @@ and sends `prompt.md` on stdin. `OVF_STEP_CMD` defaults to
 `claude -p --output-format stream-json --verbose`; command strings are
 whitespace-split argv, never shell-expanded. The model session—not this
 adapter—owns `step-result.json`.
+
+Known pause limitation: startup pause is handled before the model starts, but a
+workspace paused while this adapter is already running is currently classified
+by the task-runner driver against the Hermes pause label. That mid-run pause can
+therefore be misclassified. Driver-side pause-label parameterization is a
+follow-up; this adapter does not change `task-runner.sh` in v1.
 
 The passive monitor writes `stream.jsonl`, `overflow-stream.eof`,
 `sentinel-events.jsonl`, `attempt.json`, and, after an active fire,

--- a/adapters/claude-code/INSTALL.md
+++ b/adapters/claude-code/INSTALL.md
@@ -216,6 +216,43 @@ Contract for claude-code spawn adapters:
   disable a hook globally to make the loop pass — the bypass must be scoped to
   the headless session.
 
+## Overflow sentinel step adapter
+
+`adapters/claude-code/spawn_step.sh` is an optional `TR_SPAWN_STEP` adapter for
+Claude-family, full-context-reading sessions. Do not enable it for search-style
+or Grok-class sessions: the v1 calibration and tap contract do not cover those
+behaviors.
+
+Start in shadow mode:
+
+```sh
+export TR_SPAWN_STEP=/path/to/caty-agent-harness/adapters/claude-code/spawn_step.sh
+export OVF_SENTINEL=shadow
+export OVF_COMPACTION_OWNER=sentinel
+scripts/task-runner.sh "$WS"
+```
+
+After inspecting `sentinel-events.jsonl`, select `OVF_SENTINEL=active` to allow
+the adapter to prepare a five-point delta nudge. The nudge is shown at the next
+task-runner step boundary, not injected into the running `claude -p` process.
+The firing attempt therefore records `suppressed`; if the task terminates on
+that attempt, no runtime remains to receive the nudge. A later attempt that
+shows it records `shown` and deletes the pending file.
+
+The adapter runs the CLI in the workspace cwd, passes the existing environment,
+and sends `prompt.md` on stdin. `OVF_STEP_CMD` defaults to
+`claude -p --output-format stream-json --verbose`; command strings are
+whitespace-split argv, never shell-expanded. The model session—not this
+adapter—owns `step-result.json`.
+
+The passive monitor writes `stream.jsonl`, `overflow-stream.eof`,
+`sentinel-events.jsonl`, `attempt.json`, and, after an active fire,
+`overflow-nudge.pending` in the attempt directory. Task-scoped hysteresis state
+is `overflow-sentinel-state.json` in the task artifact directory. Event logs are
+append-only: consumers must never edit, replace, or fold existing event lines in
+place. This standalone log exists because the task-runner ledger confluence
+point is not implemented in v1.
+
 ## Scope note
 
 The hook keys on the session cwd. Sessions started inside a project dir (the normal

--- a/adapters/claude-code/overflow_sentinel_monitor.py
+++ b/adapters/claude-code/overflow_sentinel_monitor.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Passive Claude stream-json tailer for overflow-sentinel v1."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from lib_overflow_sentinel import (  # noqa: E402
+    K,
+    M,
+    N,
+    SCHEMA_VERSION,
+    atomic_write_json,
+    axis_name,
+    compaction_suspected,
+    eligible_fire_axes,
+    evaluate_series,
+    load_state,
+    outcome_from_result,
+    resolve_ctx_window,
+    save_state,
+    ttfb_floor_seconds,
+)
+
+
+ATTEMPT_FIELDS = {
+    "schema_version",
+    "task_id",
+    "attempt",
+    "mode",
+    "model",
+    "ctx_window",
+    "ctx_window_source",
+    "started_at",
+    "first_byte_at",
+    "cli_exit_code",
+    "tap_status_final",
+    "fired",
+    "events_path",
+}
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def append_event(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n")
+        handle.flush()
+
+
+def _read_complete_lines(path: Path, offset: int, pending: bytes) -> Tuple[List[str], int, bytes]:
+    if not path.exists():
+        return [], offset, pending
+    with path.open("rb") as handle:
+        handle.seek(offset)
+        chunk = handle.read()
+    offset += len(chunk)
+    data = pending + chunk
+    parts = data.split(b"\n")
+    pending = parts.pop()
+    return [part.decode("utf-8", errors="replace") for part in parts if part], offset, pending
+
+
+def _usage_from_assistant(event: Dict[str, Any]) -> Optional[Tuple[Dict[str, Any], Dict[str, Any]]]:
+    if event.get("type") != "assistant":
+        return None
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict) or usage.get("input_tokens") is None:
+        return None
+    return message, usage
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        result = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, result)
+
+
+def _read_eof(path: Path) -> Optional[int]:
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return 1
+
+
+def _read_step_result(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError, TypeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _nudge_text(turn: Dict[str, Any], ctx_window: int) -> str:
+    return (
+        "Overflow sentinel measured context pressure. Before continuing, write only these five delta points:\n"
+        "1. Goal\n"
+        "2. Current step\n"
+        "3. Evidence already completed\n"
+        "4. Blocker\n"
+        "5. Stop rule\n"
+        "Measured injected MA: {ma:.1f} tokens; last turn: {last} tokens; context window: {ctx} tokens.\n"
+        "Decomposing the remaining work through task-runner is recommended.\n"
+    ).format(ma=turn["injected_ma"], last=turn["injected_last"], ctx=ctx_window)
+
+
+def _write_pending(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        handle.write(text)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(str(temporary), str(path))
+
+
+def _run_meta(mode: str, t_abs: int, w: float) -> Dict[str, Any]:
+    return {
+        "arm": mode,
+        "seed": None,
+        "shuffle_seed": None,
+        "T_abs": t_abs,
+        "w": w,
+        "N": N,
+        "M": M,
+        "K": K,
+    }
+
+
+def monitor(args: argparse.Namespace) -> int:
+    stream_path = Path(args.stream)
+    eof_path = Path(args.eof)
+    attempt_dir = Path(args.attempt_dir)
+    artifact_dir = Path(args.artifact_dir)
+    events_path = attempt_dir / "sentinel-events.jsonl"
+    pending_path = attempt_dir / "overflow-nudge.pending"
+    state_path = artifact_dir / "overflow-sentinel-state.json"
+    started_at = now_utc()
+    started_monotonic = time.monotonic()
+    if os.environ.get("_CATY_TESTING") == "1" and os.environ.get("_CATY_OVF_TEST_ELAPSED_S"):
+        started_monotonic -= max(0.0, float(os.environ["_CATY_OVF_TEST_ELAPSED_S"]))
+    state = load_state(state_path)
+    last_fire_ma = dict(state["last_fire_ma"])
+    ctx_window, ctx_source = resolve_ctx_window(args.ctx_window, args.hf_config, args.model)
+    floor_s = ttfb_floor_seconds(state["last_run_injected_ma"], args.model)
+    if os.environ.get("_CATY_TESTING") == "1" and os.environ.get("_CATY_OVF_TEST_TTFB_FLOOR_S"):
+        floor_s = max(0, int(os.environ["_CATY_OVF_TEST_TTFB_FLOOR_S"]))
+    meta = _run_meta(args.mode, args.t_abs, args.w)
+
+    offset = 0
+    pending = b""
+    seen_ids = set()
+    series = []
+    total_tokens = 0
+    model = args.model
+    first_byte_at = None
+    alert_written = False
+    fired_turns = []
+    alert_turns = []
+    compaction_seen = False
+    last_injected = None
+    turn_count = 0
+    blind_seen = False
+    consecutive_blind = 0
+    evaluation_disabled = args.tap_status == "disabled-host"
+    saw_usage = False
+    saw_no_cache = False
+
+    while True:
+        lines, offset, pending = _read_complete_lines(stream_path, offset, pending)
+        for raw in lines:
+            try:
+                event = json.loads(raw)
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(event, dict) or event.get("type") != "assistant":
+                continue
+            if first_byte_at is None:
+                first_byte_at = str(event.get("timestamp") or now_utc())
+            parsed = _usage_from_assistant(event)
+            if parsed is None or args.tap_status == "disabled-host":
+                continue
+            message, usage = parsed
+            identity = message.get("id")
+            if isinstance(identity, str) and identity:
+                if identity in seen_ids:
+                    continue
+                seen_ids.add(identity)
+            saw_usage = True
+            input_tokens = _safe_int(usage.get("input_tokens"))
+            cache_read = _safe_int(usage.get("cache_read_input_tokens"))
+            cache_creation = _safe_int(usage.get("cache_creation_input_tokens"))
+            output_tokens = _safe_int(usage.get("output_tokens"))
+            has_cache = "cache_read_input_tokens" in usage and "cache_creation_input_tokens" in usage
+            injected = input_tokens + cache_read + cache_creation
+            blind = has_cache and injected == 0 and output_tokens == 0
+            if blind:
+                turn_tap_status = "blind"
+                blind_seen = True
+                consecutive_blind += 1
+            else:
+                turn_tap_status = "ok" if has_cache else "no-cache-accounting"
+                consecutive_blind = 0
+                if not has_cache:
+                    saw_no_cache = True
+            turn_count += 1
+            model = str(message.get("model") or model)
+            total_tokens += injected + output_tokens
+            turn_event = {
+                "event": "turn",
+                "schema_version": SCHEMA_VERSION,
+                "ts": str(event.get("timestamp") or now_utc()),
+                "task_id": args.task_id,
+                "attempt": args.attempt,
+                "turn_idx": turn_count,
+                "input_tokens": input_tokens,
+                "cache_read_tokens": cache_read,
+                "cache_creation_tokens": cache_creation,
+                "output_tokens": output_tokens,
+                "model": model,
+                "tap_status": turn_tap_status,
+            }
+            append_event(events_path, turn_event)
+            if blind:
+                if consecutive_blind >= 3:
+                    evaluation_disabled = True
+                continue
+            if evaluation_disabled:
+                continue
+            if compaction_suspected(last_injected, injected):
+                compaction_seen = True
+                series = []
+                try:
+                    pending_path.unlink()
+                except FileNotFoundError:
+                    pass
+            series.append(injected)
+            last_injected = injected
+            turn = evaluate_series(series, args.t_abs, args.w, ctx_window)["turns"][-1]
+            axes = eligible_fire_axes(turn["axis"], turn["injected_ma"], ctx_window, last_fire_ma)
+            if not axes:
+                continue
+            fire_axis = axis_name(axes)
+            for fire_candidate in axes:
+                last_fire_ma[fire_candidate] = turn["injected_ma"]
+            fire_event = {
+                "event": "fire",
+                "schema_version": SCHEMA_VERSION,
+                "ts": now_utc(),
+                "started_at": started_at,
+                "task_id": args.task_id,
+                "attempt": args.attempt,
+                "turn_idx": turn_count,
+                "axis": fire_axis,
+                "injected_ma": turn["injected_ma"],
+                "injected_last": turn["injected_last"],
+                "value_kind": "measured",
+                "threshold_hit": turn["threshold_hit"],
+                "ctx_window": ctx_window,
+                "ctx_window_source": ctx_source,
+                "slope": turn["slope"],
+                "projection_turns": turn["projection_turns"],
+                "decision": "nudge",
+                "nudge_disposition": "shadow" if args.mode == "shadow" else "suppressed",
+                "model": model,
+                "runtime": "claude-code",
+                "tap_status": "no-cache-accounting" if saw_no_cache else "ok",
+                "run_meta": meta,
+            }
+            append_event(events_path, fire_event)
+            fired_turns.append(turn_count)
+            if args.mode == "active":
+                _write_pending(pending_path, _nudge_text(turn, ctx_window))
+
+        elapsed = time.monotonic() - started_monotonic
+        if first_byte_at is None and not alert_written and elapsed > floor_s:
+            alert_turn = turn_count + 1
+            append_event(
+                events_path,
+                {
+                    "event": "alert",
+                    "schema_version": SCHEMA_VERSION,
+                    "ts": now_utc(),
+                    "task_id": args.task_id,
+                    "attempt": args.attempt,
+                    "turn_idx": alert_turn,
+                    "ttfb_ms": int(elapsed * 1000),
+                    "floor_applied": floor_s,
+                    "model": model,
+                    "runtime": "claude-code",
+                },
+            )
+            alert_written = True
+            alert_turns.append(alert_turn)
+        cli_exit_code = _read_eof(eof_path)
+        if cli_exit_code is not None:
+            break
+        time.sleep(args.poll_interval)
+
+    if os.environ.get("_CATY_TESTING") == "1" and os.environ.get("_CATY_OVF_TEST_HANG_FINALIZE") == "1":
+        while True:
+            time.sleep(1)
+
+    if args.tap_status == "disabled-host":
+        tap_status_final = "disabled-host"
+    elif blind_seen:
+        tap_status_final = "blind"
+    elif saw_no_cache:
+        tap_status_final = "no-cache-accounting"
+    elif saw_usage:
+        tap_status_final = "ok"
+    else:
+        tap_status_final = "absent"
+
+    last_run_ma = sum(series[-N:]) / float(len(series[-N:])) if series else None
+    state_last_run_ma = (
+        state["last_run_injected_ma"] if args.tap_status == "disabled-host" else last_run_ma
+    )
+    save_state(state_path, last_fire_ma, state_last_run_ma)
+    result = _read_step_result(attempt_dir / "step-result.json")
+    outcome = outcome_from_result(cli_exit_code, result)
+    window_error = outcome == "overflowed"
+    if args.nudge_shown:
+        final_disposition = "shown"
+    elif fired_turns:
+        final_disposition = "shadow" if args.mode == "shadow" else "suppressed"
+    else:
+        final_disposition = "none"
+    attempt_end = {
+        "event": "attempt_end",
+        "schema_version": SCHEMA_VERSION,
+        "ts": now_utc(),
+        "started_at": started_at,
+        "task_id": args.task_id,
+        "attempt": args.attempt,
+        "outcome": outcome,
+        "window_error": window_error,
+        "runtime_compaction": False,
+        "compaction_suspected": compaction_seen,
+        "total_tokens": total_tokens,
+        "injected_summary": {
+            "max": max(series) if series else 0,
+            "last3_mean": last_run_ma or 0,
+        },
+        "fired_turns": fired_turns,
+        "alert_turns": alert_turns,
+        "nudge_disposition_final": final_disposition,
+        "tap_status": tap_status_final,
+        "run_meta": meta,
+        "elapsed_s": round(time.monotonic() - started_monotonic, 3),
+    }
+    append_event(events_path, attempt_end)
+    attempt_receipt = {
+        "schema_version": SCHEMA_VERSION,
+        "task_id": args.task_id,
+        "attempt": args.attempt,
+        "mode": args.mode,
+        "model": model,
+        "ctx_window": ctx_window,
+        "ctx_window_source": ctx_source,
+        "started_at": started_at,
+        "first_byte_at": first_byte_at,
+        "cli_exit_code": cli_exit_code,
+        "tap_status_final": tap_status_final,
+        "fired": bool(fired_turns),
+        "events_path": str(events_path),
+    }
+    if set(attempt_receipt) != ATTEMPT_FIELDS:
+        raise RuntimeError("attempt receipt field set drifted")
+    atomic_write_json(attempt_dir / "attempt.json", attempt_receipt)
+    return 0
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stream", required=True)
+    parser.add_argument("--eof", required=True)
+    parser.add_argument("--attempt-dir", required=True)
+    parser.add_argument("--artifact-dir", required=True)
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--attempt", required=True, type=int)
+    parser.add_argument("--mode", required=True, choices=("shadow", "active"))
+    parser.add_argument("--model", default="claude-unknown")
+    parser.add_argument("--t-abs", required=True, type=int)
+    parser.add_argument("--w", required=True, type=float)
+    parser.add_argument("--ctx-window", type=int)
+    parser.add_argument("--hf-config")
+    parser.add_argument("--tap-status", default="enabled", choices=("enabled", "disabled-host"))
+    parser.add_argument("--nudge-shown", action="store_true")
+    parser.add_argument("--poll-interval", type=float, default=0.02)
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(monitor(parse_args()))

--- a/adapters/claude-code/overflow_sentinel_monitor.py
+++ b/adapters/claude-code/overflow_sentinel_monitor.py
@@ -87,11 +87,13 @@ def _usage_from_assistant(event: Dict[str, Any]) -> Optional[Tuple[Dict[str, Any
     return message, usage
 
 
-def _safe_int(value: Any) -> int:
+def _usage_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
     try:
         result = int(value or 0)
     except (TypeError, ValueError):
-        return 0
+        return None
     return max(0, result)
 
 
@@ -182,6 +184,7 @@ def monitor(args: argparse.Namespace) -> int:
     fired_turns = []
     alert_turns = []
     compaction_seen = False
+    runtime_compaction_seen = False
     last_injected = None
     turn_count = 0
     blind_seen = False
@@ -192,12 +195,31 @@ def monitor(args: argparse.Namespace) -> int:
 
     while True:
         lines, offset, pending = _read_complete_lines(stream_path, offset, pending)
+        cli_exit_code = _read_eof(eof_path)
+        eof_seen = cli_exit_code is not None
+        if eof_seen:
+            final_lines, offset, pending = _read_complete_lines(stream_path, offset, pending)
+            lines.extend(final_lines)
+            if pending:
+                lines.append(pending.decode("utf-8", errors="replace"))
+                pending = b""
         for raw in lines:
             try:
                 event = json.loads(raw)
             except (ValueError, TypeError):
                 continue
-            if not isinstance(event, dict) or event.get("type") != "assistant":
+            if not isinstance(event, dict):
+                continue
+            if event.get("type") == "system" and event.get("subtype") == "compact_boundary":
+                runtime_compaction_seen = True
+                series = []
+                last_injected = None
+                try:
+                    pending_path.unlink()
+                except FileNotFoundError:
+                    pass
+                continue
+            if event.get("type") != "assistant" or event.get("parent_tool_use_id") is not None:
                 continue
             if first_byte_at is None:
                 first_byte_at = str(event.get("timestamp") or now_utc())
@@ -211,11 +233,14 @@ def monitor(args: argparse.Namespace) -> int:
                     continue
                 seen_ids.add(identity)
             saw_usage = True
-            input_tokens = _safe_int(usage.get("input_tokens"))
-            cache_read = _safe_int(usage.get("cache_read_input_tokens"))
-            cache_creation = _safe_int(usage.get("cache_creation_input_tokens"))
-            output_tokens = _safe_int(usage.get("output_tokens"))
             has_cache = "cache_read_input_tokens" in usage and "cache_creation_input_tokens" in usage
+            input_tokens = _usage_int(usage.get("input_tokens"))
+            cache_read = _usage_int(usage.get("cache_read_input_tokens", 0))
+            cache_creation = _usage_int(usage.get("cache_creation_input_tokens", 0))
+            output_tokens = _usage_int(usage.get("output_tokens", 0))
+            if None in (input_tokens, cache_read, cache_creation, output_tokens):
+                saw_no_cache = True
+                continue
             injected = input_tokens + cache_read + cache_creation
             blind = has_cache and injected == 0 and output_tokens == 0
             if blind:
@@ -249,6 +274,8 @@ def monitor(args: argparse.Namespace) -> int:
                 if consecutive_blind >= 3:
                     evaluation_disabled = True
                 continue
+            if injected == 0:
+                continue
             if evaluation_disabled:
                 continue
             if compaction_suspected(last_injected, injected):
@@ -267,6 +294,7 @@ def monitor(args: argparse.Namespace) -> int:
             fire_axis = axis_name(axes)
             for fire_candidate in axes:
                 last_fire_ma[fire_candidate] = turn["injected_ma"]
+            save_state(state_path, last_fire_ma, state["last_run_injected_ma"])
             fire_event = {
                 "event": "fire",
                 "schema_version": SCHEMA_VERSION,
@@ -279,7 +307,6 @@ def monitor(args: argparse.Namespace) -> int:
                 "injected_ma": turn["injected_ma"],
                 "injected_last": turn["injected_last"],
                 "value_kind": "measured",
-                "threshold_hit": turn["threshold_hit"],
                 "ctx_window": ctx_window,
                 "ctx_window_source": ctx_source,
                 "slope": turn["slope"],
@@ -291,6 +318,8 @@ def monitor(args: argparse.Namespace) -> int:
                 "tap_status": "no-cache-accounting" if saw_no_cache else "ok",
                 "run_meta": meta,
             }
+            if "threshold_hit" in turn:
+                fire_event["threshold_hit"] = turn["threshold_hit"]
             append_event(events_path, fire_event)
             fired_turns.append(turn_count)
             if args.mode == "active":
@@ -316,8 +345,7 @@ def monitor(args: argparse.Namespace) -> int:
             )
             alert_written = True
             alert_turns.append(alert_turn)
-        cli_exit_code = _read_eof(eof_path)
-        if cli_exit_code is not None:
+        if eof_seen:
             break
         time.sleep(args.poll_interval)
 
@@ -337,10 +365,8 @@ def monitor(args: argparse.Namespace) -> int:
         tap_status_final = "absent"
 
     last_run_ma = sum(series[-N:]) / float(len(series[-N:])) if series else None
-    state_last_run_ma = (
-        state["last_run_injected_ma"] if args.tap_status == "disabled-host" else last_run_ma
-    )
-    save_state(state_path, last_fire_ma, state_last_run_ma)
+    if last_run_ma is not None:
+        save_state(state_path, last_fire_ma, last_run_ma)
     result = _read_step_result(attempt_dir / "step-result.json")
     outcome = outcome_from_result(cli_exit_code, result)
     window_error = outcome == "overflowed"
@@ -359,7 +385,7 @@ def monitor(args: argparse.Namespace) -> int:
         "attempt": args.attempt,
         "outcome": outcome,
         "window_error": window_error,
-        "runtime_compaction": False,
+        "runtime_compaction": runtime_compaction_seen,
         "compaction_suspected": compaction_seen,
         "total_tokens": total_tokens,
         "injected_summary": {
@@ -402,7 +428,7 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--attempt-dir", required=True)
     parser.add_argument("--artifact-dir", required=True)
     parser.add_argument("--task-id", required=True)
-    parser.add_argument("--attempt", required=True, type=int)
+    parser.add_argument("--attempt", required=True)
     parser.add_argument("--mode", required=True, choices=("shadow", "active"))
     parser.add_argument("--model", default="claude-unknown")
     parser.add_argument("--t-abs", required=True, type=int)

--- a/adapters/claude-code/spawn_step.sh
+++ b/adapters/claude-code/spawn_step.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Claude Code task-runner step adapter with an opt-in passive overflow sentinel.
+# argv: spawn_step.sh <task-file> <workspace> <attempt-dir> <step-k>
+
+usage() {
+  printf 'Usage: spawn_step.sh <task-file> <workspace> <attempt-dir> <step-k>\n' >&2
+}
+
+config_fail() {
+  printf 'spawn_step.sh: %s\n' "$1" >&2
+  exit 2
+}
+
+if (($# != 4)); then
+  usage
+  exit 2
+fi
+
+task_file=$1
+workspace=$2
+attempt_dir=$3
+step_k=$4
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+source "$repo_root/scripts/lib-bounded.sh"
+source "$repo_root/scripts/lib-command-argv.sh"
+source "$repo_root/scripts/lib-pause.sh"
+prompt_file="$attempt_dir/prompt.md"
+
+: "$task_file" "$step_k"
+
+[[ -d "$workspace" ]] || config_fail "workspace dir not found: $workspace"
+workspace=$(caty_pause_canonical_workspace "$workspace" 2>/dev/null) \
+  || config_fail 'invalid or symlinked workspace'
+pause_state=$(caty_pause_workspace_state "$workspace")
+if [[ "$pause_state" != enabled ]]; then
+  caty_pause_status_record "$workspace" overflow-spawn-step
+  exit 0
+fi
+[[ -d "$attempt_dir" ]] || config_fail "attempt dir not found: $attempt_dir"
+attempt_dir=$(cd "$attempt_dir" && pwd -P)
+prompt_file="$attempt_dir/prompt.md"
+[[ -f "$prompt_file" ]] || config_fail "missing prompt file: $prompt_file"
+
+ovf_mode=${OVF_SENTINEL:-}
+case "$ovf_mode" in
+  ''|shadow|active) ;;
+  *) config_fail 'OVF_SENTINEL must be unset, shadow, or active' ;;
+esac
+
+ovf_t_abs=${OVF_T_ABS:-80000}
+case "$ovf_t_abs" in
+  ''|*[!0-9]*|0|0[0-9]*) config_fail 'OVF_T_ABS must be an integer >= 1' ;;
+esac
+ovf_w_pct=${OVF_W_PCT:-50}
+case "$ovf_w_pct" in
+  ''|*[!0-9]*|0|0[0-9]*) config_fail 'OVF_W_PCT must be an integer from 1 through 99' ;;
+esac
+(( ovf_w_pct <= 99 )) || config_fail 'OVF_W_PCT must be an integer from 1 through 99'
+printf -v ovf_w '0.%02d' "$ovf_w_pct"
+
+ovf_ctx_window=${OVF_CTX_WINDOW:-}
+if [[ -n "$ovf_ctx_window" ]]; then
+  case "$ovf_ctx_window" in
+    *[!0-9]*|0|0[0-9]*) config_fail 'OVF_CTX_WINDOW must be an integer >= 1' ;;
+  esac
+fi
+
+ovf_finalize_timeout_s=${OVF_FINALIZE_TIMEOUT_S:-10}
+case "$ovf_finalize_timeout_s" in
+  ''|*[!0-9]*|0|0[0-9]*) config_fail 'OVF_FINALIZE_TIMEOUT_S must be an integer >= 1' ;;
+esac
+
+ovf_owner=${OVF_COMPACTION_OWNER:-}
+case "$ovf_owner" in
+  ''|sentinel|host) ;;
+  *) config_fail 'OVF_COMPACTION_OWNER must be sentinel or host' ;;
+esac
+
+ovf_hf_config=${OVF_HF_CONFIG:-}
+if [[ -n "$ovf_mode" && -n "$ovf_hf_config" ]]; then
+  python3 -B "$repo_root/scripts/lib_overflow_sentinel.py" validate-hf "$ovf_hf_config" >/dev/null \
+    || config_fail 'OVF_HF_CONFIG must name a validated local HF config.json'
+fi
+
+ovf_step_cmd=${OVF_STEP_CMD:-claude -p --output-format stream-json --verbose}
+if ! validate_cmd_argv OVF_STEP_CMD "$ovf_step_cmd"; then
+  config_fail "OVF_STEP_CMD: $_validated_reason"
+fi
+if ! resolve_cmd_argv0 OVF_STEP_CMD; then
+  config_fail "OVF_STEP_CMD: $_validated_reason"
+fi
+step_argv=("${_validated_argv[@]+"${_validated_argv[@]}"}")
+
+export TASK_FILE="$task_file" ATTEMPT_DIR="$attempt_dir" WORKSPACE="$workspace"
+artifact_dir=$(cd "$attempt_dir/../.." && pwd)
+export ARTIFACT_DIR="$artifact_dir"
+cd "$workspace"
+
+ovf_step_timeout_s=540
+if [[ -n "${TR_STEP_TIMEOUT_S:-}" && "$TR_STEP_TIMEOUT_S" =~ ^[1-9][0-9]*$ ]]; then
+  if (( TR_STEP_TIMEOUT_S > ovf_finalize_timeout_s + 2 )); then
+    ovf_step_timeout_s=$((TR_STEP_TIMEOUT_S - ovf_finalize_timeout_s - 1))
+  else
+    ovf_step_timeout_s=1
+  fi
+fi
+
+# Fully-off means no Python, no tee, and no overflow-sentinel artifacts.
+if [[ -z "$ovf_mode" ]]; then
+  set +e
+  run_bounded "$ovf_step_timeout_s" 10 /bin/bash -c \
+    'prompt=$1; shift; exec "$@" <"$prompt"' _ "$prompt_file" \
+    "${step_argv[@]+"${step_argv[@]}"}"
+  step_status=$?
+  set -e
+  exit "$step_status"
+fi
+
+if [[ -z "$ovf_owner" ]]; then
+  printf 'warning: OVF_COMPACTION_OWNER is unset; overflow sentinel owns compaction detection\n' >&2
+  ovf_owner=sentinel
+fi
+
+attempt_name=$(basename "$attempt_dir")
+case "$attempt_name" in
+  ''|*[!0-9]*) config_fail 'attempt directory basename must be numeric' ;;
+esac
+task_id=$(basename "$artifact_dir")
+stream_path="$attempt_dir/stream.jsonl"
+eof_path="$attempt_dir/overflow-stream.eof"
+eof_tmp="$eof_path.tmp.$$"
+monitor_stderr="$attempt_dir/.overflow-monitor.stderr.$$"
+augmented_prompt=
+monitor_pid=
+
+_overflow_spawn_exit_quarantine() {
+  if [[ -n "${monitor_pid:-}" ]] && kill -0 "$monitor_pid" 2>/dev/null; then
+    kill -KILL "$monitor_pid" 2>/dev/null || true
+    wait "$monitor_pid" 2>/dev/null || true
+  fi
+  [[ -z "${augmented_prompt:-}" ]] || rm -f "$augmented_prompt"
+  rm -f "$eof_tmp" "$monitor_stderr"
+}
+trap _overflow_spawn_exit_quarantine EXIT
+
+nudge_shown=0
+prior_pending=
+if [[ -d "$artifact_dir/attempts" ]]; then
+  for pending_candidate in "$artifact_dir"/attempts/*/overflow-nudge.pending; do
+    [[ -f "$pending_candidate" && ! -L "$pending_candidate" ]] || continue
+    [[ "$(dirname "$pending_candidate")" != "$attempt_dir" ]] || continue
+    if [[ -z "$prior_pending" || "$pending_candidate" > "$prior_pending" ]]; then
+      prior_pending=$pending_candidate
+    fi
+  done
+fi
+if [[ -n "$prior_pending" ]]; then
+  augmented_prompt=$(mktemp "$attempt_dir/.overflow-prompt.XXXXXX")
+  {
+    cat "$prior_pending"
+    printf '\n--- original step prompt ---\n\n'
+    cat "$prompt_file"
+  } >"$augmented_prompt"
+  rm -f "$prior_pending"
+  prompt_file=$augmented_prompt
+  nudge_shown=1
+fi
+
+monitor_args=(
+  "$repo_root/adapters/claude-code/overflow_sentinel_monitor.py"
+  --stream "$stream_path"
+  --eof "$eof_path"
+  --attempt-dir "$attempt_dir"
+  --artifact-dir "$artifact_dir"
+  --task-id "$task_id"
+  --attempt "$attempt_name"
+  --mode "$ovf_mode"
+  --model "${CLAUDE_MODEL:-claude-unknown}"
+  --t-abs "$ovf_t_abs"
+  --w "$ovf_w"
+)
+[[ -z "$ovf_ctx_window" ]] || monitor_args+=(--ctx-window "$ovf_ctx_window")
+[[ -z "$ovf_hf_config" ]] || monitor_args+=(--hf-config "$ovf_hf_config")
+[[ "$ovf_owner" != host ]] || monitor_args+=(--tap-status disabled-host)
+(( nudge_shown == 0 )) || monitor_args+=(--nudge-shown)
+
+python3 -B "${monitor_args[@]}" 2>"$monitor_stderr" &
+monitor_pid=$!
+
+set +e
+run_bounded "$ovf_step_timeout_s" 10 /bin/bash -c \
+  'prompt=$1; shift; exec "$@" <"$prompt"' _ "$prompt_file" \
+  "${step_argv[@]+"${step_argv[@]}"}" \
+  | tee "$stream_path"
+step_status=${PIPESTATUS[0]}
+set -e
+
+printf '%s\n' "$step_status" >"$eof_tmp"
+mv -f "$eof_tmp" "$eof_path"
+
+join_started=$SECONDS
+monitor_timed_out=0
+while kill -0 "$monitor_pid" 2>/dev/null; do
+  if (( SECONDS - join_started >= ovf_finalize_timeout_s )); then
+    monitor_timed_out=1
+    kill -KILL "$monitor_pid" 2>/dev/null || true
+    break
+  fi
+  sleep 0.05
+done
+set +e
+wait "$monitor_pid"
+monitor_status=$?
+set -e
+monitor_pid=
+
+if (( monitor_timed_out == 1 )); then
+  printf 'warning: overflow sentinel finalize timeout; records may be incomplete\n' >&2
+elif (( monitor_status != 0 )); then
+  printf 'warning: overflow sentinel monitor failed; continuing without complete sentinel records\n' >&2
+  [[ ! -s "$monitor_stderr" ]] || cat "$monitor_stderr" >&2
+fi
+
+exit "$step_status"

--- a/adapters/claude-code/spawn_step.sh
+++ b/adapters/claude-code/spawn_step.sh
@@ -49,6 +49,48 @@ case "$ovf_mode" in
   *) config_fail 'OVF_SENTINEL must be unset, shadow, or active' ;;
 esac
 
+ovf_step_cmd=${OVF_STEP_CMD:-claude -p --output-format stream-json --verbose}
+if ! validate_cmd_argv OVF_STEP_CMD "$ovf_step_cmd"; then
+  config_fail "OVF_STEP_CMD: $_validated_reason"
+fi
+if ! resolve_cmd_argv0 OVF_STEP_CMD; then
+  config_fail "OVF_STEP_CMD: $_validated_reason"
+fi
+step_argv=("${_validated_argv[@]+"${_validated_argv[@]}"}")
+
+export TASK_FILE="$task_file" ATTEMPT_DIR="$attempt_dir" WORKSPACE="$workspace"
+artifact_dir=$(cd "$attempt_dir/../.." && pwd)
+export ARTIFACT_DIR="$artifact_dir"
+cd "$workspace"
+
+step_call_finished=1
+_overflow_quarantine_partial() {
+  if [[ "${step_call_finished:-0}" -eq 0 ]] && [[ -f "${attempt_dir:-}/step-result.json" ]]; then
+    mv -f "$attempt_dir/step-result.json" "$attempt_dir/step-result.json.partial"
+  fi
+}
+trap _overflow_quarantine_partial EXIT
+
+# Fully-off means no Python, no tee, and no overflow-sentinel artifacts.
+if [[ -z "$ovf_mode" ]]; then
+  ovf_step_timeout_s=540
+  if [[ -n "${TR_STEP_TIMEOUT_S:-}" && "$TR_STEP_TIMEOUT_S" =~ ^[1-9][0-9]*$ ]]; then
+    ovf_step_timeout_s=$TR_STEP_TIMEOUT_S
+  fi
+  step_call_finished=0
+  set +e
+  run_bounded "$ovf_step_timeout_s" 10 /bin/bash -c \
+    'prompt=$1; shift; exec "$@" <"$prompt"' _ "$prompt_file" \
+    "${step_argv[@]+"${step_argv[@]}"}"
+  step_status=$?
+  set -e
+  step_call_finished=1
+  if [[ "$step_status" -eq 124 || "$step_status" -gt 128 ]] && [[ -f "$attempt_dir/step-result.json" ]]; then
+    mv -f "$attempt_dir/step-result.json" "$attempt_dir/step-result.json.partial"
+  fi
+  exit "$step_status"
+fi
+
 ovf_t_abs=${OVF_T_ABS:-80000}
 case "$ovf_t_abs" in
   ''|*[!0-9]*|0|0[0-9]*) config_fail 'OVF_T_ABS must be an integer >= 1' ;;
@@ -79,24 +121,10 @@ case "$ovf_owner" in
 esac
 
 ovf_hf_config=${OVF_HF_CONFIG:-}
-if [[ -n "$ovf_mode" && -n "$ovf_hf_config" ]]; then
+if [[ -n "$ovf_hf_config" ]]; then
   python3 -B "$repo_root/scripts/lib_overflow_sentinel.py" validate-hf "$ovf_hf_config" >/dev/null \
     || config_fail 'OVF_HF_CONFIG must name a validated local HF config.json'
 fi
-
-ovf_step_cmd=${OVF_STEP_CMD:-claude -p --output-format stream-json --verbose}
-if ! validate_cmd_argv OVF_STEP_CMD "$ovf_step_cmd"; then
-  config_fail "OVF_STEP_CMD: $_validated_reason"
-fi
-if ! resolve_cmd_argv0 OVF_STEP_CMD; then
-  config_fail "OVF_STEP_CMD: $_validated_reason"
-fi
-step_argv=("${_validated_argv[@]+"${_validated_argv[@]}"}")
-
-export TASK_FILE="$task_file" ATTEMPT_DIR="$attempt_dir" WORKSPACE="$workspace"
-artifact_dir=$(cd "$attempt_dir/../.." && pwd)
-export ARTIFACT_DIR="$artifact_dir"
-cd "$workspace"
 
 ovf_step_timeout_s=540
 if [[ -n "${TR_STEP_TIMEOUT_S:-}" && "$TR_STEP_TIMEOUT_S" =~ ^[1-9][0-9]*$ ]]; then
@@ -105,17 +133,10 @@ if [[ -n "${TR_STEP_TIMEOUT_S:-}" && "$TR_STEP_TIMEOUT_S" =~ ^[1-9][0-9]*$ ]]; t
   else
     ovf_step_timeout_s=1
   fi
-fi
-
-# Fully-off means no Python, no tee, and no overflow-sentinel artifacts.
-if [[ -z "$ovf_mode" ]]; then
-  set +e
-  run_bounded "$ovf_step_timeout_s" 10 /bin/bash -c \
-    'prompt=$1; shift; exec "$@" <"$prompt"' _ "$prompt_file" \
-    "${step_argv[@]+"${step_argv[@]}"}"
-  step_status=$?
-  set -e
-  exit "$step_status"
+  if (( ovf_step_timeout_s <= 30 )); then
+    printf 'warning: overflow sentinel derived CLI budget is only %ss after finalize reservation\n' \
+      "$ovf_step_timeout_s" >&2
+  fi
 fi
 
 if [[ -z "$ovf_owner" ]]; then
@@ -142,17 +163,25 @@ _overflow_spawn_exit_quarantine() {
   fi
   [[ -z "${augmented_prompt:-}" ]] || rm -f "$augmented_prompt"
   rm -f "$eof_tmp" "$monitor_stderr"
+  _overflow_quarantine_partial
 }
 trap _overflow_spawn_exit_quarantine EXIT
 
 nudge_shown=0
 prior_pending=
+prior_pending_number=-1
 if [[ -d "$artifact_dir/attempts" ]]; then
   for pending_candidate in "$artifact_dir"/attempts/*/overflow-nudge.pending; do
     [[ -f "$pending_candidate" && ! -L "$pending_candidate" ]] || continue
     [[ "$(dirname "$pending_candidate")" != "$attempt_dir" ]] || continue
-    if [[ -z "$prior_pending" || "$pending_candidate" > "$prior_pending" ]]; then
+    pending_attempt=$(basename "$(dirname "$pending_candidate")")
+    case "$pending_attempt" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    pending_number=$((10#$pending_attempt))
+    if (( pending_number > prior_pending_number )); then
       prior_pending=$pending_candidate
+      prior_pending_number=$pending_number
     fi
   done
 fi
@@ -189,6 +218,7 @@ monitor_args=(
 python3 -B "${monitor_args[@]}" 2>"$monitor_stderr" &
 monitor_pid=$!
 
+step_call_finished=0
 set +e
 run_bounded "$ovf_step_timeout_s" 10 /bin/bash -c \
   'prompt=$1; shift; exec "$@" <"$prompt"' _ "$prompt_file" \
@@ -196,6 +226,11 @@ run_bounded "$ovf_step_timeout_s" 10 /bin/bash -c \
   | tee "$stream_path"
 step_status=${PIPESTATUS[0]}
 set -e
+step_call_finished=1
+
+if [[ "$step_status" -eq 124 || "$step_status" -gt 128 ]] && [[ -f "$attempt_dir/step-result.json" ]]; then
+  mv -f "$attempt_dir/step-result.json" "$attempt_dir/step-result.json.partial"
+fi
 
 printf '%s\n' "$step_status" >"$eof_tmp"
 mv -f "$eof_tmp" "$eof_path"

--- a/docs/design/159-overflow-sentinel/DESIGN.md
+++ b/docs/design/159-overflow-sentinel/DESIGN.md
@@ -1,6 +1,6 @@
 # DESIGN: #159 overflow sentinel — 文脈圧力の実測で task-runner を発火する
 
-status: **v0.5.2**（2026-08-25・Alpha・L1-9 r3 PASS〔3席 CUMULATIVE GO 収束・blocking 残0〕+
+status: **v0.5.3**（2026-08-25・Alpha・L1-9 r3 PASS〔3席 CUMULATIVE GO 収束・blocking 残0〕+
 **EV-008 完了・default-on GO 宣言済み（案A・2026-08-25）を「設計の現在地」として反映**・サイズ H）
 inputs: PILOT.md（訂正節含む）/ REPORT-runtime-context-survey.md / REPORT-pattern4-rootcause.md /
 REPORT-hermes-provider-layer.md / REPORT-hermes-provider-deep-research.md / REPORT-qwen38-artifacts.md /
@@ -138,7 +138,7 @@ alert       = ts_first_byte 不在のまま TTFB 床超過（fire とは別イ�
 ```
 
 **OR の実効挙動を明記**（Opus NB1）: 実効水位閾値は `min(T_abs, w×ctx_window)` であり、
-**ctx_window ≥ T_abs/w（設計時初期値 T_abs=40k・w=50% なら 80k。製品既定は §5= TBD）のモデルでは絶対項が常に先に効く**。相対項が主役になるのは
+**ctx_window ≥ T_abs/w（製品既定 T_abs=80k・w=50% なら 160k）のモデルでは絶対項が常に先に効く**。相対項が主役になるのは
 小窓モデル（64k 級・EV-008 の人工縮小腕を含む）のみ。「相対=あふれ射影用」という v0.3 の説明は不正確
 だったため削除。
 
@@ -165,13 +165,13 @@ alert       = ts_first_byte 不在のまま TTFB 床超過（fire とは別イ�
 - 所有境界: **sentinel 軸= 生きている間の検出+alert / harness#162= 死んだ後の attempt 分類+早期 DLQ**。
   共有するのは byte tap のみ。kill/再接続の semantics は v2 で #162 側と合同設計。
 
-## 5. 閾値と ctx_window（D4: 設計時初期値 + config 上書き — 製品既定は実装 Issue で確定）
+## 5. 閾値と ctx_window（D4: 製品既定 + config 上書き）
 
 | パラメータ | 既定 | 由来 |
 |---|---|---|
 | N（移動平均窓） | 3 turns | pilot の bare 立ち上がり 2〜4 turn |
-| T_abs（絶対水位） | **TBD（EV-008 GO 実走= 80k・製品既定の最終確定は実装 Issue の clarify で行う）** — 設計時の初期値 40,000 tok/turn は較正候補 {40k, 80k, 120k} の下端として由来欄に残置。LITE Phase 0 replay で 40k は claude 系 bare のターン1即発火= 過敏と実測済み | EV-006 harness 上界の上端（F2）。**系譜注記（Fable r2）**: EV-006 の 20〜40k は harness の per-step fresh-context 注入量・sentinel の injected は累積プロンプト全体でレジームが異なる。40k は過敏側（200k 窓の実質全タスクが中盤で跨ぐ）の可能性があり、既定の最終確定は較正に委ねる |
-| w（窓比水位） | 50% | bare sonnet L帯 定常 ~56% の近傍。**導出ではなく同域の初期値** — EV-008 は実走 50% で GO 成立（ライブ sweep は prereg v0.3 で replay 較正に置換）。製品既定の最終確定は T_abs と同じく実装 Issue の clarify |
+| T_abs（絶対水位） | **80,000 tok/turn** | EV-008 GO 実走値。設計時の初期値 40,000 tok/turn は較正候補 {40k, 80k, 120k} の下端として由来欄に残置。LITE Phase 0 replay で 40k は claude 系 bare のターン1即発火= 過敏と実測済み。**系譜注記（Fable r2）**: EV-006 の 20〜40k は harness の per-step fresh-context 注入量・sentinel の injected は累積プロンプト全体でレジームが異なる |
+| w（窓比水位） | **50%** | bare sonnet L帯 定常 ~56% の近傍。**導出ではなく同域の初期値** — EV-008 は実走 50% で GO 成立（ライブ sweep は prereg v0.3 で replay 較正に置換） |
 | M（射影ホライズン） | 10 turns | 保守的（v1 の誤発火コスト= ログ1行+ナッジ1回） |
 | TTFB 床 | 90/150/240s + reasoning floor 表 + unknown=240s | Hermes 実装値 + hermes#89241 の逆張り |
 
@@ -285,3 +285,8 @@ task_end: {ts, started_at, task_id, outcome: completed|overflowed|decomposed|abo
   方法論」の列挙形に精密化 / README の
   「3席 cumulative GO」を裁定記録ベースと明示（r3 確認ログ非保全の開示と整合）/ §4 の「既定なら 80k」と
   §5 見出しを TBD 化と整合 / §10 r1 訂正注記の版表記を v0.5 までに修正
+- v0.5.3（2026-08-25・#180 実装 writeback）: §5 の製品既定を T_abs=80k / w=50% に確定。
+  v1 claude-code integration は monitored run ごとの terminal record として `attempt_end` を emit し、
+  task-level `task_end` は ledger-confluence follow-up へ延期する。nudge delivery は next-step boundary のため、
+  発火 attempt で task が終了した場合は nudge 未配送となる。TTFB v1 は run-start→first assistant byte のみで、
+  inter-turn stall detection は passive stream で request boundary を観測できる joint-design follow-up へ延期する

--- a/docs/design/159-overflow-sentinel/DESIGN.md
+++ b/docs/design/159-overflow-sentinel/DESIGN.md
@@ -193,7 +193,7 @@ alert       = ts_first_byte 不在のまま TTFB 床超過（fire とは別イ�
 turn:     （§3 の tap イベントをそのまま ledger に毎ターン保存。replay・miss 判定・事後再計算の材料。
            Opus r2 B2: 要約だけでは「あふれ何ターン前に閾値を跨いだか」を復元できない）
 fire:     {ts, started_at, task_id, turn_idx, axis: level|slope|both, injected_ma, injected_last,
-           value_kind: measured|estimated, threshold_hit: abs|ratio|both, ctx_window, ctx_window_source,
+           value_kind: measured|estimated, threshold_hit?: abs|ratio|both（level crossing 時のみ）, ctx_window, ctx_window_source,
            slope, projection_turns, decision: nudge, nudge_disposition: shown|suppressed|shadow,
            model, runtime, tap_status, run_meta: {arm?, seed?, shuffle_seed?, T_abs, w, N, M, K},
            schema_version}
@@ -248,7 +248,7 @@ task_end: {ts, started_at, task_id, outcome: completed|overflowed|decomposed|abo
 - tap 適合 golden-file テスト（アダプタ毎: 排他加算・cached 内包の除去・SSE ping 除外を固定入力で検証。
   Fable r2: 契約は「書けば守られる」側に倒れやすい — 違反は水位の系統誤差として静かに入るため）
 - reasoning floor 表の実体収載（v1 表= 90/150/240s + 記名 override。無記名モデル= reasoning 含め 240s）
-- TTFB 床の tier キー= 前ターンの injected（byte イベントに optional `request_size_estimate` を追加可）
+- TTFB 床の tier キー= 前 monitored run の last injected MA（v0.5.3 実装 delta で旧「前ターン」表現を訂正）
 
 ## 10. レビュー履歴
 

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -147,6 +147,9 @@ runtime host が compaction を所有する場合は `OVF_COMPACTION_OWNER=host`
 水位述語を実行せず `disabled-host` を記録します。有効時に owner を未設定のままにすると warning を出し、
 sentinel heuristic を選びます。
 
+Claude の明示的な `system/compact_boundary` event を観測すると measured series を reset します。
+この event が得られない場合は injected-token の急落 heuristic が fallback のままです。
+
 監視対象の各 attempt は `turn`、`fire`、`alert`、`attempt_end` を独立した
 `sentinel-events.jsonl` へ append します。task-runner ledger に confluence point ができるまでは
 このファイルを分離して保持します。次 step 境界で nudge を配送するため、発火した attempt で task が

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -133,6 +133,28 @@ fold 経路は workspace につき 1 本だけです。この consumer か、Ope
 
 詳しいセットアップ手順・ledger の形式・schedule の詳細は [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) を参照してください。
 
+### Overflow sentinel
+
+Claude Code の step adapter は、passive な overflow sentinel を opt-in で利用できます。
+sentinel は Claude の `stream-json` を tail し、assistant message を identity で dedup した上で、
+各 prompt を input・cache-read・cache-creation token の排他的な合計として測定します。
+shadow mode は判断を記録するだけで、active mode は次の task-runner step へ渡す 5 点の delta nudge も
+準備します。model を中断・signal することはなく、model 終了後の bounded な記録確定 join を除いて
+model を block しません。
+
+sentinel は healthy tap、cache accounting 不足、tap absent、全ゼロの blind tap を区別します。
+runtime host が compaction を所有する場合は `OVF_COMPACTION_OWNER=host` を設定します。この場合は
+水位述語を実行せず `disabled-host` を記録します。有効時に owner を未設定のままにすると warning を出し、
+sentinel heuristic を選びます。
+
+監視対象の各 attempt は `turn`、`fire`、`alert`、`attempt_end` を独立した
+`sentinel-events.jsonl` へ append します。task-runner ledger に confluence point ができるまでは
+このファイルを分離して保持します。次 step 境界で nudge を配送するため、発火した attempt で task が
+終了すると pending nudge を受け取る runtime がない、という既知の制限があります。`suppressed` の
+fire/terminal disposition により、この未配送は計測可能です。passive な `claude -p` stream からは
+run start と最初の assistant byte しか観測できず、request ごとの境界は観測できないため、inter-turn
+TTFB stall も後続版へ延期します。
+
 ---
 
 <a id="pause"></a>

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -149,6 +149,10 @@ host owns compaction; this records `disabled-host` instead of running the water
 level predicate. Leaving the owner unset while enabled warns and selects the
 sentinel heuristic.
 
+An explicit Claude `system/compact_boundary` event resets the measured series;
+when that event is unavailable, the injected-token drop heuristic remains the
+fallback.
+
 Each monitored attempt appends `turn`, `fire`, `alert`, and `attempt_end` records
 to its standalone `sentinel-events.jsonl`. This file remains separate until the
 task-runner ledger has a confluence point. The next-step delivery boundary has

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -133,6 +133,31 @@ Exactly one fold route may run per workspace: this consumer, or OpenClaw's `dist
 
 See [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) for the full setup steps, ledger format, and scheduling detail.
 
+### Overflow sentinel
+
+The Claude Code step adapter can opt into a passive overflow sentinel. It tails
+Claude `stream-json`, deduplicates assistant messages by identity, and measures
+each prompt as the exclusive sum of input, cache-read, and cache-creation
+tokens. Shadow mode logs decisions; active mode additionally prepares a
+five-point delta nudge for the next task-runner step. It never interrupts,
+signals, or blocks the model beyond a bounded post-exit record-finalization
+join.
+
+The sentinel distinguishes a healthy tap, missing cache accounting, an absent
+tap, and an all-zero blind tap. Set `OVF_COMPACTION_OWNER=host` when the runtime
+host owns compaction; this records `disabled-host` instead of running the water
+level predicate. Leaving the owner unset while enabled warns and selects the
+sentinel heuristic.
+
+Each monitored attempt appends `turn`, `fire`, `alert`, and `attempt_end` records
+to its standalone `sentinel-events.jsonl`. This file remains separate until the
+task-runner ledger has a confluence point. The next-step delivery boundary has
+one known limitation: a task that ends on its firing attempt cannot receive the
+pending nudge. The `suppressed` fire/terminal disposition makes that miss
+measurable. Inter-turn TTFB stalls are likewise deferred because a passive
+`claude -p` stream exposes run start and first assistant byte, but not individual
+request boundaries.
+
 ---
 
 <a id="pause"></a>

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -87,8 +87,9 @@ flush intake consumer の会計 ledger は `loop/pending/intake-runs.log` です
 ### Claude Code overflow sentinel の環境変数
 
 Claude Code adapter は CLI を spawn する前に次の値を検証します。不正値は exit 2 です。
-`OVF_SENTINEL` が unset または空なら、sentinel のその他の動作もすべて無効です。CLI は
-`prompt.md` を stdin から直接受け取り、stdout は変わらず、sentinel artifact は 1 つも作られません。
+`OVF_SENTINEL` が unset または空なら、CLI selector の `OVF_STEP_CMD` 以外の sentinel 設定は無視され、
+sentinel の動作も無効です。CLI は `prompt.md` を stdin から直接受け取り、export 済み
+`TR_STEP_TIMEOUT_S` の全 budget を維持し、stdout は変わらず、sentinel artifact は 1 つも作られません。
 
 | 変数 | 契約 |
 | --- | --- |
@@ -100,9 +101,11 @@ Claude Code adapter は CLI を spawn する前に次の値を検証します。
 | `OVF_COMPACTION_OWNER` | `sentinel` または `host`。unset は warning 後 `sentinel`、`host` は `disabled-host` を記録 |
 | `OVF_STEP_CMD` | whitespace 分割の CLI argv。既定 `claude -p --output-format stream-json --verbose` |
 | `OVF_FINALIZE_TIMEOUT_S` | 1 以上の整数。既定 `10`。CLI 終了後の monitor join 上限 |
+| `CLAUDE_MODEL` | 実際の Claude model identifier。unset は `claude-unknown` を記録し、`claude-` catalog prefix には一致しない unknown として扱う |
 
 context-window は config、検証済み local HF config、Claude-family prefix catalog、200k 既定の順で
 解決します。採用 source は `config`、`hf-config`、`catalog`、`default` のいずれかで記録します。
+placeholder の `claude-unknown` は常に `default` を使います。
 
 TTFB は run start から最初の `assistant` stream line までです。token tier は 90 秒、前 attempt の
 last injected MA が厳密に 50k 超なら 150 秒、厳密に 100k 超なら 240 秒です。prior state がない場合と
@@ -110,11 +113,22 @@ last injected MA が厳密に 50k 超なら 150 秒、厳密に 100k 超なら 2
 `qwq*` 300 秒、`glm-5*` 300 秒、`grok-*` 300 秒、`deepseek-r1*` 600 秒、
 `o1*`/`o3*` 600 秒です。これらは `alert` を記録するだけで CLI を終了しません。
 
+`system/compact_boundary` を観測すると measured series を reset し、pending nudge を取り下げ、
+`runtime_compaction=true` を記録します。この event がない場合は injected が厳密に 40% 超急落したかを
+見る heuristic が fallback です。異なる大きさの turn が混在すると、本来有効な nudge を 1 回だけ
+抑制することがありますが、これは v1 で受容する bounded false-positive cost です。
+
+hysteresis で block された predicate crossing は event flood 防止のため意図的に `fire` を追加しません。
+append-only の `turn` series から再構成できます。slope-only fire では level threshold を跨いでいないため、
+`threshold_hit` を省略します。
+
 `sentinel-events.jsonl` は append-only で、`turn`、`fire`、`alert`、run ごとの
 `attempt_end` を収録します。task-level の `task_end` は ledger-confluence integration へ延期します。
 `attempt.json` は厳密に `schema_version`、`task_id`、`attempt`、`mode`、`model`、
 `ctx_window`、`ctx_window_source`、`started_at`、nullable な `first_byte_at`、
-`cli_exit_code`、`tap_status_final`、`fired`、`events_path` の field で atomic に確定します。
+`cli_exit_code`、`tap_status_final`、`fired`、`events_path` の field で atomic に確定します。attempt identity は
+zero-padding を保った attempt directory basename string です。timeout または signal death では model が
+書いた `step-result.json` を `step-result.json.partial` へ quarantine します。
 event field の契約は [overflow sentinel DESIGN](design/159-overflow-sentinel/DESIGN.md) の §3–§6 を
 参照してください。
 

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -84,6 +84,40 @@ flush intake consumer の会計 ledger は `loop/pending/intake-runs.log` です
   `HERMES_PROBE_CMD`、`TR_PUSH_CMD` は whitespace で分割して argv 配列にし、PATH 解決される
   通常の実行可能ファイル名も使えます。
 
+### Claude Code overflow sentinel の環境変数
+
+Claude Code adapter は CLI を spawn する前に次の値を検証します。不正値は exit 2 です。
+`OVF_SENTINEL` が unset または空なら、sentinel のその他の動作もすべて無効です。CLI は
+`prompt.md` を stdin から直接受け取り、stdout は変わらず、sentinel artifact は 1 つも作られません。
+
+| 変数 | 契約 |
+| --- | --- |
+| `OVF_SENTINEL` | unset/空 = off。それ以外は厳密に `shadow` または `active` |
+| `OVF_T_ABS` | 1 以上の整数。既定 `80000` token |
+| `OVF_W_PCT` | 1–99 の整数。既定 `50`、100 で割って変換 |
+| `OVF_CTX_WINDOW` | optional の 1 以上の整数。context-window 梯子の第 1 段 |
+| `OVF_HF_CONFIG` | optional の local・non-symlink HF `config.json` path（またはその directory）。network lookup なし |
+| `OVF_COMPACTION_OWNER` | `sentinel` または `host`。unset は warning 後 `sentinel`、`host` は `disabled-host` を記録 |
+| `OVF_STEP_CMD` | whitespace 分割の CLI argv。既定 `claude -p --output-format stream-json --verbose` |
+| `OVF_FINALIZE_TIMEOUT_S` | 1 以上の整数。既定 `10`。CLI 終了後の monitor join 上限 |
+
+context-window は config、検証済み local HF config、Claude-family prefix catalog、200k 既定の順で
+解決します。採用 source は `config`、`hf-config`、`catalog`、`default` のいずれかで記録します。
+
+TTFB は run start から最初の `assistant` stream line までです。token tier は 90 秒、前 attempt の
+last injected MA が厳密に 50k 超なら 150 秒、厳密に 100k 超なら 240 秒です。prior state がない場合と
+未収載 model は 240 秒です。記名 reasoning floor は `claude-opus*` 240 秒、`qwen3*` 180 秒、
+`qwq*` 300 秒、`glm-5*` 300 秒、`grok-*` 300 秒、`deepseek-r1*` 600 秒、
+`o1*`/`o3*` 600 秒です。これらは `alert` を記録するだけで CLI を終了しません。
+
+`sentinel-events.jsonl` は append-only で、`turn`、`fire`、`alert`、run ごとの
+`attempt_end` を収録します。task-level の `task_end` は ledger-confluence integration へ延期します。
+`attempt.json` は厳密に `schema_version`、`task_id`、`attempt`、`mode`、`model`、
+`ctx_window`、`ctx_window_source`、`started_at`、nullable な `first_byte_at`、
+`cli_exit_code`、`tap_status_final`、`fired`、`events_path` の field で atomic に確定します。
+event field の契約は [overflow sentinel DESIGN](design/159-overflow-sentinel/DESIGN.md) の §3–§6 を
+参照してください。
+
 ---
 
 ## 契約文書
@@ -92,6 +126,7 @@ flush intake consumer の会計 ledger は `loop/pending/intake-runs.log` です
 | --- | --- |
 | [DESIGN.md](design/DESIGN.md) | learning-loop contract、verification seam、promotion rule、adapter contract |
 | [DESIGN-task-runner.md](design/DESIGN-task-runner.md) | task-runner contract、budget、DLQ、metric |
+| [159 overflow sentinel DESIGN](design/159-overflow-sentinel/DESIGN.md) | overflow predicate、tap、TTFB、event、nudge の契約 |
 | [governance-rules.md](governance-rules.md) | family adoption governance canon（governance R1–R14・amendment status と effectiveness gate） |
 | [plugin-convention.md](plugin-convention.md) | plugin seam contract と extraction policy |
 | [plugins.md](plugins.md) | known plugin registry と attachment status |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -85,6 +85,44 @@ The flush intake consumer's accounting ledger is `loop/pending/intake-runs.log`.
   `TR_PUSH_CMD` are whitespace-split into argv arrays and may use PATH-resolved
   regular executable names.
 
+### Claude Code overflow sentinel environment
+
+The Claude Code adapter validates these values before spawning the CLI. Invalid
+values exit 2. With `OVF_SENTINEL` unset or empty, all other sentinel behavior is
+off: the CLI receives `prompt.md` on stdin directly, stdout remains unchanged,
+and no sentinel artifact is created.
+
+| Variable | Contract |
+| --- | --- |
+| `OVF_SENTINEL` | unset/empty = off; otherwise exactly `shadow` or `active` |
+| `OVF_T_ABS` | integer >= 1; default `80000` tokens |
+| `OVF_W_PCT` | integer 1–99; default `50`, converted by dividing by 100 |
+| `OVF_CTX_WINDOW` | optional integer >= 1; first context-window ladder rung |
+| `OVF_HF_CONFIG` | optional local non-symlink HF `config.json` path (or its directory); no network lookup |
+| `OVF_COMPACTION_OWNER` | `sentinel` or `host`; unset warns and selects `sentinel`; `host` records `disabled-host` |
+| `OVF_STEP_CMD` | whitespace-split CLI argv; default `claude -p --output-format stream-json --verbose` |
+| `OVF_FINALIZE_TIMEOUT_S` | integer >= 1; default `10`; bounded monitor join after CLI exit |
+
+Context-window resolution is config, validated local HF config, a Claude-family
+prefix catalog, then the 200k default. The selected source is logged as `config`,
+`hf-config`, `catalog`, or `default`.
+
+TTFB is run start to the first `assistant` stream line. The token tiers are 90s,
+150s when the prior attempt's last injected MA is strictly above 50k, and 240s
+when strictly above 100k. No prior state and unlisted models use 240s. Named
+reasoning floors are: `claude-opus*` 240s, `qwen3*` 180s, `qwq*` 300s,
+`glm-5*` 300s, `grok-*` 300s, `deepseek-r1*` 600s, and `o1*`/`o3*` 600s.
+These floors create `alert` records only; they never terminate the CLI.
+
+`sentinel-events.jsonl` is append-only and contains `turn`, `fire`, `alert`, and
+per-run `attempt_end` records. The task-level `task_end` event is deferred to the
+ledger-confluence integration. `attempt.json` is atomically finalized with exactly
+these fields: `schema_version`, `task_id`, `attempt`, `mode`, `model`,
+`ctx_window`, `ctx_window_source`, `started_at`, nullable `first_byte_at`,
+`cli_exit_code`, `tap_status_final`, `fired`, and `events_path`. See §3–§6 of the
+[overflow sentinel DESIGN](design/159-overflow-sentinel/DESIGN.md) for the
+event-field contracts.
+
 ---
 
 ## Contract documents
@@ -93,6 +131,7 @@ The flush intake consumer's accounting ledger is `loop/pending/intake-runs.log`.
 | --- | --- |
 | [DESIGN.md](design/DESIGN.md) | learning-loop contracts, verification seam, promotion rules, and adapter contracts |
 | [DESIGN-task-runner.md](design/DESIGN-task-runner.md) | task-runner contract, budgets, DLQ, and metrics |
+| [159 overflow sentinel DESIGN](design/159-overflow-sentinel/DESIGN.md) | overflow predicate, tap, TTFB, event, and nudge contracts |
 | [governance-rules.md](governance-rules.md) | family adoption governance canon (governance R1–R14; amendment status and effectiveness gates) |
 | [plugin-convention.md](plugin-convention.md) | plugin seam contract and extraction policy |
 | [plugins.md](plugins.md) | known plugin registry and attachment status |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -88,9 +88,11 @@ The flush intake consumer's accounting ledger is `loop/pending/intake-runs.log`.
 ### Claude Code overflow sentinel environment
 
 The Claude Code adapter validates these values before spawning the CLI. Invalid
-values exit 2. With `OVF_SENTINEL` unset or empty, all other sentinel behavior is
-off: the CLI receives `prompt.md` on stdin directly, stdout remains unchanged,
-and no sentinel artifact is created.
+values exit 2. With `OVF_SENTINEL` unset or empty, sentinel settings other than
+the CLI selector `OVF_STEP_CMD` are ignored and sentinel behavior is off: the CLI
+receives `prompt.md` on stdin directly, keeps the full exported
+`TR_STEP_TIMEOUT_S` budget, stdout remains unchanged, and no sentinel artifact
+is created.
 
 | Variable | Contract |
 | --- | --- |
@@ -102,10 +104,12 @@ and no sentinel artifact is created.
 | `OVF_COMPACTION_OWNER` | `sentinel` or `host`; unset warns and selects `sentinel`; `host` records `disabled-host` |
 | `OVF_STEP_CMD` | whitespace-split CLI argv; default `claude -p --output-format stream-json --verbose` |
 | `OVF_FINALIZE_TIMEOUT_S` | integer >= 1; default `10`; bounded monitor join after CLI exit |
+| `CLAUDE_MODEL` | actual Claude model identifier; unset records `claude-unknown`, treated as unknown rather than matching the `claude-` catalog prefix |
 
 Context-window resolution is config, validated local HF config, a Claude-family
 prefix catalog, then the 200k default. The selected source is logged as `config`,
-`hf-config`, `catalog`, or `default`.
+`hf-config`, `catalog`, or `default`; the `claude-unknown` placeholder always uses
+`default`.
 
 TTFB is run start to the first `assistant` stream line. The token tiers are 90s,
 150s when the prior attempt's last injected MA is strictly above 50k, and 240s
@@ -114,12 +118,26 @@ reasoning floors are: `claude-opus*` 240s, `qwen3*` 180s, `qwq*` 300s,
 `glm-5*` 300s, `grok-*` 300s, `deepseek-r1*` 600s, and `o1*`/`o3*` 600s.
 These floors create `alert` records only; they never terminate the CLI.
 
+An observed `system/compact_boundary` resets the measured series, withdraws a
+pending nudge, and sets `runtime_compaction=true`. When that event is absent, the
+strict greater-than-40% injected drop remains the fallback heuristic. This
+mixed-magnitude heuristic can suppress one otherwise valid nudge; that bounded
+false positive is an accepted v1 cost.
+
+Hysteresis-blocked predicate crossings intentionally append no `fire` event to
+avoid event floods. They remain reconstructable from the append-only `turn`
+series. On slope-only fires, `threshold_hit` is omitted because neither level
+threshold crossed.
+
 `sentinel-events.jsonl` is append-only and contains `turn`, `fire`, `alert`, and
 per-run `attempt_end` records. The task-level `task_end` event is deferred to the
 ledger-confluence integration. `attempt.json` is atomically finalized with exactly
 these fields: `schema_version`, `task_id`, `attempt`, `mode`, `model`,
 `ctx_window`, `ctx_window_source`, `started_at`, nullable `first_byte_at`,
-`cli_exit_code`, `tap_status_final`, `fired`, and `events_path`. See §3–§6 of the
+`cli_exit_code`, `tap_status_final`, `fired`, and `events_path`. Attempt identity
+is the zero-padded attempt-directory basename string. A timeout or signal death
+quarantines a model-written `step-result.json` as `step-result.json.partial`.
+See §3–§6 of the
 [overflow sentinel DESIGN](design/159-overflow-sentinel/DESIGN.md) for the
 event-field contracts.
 

--- a/scripts/activation-manifest.tsv
+++ b/scripts/activation-manifest.tsv
@@ -2,6 +2,8 @@
 adapters/claude-code/checkpoint-stop-hook.sh	guarded	hook-payload.cwd	exit-0-silent	interactive-hook	caty_pause_workspace_state	mkdir -p "$guard_dir"
 adapters/claude-code/flush-intake.sh	guarded	argv	exit-0-status	automated-state-fold	caty_pause_workspace_state	source "$repo_root/scripts/flush-intake.sh"
 adapters/claude-code/precompact-flush-hook.sh	guarded	hook-payload.cwd	exit-0-silent	interactive-hook	caty_pause_workspace_state	mkdir -p "$guard_dir"
+adapters/claude-code/spawn_step.sh	guarded	argv.workspace	exit-0-status	automated-model-call-with-overflow-sentinel	caty_pause_workspace_state	run_bounded "$ovf_step_timeout_s"
+adapters/claude-code/overflow_sentinel_monitor.py	exempt	none	not-applicable	passive-overflow-sentinel-monitor	-	-
 adapters/codex/checkpoint-stop-hook.sh	guarded	hook-payload.cwd	exit-0-silent	interactive-hook	caty_pause_workspace_state	mkdir -p "$guard_dir"
 adapters/hermes/examples/verifier-probe.sh	exempt	none	not-applicable	provider-conformance-example	-	-
 adapters/hermes/examples/verifier-probe-cli.sh	exempt	none	not-applicable	provider-conformance-example	-	-
@@ -29,6 +31,7 @@ scripts/lib-command-argv.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-classify.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-donecheck.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-pause.sh	exempt	explicit-function-argument	not-applicable	sourced-library	-	-
+scripts/lib_overflow_sentinel.py	exempt	none	not-applicable	importable-overflow-sentinel-library	-	-
 scripts/lib-secrets-env.sh	exempt	none	not-applicable	sourced-library	-	-
 scripts/lib-state-fold.sh	exempt	explicit-function-argument	not-applicable	sourced-library	-	-
 scripts/lib-wrapper-conformance.sh	exempt	none	not-applicable	sourced-library	-	-

--- a/scripts/lib_overflow_sentinel.py
+++ b/scripts/lib_overflow_sentinel.py
@@ -109,11 +109,7 @@ def _threshold_hit(ma_value: float, t_abs: int, ratio_threshold: float) -> str:
         return "both"
     if hits:
         return hits[0]
-    # A slope-only fire has crossed neither level threshold. The wire schema has
-    # no "none" value, so identify the threshold that currently governs min().
-    if t_abs == ratio_threshold:
-        return "both"
-    return "abs" if t_abs < ratio_threshold else "ratio"
+    raise ValueError("threshold_hit requested without a level crossing")
 
 
 def evaluate_series(
@@ -154,7 +150,7 @@ def evaluate_series(
             "axis": axis,
             "threshold": threshold,
         }
-        if axis is not None:
+        if level_fire:
             turn["threshold_hit"] = _threshold_hit(ma_value, t_abs, ratio_threshold)
         turns.append(turn)
     return {
@@ -225,6 +221,8 @@ def resolve_ctx_window(
     if hf_config:
         return _hf_window(Path(hf_config)), "hf-config"
     normalized = model.lower().split("/")[-1]
+    if normalized == "claude-unknown":
+        return DEFAULT_CTX_WINDOW, "default"
     for prefix, window in CTX_WINDOW_CATALOG:
         if normalized.startswith(prefix):
             return window, "catalog"
@@ -233,6 +231,8 @@ def resolve_ctx_window(
 
 def ttfb_floor_seconds(previous_injected_ma: Optional[float], model: str) -> int:
     normalized = model.lower().split("/")[-1]
+    if normalized == "claude-unknown":
+        return 240
     for prefix, floor in REASONING_TTFB_FLOORS:
         if normalized.startswith(prefix):
             return floor

--- a/scripts/lib_overflow_sentinel.py
+++ b/scripts/lib_overflow_sentinel.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Shared overflow-sentinel v1 predicate and persistence helpers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+
+SCHEMA_VERSION = 1
+N = 3
+K = 3
+M = 10
+DEFAULT_T_ABS = 80000
+DEFAULT_W = 0.50
+DEFAULT_CTX_WINDOW = 200000
+
+# Prefix catalog only.  Provider training limits are deliberately not inferred.
+CTX_WINDOW_CATALOG = (
+    ("claude-", 200000),
+)
+
+# Named reasoning floors are alert delays, never kill deadlines. Unknown models
+# take the conservative 240-second floor in ttfb_floor_seconds().
+REASONING_TTFB_FLOORS = (
+    ("claude-opus", 240),
+    ("deepseek-r1", 600),
+    ("glm-5", 300),
+    ("grok-", 300),
+    ("o1", 600),
+    ("o3", 600),
+    ("qwen3", 180),
+    ("qwq", 300),
+)
+
+
+def atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    """Write one JSON object with fsync + replace in the destination directory."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=True, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, str(path))
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def load_state(path: Path) -> Dict[str, Any]:
+    default = {
+        "schema_version": SCHEMA_VERSION,
+        "last_fire_ma": {},
+        "last_run_injected_ma": None,
+    }
+    try:
+        with path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError, TypeError):
+        return default
+    if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+        return default
+    last_fire = payload.get("last_fire_ma")
+    if not isinstance(last_fire, dict):
+        last_fire = {}
+    clean_fire = {}
+    for axis in ("level", "slope"):
+        value = last_fire.get(axis)
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and value >= 0:
+            clean_fire[axis] = float(value)
+    last_run = payload.get("last_run_injected_ma")
+    if not isinstance(last_run, (int, float)) or isinstance(last_run, bool) or last_run < 0:
+        last_run = None
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "last_fire_ma": clean_fire,
+        "last_run_injected_ma": last_run,
+    }
+
+
+def save_state(path: Path, last_fire_ma: Mapping[str, float], last_run_injected_ma: Optional[float]) -> None:
+    atomic_write_json(
+        path,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "last_fire_ma": dict(last_fire_ma),
+            "last_run_injected_ma": last_run_injected_ma,
+        },
+    )
+
+
+def _threshold_hit(ma_value: float, t_abs: int, ratio_threshold: float) -> str:
+    hits = []
+    if ma_value > t_abs:
+        hits.append("abs")
+    if ma_value > ratio_threshold:
+        hits.append("ratio")
+    if len(hits) == 2:
+        return "both"
+    if hits:
+        return hits[0]
+    # A slope-only fire has crossed neither level threshold. The wire schema has
+    # no "none" value, so identify the threshold that currently governs min().
+    if t_abs == ratio_threshold:
+        return "both"
+    return "abs" if t_abs < ratio_threshold else "ratio"
+
+
+def evaluate_series(
+    series: Sequence[int],
+    t_abs: int = DEFAULT_T_ABS,
+    w: float = DEFAULT_W,
+    ctx: int = DEFAULT_CTX_WINDOW,
+) -> Dict[str, Any]:
+    """Evaluate the frozen N=3/K=3/M=10 predicate over one fresh run."""
+    ratio_threshold = w * ctx
+    threshold = min(t_abs, ratio_threshold)
+    turns = []
+    ma_values = []
+    for turn_idx, injected_last in enumerate(series, start=1):
+        window = series[max(0, turn_idx - N) : turn_idx]
+        ma_value = sum(window) / float(len(window))
+        ma_values.append(ma_value)
+        level_fire = ma_value > threshold
+        slope = None
+        projection_turns = None
+        slope_fire = False
+        if turn_idx >= K + 1:
+            slope = (ma_value - ma_values[-1 - K]) / K
+            if slope > 0:
+                projection_turns = (ctx - ma_value) / slope
+                slope_fire = projection_turns <= M
+        axis = None
+        if level_fire or slope_fire:
+            axis = "both" if level_fire and slope_fire else ("level" if level_fire else "slope")
+        turn = {
+            "turn_idx": turn_idx,
+            "injected_last": injected_last,
+            "injected_ma": ma_value,
+            "level_fire": level_fire,
+            "slope": slope,
+            "projection_turns": projection_turns,
+            "slope_fire": slope_fire,
+            "axis": axis,
+            "threshold": threshold,
+        }
+        if axis is not None:
+            turn["threshold_hit"] = _threshold_hit(ma_value, t_abs, ratio_threshold)
+        turns.append(turn)
+    return {
+        "series": list(series),
+        "threshold": threshold,
+        "ratio_threshold": ratio_threshold,
+        "turns": turns,
+        "params": {"T_abs": t_abs, "w": w, "ctx_window": ctx, "N": N, "K": K, "M": M},
+    }
+
+
+def fire_axes(axis: Optional[str]) -> List[str]:
+    if axis == "both":
+        return ["level", "slope"]
+    if axis in ("level", "slope"):
+        return [axis]
+    return []
+
+
+def eligible_fire_axes(
+    axis: Optional[str], ma_value: float, ctx_window: int, last_fire_ma: Mapping[str, float]
+) -> List[str]:
+    """Apply task-scoped per-axis hysteresis; exact +10% re-arms (>=)."""
+    eligible = []
+    increment = 0.10 * ctx_window
+    for candidate in fire_axes(axis):
+        previous = last_fire_ma.get(candidate)
+        if previous is None or ma_value >= previous + increment:
+            eligible.append(candidate)
+    return eligible
+
+
+def axis_name(axes: Sequence[str]) -> Optional[str]:
+    if "level" in axes and "slope" in axes:
+        return "both"
+    return axes[0] if axes else None
+
+
+def compaction_suspected(previous: Optional[int], current: int) -> bool:
+    return previous is not None and current < 0.60 * previous
+
+
+def _hf_window(config_path: Path) -> int:
+    candidate = config_path / "config.json" if config_path.is_dir() else config_path
+    if not candidate.is_file() or candidate.is_symlink():
+        raise ValueError("HF config must be a non-symlink regular config.json file")
+    try:
+        with candidate.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError) as exc:
+        raise ValueError("HF config is not readable JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("HF config must contain a JSON object")
+    for key in ("max_position_embeddings", "n_positions", "max_seq_len", "model_max_length"):
+        value = payload.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 1:
+            return value
+    raise ValueError("HF config has no positive supported context-window field")
+
+
+def resolve_ctx_window(
+    configured: Optional[int], hf_config: Optional[str], model: str
+) -> Tuple[int, str]:
+    if configured is not None:
+        if configured < 1:
+            raise ValueError("configured context window must be positive")
+        return configured, "config"
+    if hf_config:
+        return _hf_window(Path(hf_config)), "hf-config"
+    normalized = model.lower().split("/")[-1]
+    for prefix, window in CTX_WINDOW_CATALOG:
+        if normalized.startswith(prefix):
+            return window, "catalog"
+    return DEFAULT_CTX_WINDOW, "default"
+
+
+def ttfb_floor_seconds(previous_injected_ma: Optional[float], model: str) -> int:
+    normalized = model.lower().split("/")[-1]
+    for prefix, floor in REASONING_TTFB_FLOORS:
+        if normalized.startswith(prefix):
+            return floor
+    if not normalized.startswith("claude-"):
+        return 240
+    if previous_injected_ma is None:
+        return 240
+    if previous_injected_ma > 100000:
+        return 240
+    if previous_injected_ma > 50000:
+        return 150
+    return 90
+
+
+def outcome_from_result(cli_exit_code: int, result: Mapping[str, Any]) -> str:
+    error_class = str(result.get("error_class") or "")
+    window_error = bool(result.get("window_error")) or error_class == "window-error"
+    if window_error:
+        return "overflowed"
+    if cli_exit_code == 0 and result.get("step_complete") is True:
+        return "step_completed"
+    return "aborted"
+
+
+def _main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    evaluate = sub.add_parser("eval-series")
+    evaluate.add_argument("--series", required=True)
+    evaluate.add_argument("--t-abs", type=int, default=DEFAULT_T_ABS)
+    evaluate.add_argument("--w", type=float, default=DEFAULT_W)
+    evaluate.add_argument("--ctx", type=int, default=DEFAULT_CTX_WINDOW)
+    validate_hf = sub.add_parser("validate-hf")
+    validate_hf.add_argument("path")
+    args = parser.parse_args(argv)
+    if args.command == "eval-series":
+        values = [int(part) for part in args.series.split(",") if part]
+        print(json.dumps(evaluate_series(values, args.t_abs, args.w, args.ctx), sort_keys=True))
+        return 0
+    try:
+        print(_hf_window(Path(args.path)))
+    except ValueError as exc:
+        print(str(exc), file=os.sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/fixtures/overflow-sentinel/absent.jsonl
+++ b/tests/fixtures/overflow-sentinel/absent.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init"}
+{"type":"keepalive"}

--- a/tests/fixtures/overflow-sentinel/blind-short.jsonl
+++ b/tests/fixtures/overflow-sentinel/blind-short.jsonl
@@ -1,0 +1,2 @@
+{"type":"assistant","message":{"id":"blind-short-1","usage":{"input_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":0}}}
+{"type":"assistant","message":{"id":"blind-short-2","usage":{"input_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":0}}}

--- a/tests/fixtures/overflow-sentinel/blind-three.jsonl
+++ b/tests/fixtures/overflow-sentinel/blind-three.jsonl
@@ -1,0 +1,4 @@
+{"type":"assistant","message":{"id":"blind-1","model":"claude-sonnet-4-5","usage":{"input_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":0}}}
+{"type":"assistant","message":{"id":"blind-2","model":"claude-sonnet-4-5","usage":{"input_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":0}}}
+{"type":"assistant","message":{"id":"blind-3","model":"claude-sonnet-4-5","usage":{"input_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":0}}}
+{"type":"assistant","message":{"id":"after-disable","model":"claude-sonnet-4-5","usage":{"input_tokens":90000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}

--- a/tests/fixtures/overflow-sentinel/cache-boundary.jsonl
+++ b/tests/fixtures/overflow-sentinel/cache-boundary.jsonl
@@ -1,0 +1,2 @@
+{"type":"assistant","message":{"id":"cache-at-threshold","model":"claude-sonnet-4-5","usage":{"input_tokens":30000,"cache_read_input_tokens":30000,"cache_creation_input_tokens":20000,"output_tokens":1}}}
+{"type":"assistant","message":{"id":"cache-above-threshold","model":"claude-sonnet-4-5","usage":{"input_tokens":30001,"cache_read_input_tokens":30000,"cache_creation_input_tokens":20000,"output_tokens":1}}}

--- a/tests/fixtures/overflow-sentinel/compact-boundary.jsonl
+++ b/tests/fixtures/overflow-sentinel/compact-boundary.jsonl
@@ -1,0 +1,3 @@
+{"type":"assistant","message":{"id":"before-runtime-compact","model":"claude-sonnet-4-5","usage":{"input_tokens":90000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"system","subtype":"compact_boundary"}
+{"type":"assistant","message":{"id":"after-runtime-compact","model":"claude-sonnet-4-5","usage":{"input_tokens":50000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}

--- a/tests/fixtures/overflow-sentinel/compaction.jsonl
+++ b/tests/fixtures/overflow-sentinel/compaction.jsonl
@@ -1,0 +1,2 @@
+{"type":"assistant","message":{"id":"pressure","model":"claude-sonnet-4-5","usage":{"input_tokens":90000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"assistant","message":{"id":"compact","model":"claude-sonnet-4-5","usage":{"input_tokens":50000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}

--- a/tests/fixtures/overflow-sentinel/fire.jsonl
+++ b/tests/fixtures/overflow-sentinel/fire.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init"}
+{"type":"keepalive"}
+{"type":"assistant","timestamp":"2026-08-25T00:00:01Z","message":{"id":"fire-1","model":"claude-sonnet-4-5","usage":{"input_tokens":90000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":10}}}

--- a/tests/fixtures/overflow-sentinel/mock-cli.sh
+++ b/tests/fixtures/overflow-sentinel/mock-cli.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${MOCK_STDIN_PATH:-}" ]]; then
+  cat >"$MOCK_STDIN_PATH"
+else
+  cat >/dev/null
+fi
+if [[ -n "${MOCK_CWD_PATH:-}" ]]; then
+  pwd >"$MOCK_CWD_PATH"
+fi
+if [[ -n "${MOCK_ENV_PATH:-}" ]]; then
+  printf '%s' "${MOCK_MARKER:-}" >"$MOCK_ENV_PATH"
+fi
+printf '%s\n' "${MOCK_STDERR:-mock stderr}" >&2
+if [[ -n "${MOCK_STREAM_FILE:-}" ]]; then
+  cat "$MOCK_STREAM_FILE"
+else
+  printf '%s' "${MOCK_STDOUT:-mock stdout}"
+fi
+if [[ -n "${MOCK_STEP_RESULT:-}" ]]; then
+  printf '%s\n' "$MOCK_STEP_RESULT" >"$ATTEMPT_DIR/step-result.json"
+fi
+if [[ -n "${MOCK_SLEEP_S:-}" ]]; then
+  sleep "$MOCK_SLEEP_S"
+fi
+if [[ -n "${MOCK_ALIVE_PATH:-}" ]]; then
+  printf 'alive\n' >"$MOCK_ALIVE_PATH"
+fi
+exit "${MOCK_EXIT:-0}"

--- a/tests/fixtures/overflow-sentinel/no-trailing-newline.jsonl
+++ b/tests/fixtures/overflow-sentinel/no-trailing-newline.jsonl
@@ -1,0 +1,1 @@
+{"type":"assistant","message":{"id":"unterminated-final","model":"claude-sonnet-4-5","usage":{"input_tokens":90000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}

--- a/tests/fixtures/overflow-sentinel/realistic.jsonl
+++ b/tests/fixtures/overflow-sentinel/realistic.jsonl
@@ -1,0 +1,6 @@
+{"type":"system","subtype":"init","timestamp":"2026-08-25T00:00:00Z"}
+{"type":"keepalive","unknown":"ignored"}
+not-json
+{"type":"assistant","timestamp":"2026-08-25T00:00:01Z","future_field":true,"message":{"id":"msg-1","model":"claude-sonnet-4-5","usage":{"input_tokens":100,"cache_read_input_tokens":20,"cache_creation_input_tokens":10,"output_tokens":5,"future_usage":999}}}
+{"type":"assistant","timestamp":"2026-08-25T00:00:02Z","message":{"id":"msg-1","model":"claude-sonnet-4-5","usage":{"input_tokens":100,"cache_read_input_tokens":20,"cache_creation_input_tokens":10,"output_tokens":5}}}
+{"type":"assistant","timestamp":"2026-08-25T00:00:03Z","message":{"id":"msg-2","model":"claude-sonnet-4-5","usage":{"input_tokens":200,"output_tokens":7}}}

--- a/tests/fixtures/overflow-sentinel/slope-only.jsonl
+++ b/tests/fixtures/overflow-sentinel/slope-only.jsonl
@@ -1,0 +1,4 @@
+{"type":"assistant","message":{"id":"slope-1","model":"claude-sonnet-4-5","usage":{"input_tokens":1000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"assistant","message":{"id":"slope-2","model":"claude-sonnet-4-5","usage":{"input_tokens":1000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"assistant","message":{"id":"slope-3","model":"claude-sonnet-4-5","usage":{"input_tokens":1000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"assistant","message":{"id":"slope-4","model":"claude-sonnet-4-5","usage":{"input_tokens":150000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}

--- a/tests/fixtures/overflow-sentinel/subagent-interleave.jsonl
+++ b/tests/fixtures/overflow-sentinel/subagent-interleave.jsonl
@@ -1,0 +1,3 @@
+{"type":"assistant","message":{"id":"main-pressure-1","model":"claude-sonnet-4-5","usage":{"input_tokens":90000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"assistant","parent_tool_use_id":"tool-parent-1","message":{"id":"subagent-small","model":"claude-sonnet-4-5","usage":{"input_tokens":10000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"assistant","message":{"id":"main-pressure-2","model":"claude-sonnet-4-5","usage":{"input_tokens":90001,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}

--- a/tests/fixtures/overflow-sentinel/zero-and-invalid.jsonl
+++ b/tests/fixtures/overflow-sentinel/zero-and-invalid.jsonl
@@ -1,0 +1,4 @@
+{"type":"assistant","message":{"id":"measured-before-zero","model":"claude-sonnet-4-5","usage":{"input_tokens":90000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"assistant","message":{"id":"zero-with-output","model":"claude-sonnet-4-5","usage":{"input_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":50}}}
+{"type":"assistant","message":{"id":"invalid-cache","model":"claude-sonnet-4-5","usage":{"input_tokens":1,"cache_read_input_tokens":"garbage","cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"assistant","message":{"id":"measured-after-invalid","model":"claude-sonnet-4-5","usage":{"input_tokens":90001,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}

--- a/tests/overflow-sentinel-tap.test.sh
+++ b/tests/overflow-sentinel-tap.test.sh
@@ -57,6 +57,20 @@ run_monitor_fixture() {
     --mode "$mode" --model claude-sonnet-4-5 --t-abs 80000 --w 0.50
 }
 
+run_unterminated_monitor_fixture() {
+  local fixture=$1
+  local attempt_dir=$2
+  printf '%s' "$(cat "$FIXTURES/$fixture")" >"$attempt_dir/stream.jsonl"
+  printf '0\n' >"$attempt_dir/overflow-stream.eof"
+  python3 -B "$MONITOR" \
+    --stream "$attempt_dir/stream.jsonl" \
+    --eof "$attempt_dir/overflow-stream.eof" \
+    --attempt-dir "$attempt_dir" \
+    --artifact-dir "$(cd "$attempt_dir/../.." && pwd)" \
+    --task-id fixture-task --attempt "$(basename "$attempt_dir")" \
+    --mode shadow --model claude-sonnet-4-5 --t-abs 80000 --w 0.50
+}
+
 case_root="$TMP_ROOT/realistic"
 make_attempt "$case_root"
 run_monitor_fixture realistic.jsonl "$case_root/artifact/attempts/001"
@@ -79,8 +93,79 @@ assert_python "attempt.json has the complete pinned field set and non-null first
 p=json.loads(pathlib.Path(sys.argv[1]).read_text())
 expected={"schema_version","task_id","attempt","mode","model","ctx_window","ctx_window_source","started_at","first_byte_at","cli_exit_code","tap_status_final","fired","events_path"}
 assert set(p)==expected and p["first_byte_at"]=="2026-08-25T00:00:01Z"
-assert p["tap_status_final"]=="no-cache-accounting"
+assert p["tap_status_final"]=="no-cache-accounting" and p["attempt"]=="001"
 ' "$case_root/artifact/attempts/001/attempt.json"
+
+case_root="$TMP_ROOT/cache-boundary"
+make_attempt "$case_root"
+run_monitor_fixture cache-boundary.jsonl "$case_root/artifact/attempts/001"
+assert_python "cache-heavy boundary fires only above the true exclusive-sum threshold" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+turns=[x for x in events if x["event"]=="turn"]
+end=next(x for x in events if x["event"]=="attempt_end")
+assert len(turns)==2
+assert [x["input_tokens"]+x["cache_read_tokens"]+x["cache_creation_tokens"] for x in turns]==[80000,80001]
+assert end["fired_turns"]==[2]
+assert end["injected_summary"]=={"max":80001,"last3_mean":80000.5}
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+
+case_root="$TMP_ROOT/subagent-interleave"
+make_attempt "$case_root"
+run_monitor_fixture subagent-interleave.jsonl "$case_root/artifact/attempts/001" active
+assert_python "sub-agent assistant events do not enter or compact the main-session series" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+turns=[x for x in events if x["event"]=="turn"]
+end=next(x for x in events if x["event"]=="attempt_end")
+assert [x["input_tokens"] for x in turns]==[90000,90001]
+assert end["compaction_suspected"] is False and end["runtime_compaction"] is False
+assert end["injected_summary"]=={"max":90001,"last3_mean":90000.5}
+assert end["fired_turns"]==[1] and pathlib.Path(sys.argv[2]).is_file()
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl" "$case_root/artifact/attempts/001/overflow-nudge.pending"
+
+case_root="$TMP_ROOT/compact-boundary"
+make_attempt "$case_root"
+run_monitor_fixture compact-boundary.jsonl "$case_root/artifact/attempts/001" active
+assert_python "runtime compact_boundary resets the series and withdraws a pending nudge" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+end=next(x for x in events if x["event"]=="attempt_end")
+assert end["runtime_compaction"] is True and end["compaction_suspected"] is False
+assert end["injected_summary"]=={"max":50000,"last3_mean":50000.0}
+assert not pathlib.Path(sys.argv[2]).exists()
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl" "$case_root/artifact/attempts/001/overflow-nudge.pending"
+
+case_root="$TMP_ROOT/no-trailing-newline"
+make_attempt "$case_root"
+run_unterminated_monitor_fixture no-trailing-newline.jsonl "$case_root/artifact/attempts/001"
+assert_python "post-EOF drain parses an unterminated final assistant line" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+assert len([x for x in events if x["event"]=="turn"])==1
+end=next(x for x in events if x["event"]=="attempt_end")
+assert end["fired_turns"]==[1] and end["injected_summary"]=={"max":90000,"last3_mean":90000.0}
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+
+case_root="$TMP_ROOT/zero-and-invalid"
+make_attempt "$case_root"
+run_monitor_fixture zero-and-invalid.jsonl "$case_root/artifact/attempts/001"
+assert_python "zero-injected and unparsable usage never corrupt the measured series" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+turns=[x for x in events if x["event"]=="turn"]
+end=next(x for x in events if x["event"]=="attempt_end")
+assert [x["input_tokens"] for x in turns]==[90000,0,90001]
+assert not any(x.get("cache_read_tokens")=="garbage" for x in turns)
+assert end["compaction_suspected"] is False
+assert end["injected_summary"]=={"max":90001,"last3_mean":90000.5}
+assert end["tap_status"]=="no-cache-accounting"
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+
+case_root="$TMP_ROOT/slope-only"
+make_attempt "$case_root"
+run_monitor_fixture slope-only.jsonl "$case_root/artifact/attempts/001"
+assert_python "slope-only fire omits the level threshold_hit field" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+fires=[x for x in events if x["event"]=="fire"]
+assert len(fires)==1 and fires[0]["axis"]=="slope"
+assert fires[0]["projection_turns"] <= 10 and "threshold_hit" not in fires[0]
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
 
 case_root="$TMP_ROOT/blind-three"
 make_attempt "$case_root"
@@ -96,15 +181,25 @@ assert end["tap_status"]=="blind" and end["injected_summary"]=={"max":0,"last3_m
 
 case_root="$TMP_ROOT/blind-short"
 make_attempt "$case_root"
+printf '%s\n' '{"last_fire_ma":{"level":91000.0},"last_run_injected_ma":87000.0,"schema_version":1}' \
+  >"$case_root/artifact/overflow-sentinel-state.json"
+blind_state_before=$(shasum -a 256 "$case_root/artifact/overflow-sentinel-state.json" | awk '{print $1}')
 run_monitor_fixture blind-short.jsonl "$case_root/artifact/attempts/001"
 assert_python "short all-zero run is reported blind immediately" '
 events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
 assert [x for x in events if x["event"]=="attempt_end"][0]["tap_status"]=="blind"
 assert all(x["tap_status"]=="blind" for x in events if x["event"]=="turn")
 ' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+blind_state_after=$(shasum -a 256 "$case_root/artifact/overflow-sentinel-state.json" | awk '{print $1}')
+[[ "$blind_state_before" == "$blind_state_after" ]] \
+  && pass "blind run preserves prior hysteresis state bytes" \
+  || fail_case "blind run preserves prior hysteresis state bytes" "digest changed"
 
 case_root="$TMP_ROOT/absent"
 make_attempt "$case_root"
+printf '%s\n' '{"last_fire_ma":{"slope":70000.0},"last_run_injected_ma":65000.0,"schema_version":1}' \
+  >"$case_root/artifact/overflow-sentinel-state.json"
+absent_state_before=$(shasum -a 256 "$case_root/artifact/overflow-sentinel-state.json" | awk '{print $1}')
 run_monitor_fixture absent.jsonl "$case_root/artifact/attempts/001"
 assert_python "absent usage remains distinct and first_byte_at is null" '
 events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
@@ -113,6 +208,10 @@ receipt=json.loads(pathlib.Path(sys.argv[2]).read_text())
 assert end["tap_status"]=="absent" and not [x for x in events if x["event"]=="turn"]
 assert receipt["first_byte_at"] is None
 ' "$case_root/artifact/attempts/001/sentinel-events.jsonl" "$case_root/artifact/attempts/001/attempt.json"
+absent_state_after=$(shasum -a 256 "$case_root/artifact/overflow-sentinel-state.json" | awk '{print $1}')
+[[ "$absent_state_before" == "$absent_state_after" ]] \
+  && pass "absent run preserves prior hysteresis state bytes" \
+  || fail_case "absent run preserves prior hysteresis state bytes" "digest changed"
 
 case_root="$TMP_ROOT/compaction"
 make_attempt "$case_root"
@@ -161,14 +260,16 @@ off_root="$TMP_ROOT/off"
 make_attempt "$off_root"
 off_attempt="$off_root/artifact/attempts/001"
 set +e
+OVF_T_ABS=garbage OVF_W_PCT=garbage OVF_CTX_WINDOW=garbage \
+OVF_COMPACTION_OWNER=garbage OVF_FINALIZE_TIMEOUT_S=garbage OVF_HF_CONFIG="$TMP_ROOT/missing.json" \
 OVF_STEP_CMD="$MOCK_CLI" MOCK_STDOUT='raw model stdout' MOCK_STDERR='off stderr' \
   "$ADAPTER" "$off_root/workspace/task.md" "$off_root/workspace" "$off_attempt" 1 \
   >"$off_root/stdout" 2>"$off_root/stderr"
 off_rc=$?
 set -e
 [[ "$off_rc" -eq 0 && "$(cat "$off_root/stdout")" == 'raw model stdout' ]] \
-  && pass "OVF_SENTINEL unset preserves direct stdout" \
-  || fail_case "OVF_SENTINEL unset preserves direct stdout" "rc=$off_rc stdout=$(cat "$off_root/stdout")"
+  && pass "OVF_SENTINEL unset ignores stray OVF configuration and preserves direct stdout" \
+  || fail_case "OVF_SENTINEL unset ignores stray OVF configuration and preserves direct stdout" "rc=$off_rc stdout=$(cat "$off_root/stdout")"
 if find "$off_root/artifact" -name 'sentinel-events.jsonl' -o -name 'overflow-nudge.pending' \
   -o -name 'attempt.json' -o -name 'stream.jsonl' -o -name 'overflow-stream.eof' \
   -o -name 'overflow-sentinel-state.json' | grep -q .; then
@@ -176,6 +277,19 @@ if find "$off_root/artifact" -name 'sentinel-events.jsonl' -o -name 'overflow-nu
 else
   pass "OVF_SENTINEL unset creates zero sentinel artifacts"
 fi
+
+off_budget_root="$TMP_ROOT/off-budget"
+make_attempt "$off_budget_root"
+set +e
+TR_STEP_TIMEOUT_S=2 OVF_FINALIZE_TIMEOUT_S=garbage OVF_T_ABS=garbage \
+OVF_STEP_CMD="$MOCK_CLI" MOCK_SLEEP_S=1.2 MOCK_STDOUT='budget preserved' \
+  "$ADAPTER" "$off_budget_root/workspace/task.md" "$off_budget_root/workspace" \
+  "$off_budget_root/artifact/attempts/001" 1 >"$off_budget_root/out" 2>"$off_budget_root/err"
+off_budget_rc=$?
+set -e
+[[ "$off_budget_rc" -eq 0 && "$(cat "$off_budget_root/out")" == 'budget preserved' ]] \
+  && pass "OVF_SENTINEL unset retains the full exported TR step budget" \
+  || fail_case "OVF_SENTINEL unset retains the full exported TR step budget" "rc=$off_budget_rc"
 
 invalid_root="$TMP_ROOT/invalid"
 make_attempt "$invalid_root"
@@ -230,6 +344,17 @@ grep -Fqx 'warning: OVF_COMPACTION_OWNER is unset; overflow sentinel owns compac
   && pass "unset compaction owner emits exact lowercase warning" \
   || fail_case "unset compaction owner emits exact lowercase warning" "$(cat "$warning_root/err")"
 
+small_budget_root="$TMP_ROOT/small-budget"
+make_attempt "$small_budget_root"
+TR_STEP_TIMEOUT_S=20 OVF_FINALIZE_TIMEOUT_S=10 OVF_SENTINEL=shadow \
+OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
+  "$ADAPTER" "$small_budget_root/workspace/task.md" "$small_budget_root/workspace" \
+  "$small_budget_root/artifact/attempts/001" 1 >"$small_budget_root/out" 2>"$small_budget_root/err"
+grep -Fqx 'warning: overflow sentinel derived CLI budget is only 9s after finalize reservation' \
+  "$small_budget_root/err" \
+  && pass "implausibly small derived CLI budget emits a warning" \
+  || fail_case "implausibly small derived CLI budget emits a warning" "$(cat "$small_budget_root/err")"
+
 host_root="$TMP_ROOT/host"
 make_attempt "$host_root"
 OVF_SENTINEL=active OVF_COMPACTION_OWNER=host OVF_STEP_CMD="$MOCK_CLI" MOCK_STREAM_FILE="$FIXTURES/fire.jsonl" \
@@ -279,6 +404,25 @@ end=[x for x in events if x["event"]=="attempt_end"][0]
 assert end["nudge_disposition_final"]=="shown" and not end["fired_turns"]
 ' "$second_attempt/sentinel-events.jsonl"
 
+numeric_root="$TMP_ROOT/numeric-pending"
+make_attempt "$numeric_root" 011
+mkdir -p "$numeric_root/artifact/attempts/9" "$numeric_root/artifact/attempts/010"
+printf 'older numeric pending\n' >"$numeric_root/artifact/attempts/9/overflow-nudge.pending"
+printf 'newer numeric pending\n' >"$numeric_root/artifact/attempts/010/overflow-nudge.pending"
+numeric_capture="$numeric_root/numeric.prompt"
+OVF_SENTINEL=active OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" \
+MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" MOCK_STDIN_PATH="$numeric_capture" \
+  "$ADAPTER" "$numeric_root/workspace/task.md" "$numeric_root/workspace" \
+  "$numeric_root/artifact/attempts/011" 1 >"$numeric_root/out" 2>"$numeric_root/err"
+if grep -Fq 'newer numeric pending' "$numeric_capture" \
+  && ! grep -Fq 'older numeric pending' "$numeric_capture" \
+  && [[ -f "$numeric_root/artifact/attempts/9/overflow-nudge.pending" ]] \
+  && [[ ! -e "$numeric_root/artifact/attempts/010/overflow-nudge.pending" ]]; then
+  pass "pending nudge selection orders attempt basenames numerically"
+else
+  fail_case "pending nudge selection orders attempt basenames numerically" "wrong pending selected"
+fi
+
 w_root="$TMP_ROOT/w-pct"
 make_attempt "$w_root"
 OVF_SENTINEL=shadow OVF_COMPACTION_OWNER=sentinel OVF_W_PCT=5 OVF_CTX_WINDOW=10000 \
@@ -300,6 +444,51 @@ MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
 exit_rc=$?
 set -e
 [[ "$exit_rc" -eq 7 ]] && pass "mock CLI exit code N propagates exactly" || fail_case "mock CLI exit code N propagates exactly" "$exit_rc"
+
+partial_timeout_root="$TMP_ROOT/partial-timeout"
+make_attempt "$partial_timeout_root"
+set +e
+TR_STEP_TIMEOUT_S=4 OVF_FINALIZE_TIMEOUT_S=1 OVF_SENTINEL=shadow \
+OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
+MOCK_STEP_RESULT='{"step_comp"' MOCK_SLEEP_S=60 \
+  "$ADAPTER" "$partial_timeout_root/workspace/task.md" "$partial_timeout_root/workspace" \
+  "$partial_timeout_root/artifact/attempts/001" 1 >"$partial_timeout_root/out" 2>"$partial_timeout_root/err"
+partial_timeout_rc=$?
+set -e
+if [[ "$partial_timeout_rc" -eq 124 ]] \
+  && [[ ! -e "$partial_timeout_root/artifact/attempts/001/step-result.json" ]] \
+  && [[ -f "$partial_timeout_root/artifact/attempts/001/step-result.json.partial" ]]; then
+  pass "timed-out model output is quarantined as step-result.json.partial"
+else
+  fail_case "timed-out model output is quarantined as step-result.json.partial" "rc=$partial_timeout_rc"
+fi
+
+partial_signal_root="$TMP_ROOT/partial-signal"
+make_attempt "$partial_signal_root"
+TR_STEP_TIMEOUT_S=30 OVF_FINALIZE_TIMEOUT_S=1 OVF_SENTINEL=shadow \
+OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
+MOCK_STEP_RESULT='{"step_comp"' MOCK_SLEEP_S=60 \
+  "$ADAPTER" "$partial_signal_root/workspace/task.md" "$partial_signal_root/workspace" \
+  "$partial_signal_root/artifact/attempts/001" 1 >"$partial_signal_root/out" 2>"$partial_signal_root/err" &
+partial_signal_pid=$!
+partial_signal_tries=0
+while [[ ! -f "$partial_signal_root/artifact/attempts/001/step-result.json" ]] \
+  && (( partial_signal_tries < 50 )); do
+  sleep 0.1
+  partial_signal_tries=$((partial_signal_tries + 1))
+done
+kill -TERM "$partial_signal_pid" 2>/dev/null || true
+set +e
+wait "$partial_signal_pid"
+partial_signal_rc=$?
+set -e
+if [[ "$partial_signal_rc" -eq 143 ]] \
+  && [[ ! -e "$partial_signal_root/artifact/attempts/001/step-result.json" ]] \
+  && [[ -f "$partial_signal_root/artifact/attempts/001/step-result.json.partial" ]]; then
+  pass "signal-killed model output is quarantined as step-result.json.partial"
+else
+  fail_case "signal-killed model output is quarantined as step-result.json.partial" "rc=$partial_signal_rc"
+fi
 
 hang_root="$TMP_ROOT/hang"
 make_attempt "$hang_root"
@@ -362,7 +551,7 @@ make_attempt "$timeout_root"
 set +e
 _CATY_TESTING=1 _CATY_OVF_TEST_HANG_FINALIZE=1 OVF_FINALIZE_TIMEOUT_S=1 \
 OVF_SENTINEL=shadow OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" MOCK_EXIT=7 \
-MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
+MOCK_STREAM_FILE="$FIXTURES/fire.jsonl" \
   "$ADAPTER" "$timeout_root/workspace/task.md" "$timeout_root/workspace" \
   "$timeout_root/artifact/attempts/001" 1 >"$timeout_root/out" 2>"$timeout_root/err"
 timeout_rc=$?
@@ -372,6 +561,10 @@ if [[ "$timeout_rc" -eq 7 ]] && grep -Fqx 'warning: overflow sentinel finalize t
 else
   fail_case "hung monitor timeout warns without changing CLI exit code" "rc=$timeout_rc stderr=$(cat "$timeout_root/err")"
 fi
+assert_python "fire-time state survives a monitor finalize timeout" '
+state=json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert state["last_fire_ma"]=={"level":90000.0}
+' "$timeout_root/artifact/overflow-sentinel-state.json"
 
 if (( failures )); then
   printf '%s overflow sentinel tap test(s) failed; %s passed\n' "$failures" "$passes" >&2

--- a/tests/overflow-sentinel-tap.test.sh
+++ b/tests/overflow-sentinel-tap.test.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+FIXTURES="$ROOT/tests/fixtures/overflow-sentinel"
+ADAPTER="$ROOT/adapters/claude-code/spawn_step.sh"
+MONITOR="$ROOT/adapters/claude-code/overflow_sentinel_monitor.py"
+MOCK_CLI="$FIXTURES/mock-cli.sh"
+TMP_ROOT=${TMPDIR:-/tmp}/caty-overflow-sentinel-tap.$$
+trap 'rm -rf "$TMP_ROOT"' EXIT
+mkdir -p "$TMP_ROOT"
+passes=0
+failures=0
+
+pass() { printf 'ok - %s\n' "$1"; passes=$((passes + 1)); }
+fail_case() { printf 'not ok - %s: %s\n' "$1" "$2" >&2; failures=$((failures + 1)); }
+
+assert_python() {
+  local name=$1
+  local body=$2
+  shift 2
+  if CASE_BODY="$body" python3 -B - "$@" <<'PY'
+import json
+import os
+import pathlib
+import sys
+exec(os.environ["CASE_BODY"], globals(), globals())
+PY
+  then
+    pass "$name"
+  else
+    fail_case "$name" "Python assertion failed"
+  fi
+}
+
+make_attempt() {
+  local case_root=$1
+  local number=${2:-001}
+  mkdir -p "$case_root/workspace/loop" "$case_root/artifact/attempts/$number"
+  printf '# State\n' >"$case_root/workspace/STATE.md"
+  printf 'task body\n' >"$case_root/workspace/task.md"
+  printf 'prompt line 1\nprompt line 2\n' >"$case_root/artifact/attempts/$number/prompt.md"
+}
+
+run_monitor_fixture() {
+  local fixture=$1
+  local attempt_dir=$2
+  local mode=${3:-shadow}
+  cp "$FIXTURES/$fixture" "$attempt_dir/stream.jsonl"
+  printf '0\n' >"$attempt_dir/overflow-stream.eof"
+  python3 -B "$MONITOR" \
+    --stream "$attempt_dir/stream.jsonl" \
+    --eof "$attempt_dir/overflow-stream.eof" \
+    --attempt-dir "$attempt_dir" \
+    --artifact-dir "$(cd "$attempt_dir/../.." && pwd)" \
+    --task-id fixture-task --attempt "$(basename "$attempt_dir")" \
+    --mode "$mode" --model claude-sonnet-4-5 --t-abs 80000 --w 0.50
+}
+
+case_root="$TMP_ROOT/realistic"
+make_attempt "$case_root"
+run_monitor_fixture realistic.jsonl "$case_root/artifact/attempts/001"
+assert_python "realistic golden preserves exclusive addition and deduplicates message.id" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+turns=[x for x in events if x["event"]=="turn"]
+assert len(turns)==2
+assert (turns[0]["input_tokens"],turns[0]["cache_read_tokens"],turns[0]["cache_creation_tokens"])==(100,20,10)
+assert turns[0]["input_tokens"]+turns[0]["cache_read_tokens"]+turns[0]["cache_creation_tokens"]==130
+assert turns[1]["tap_status"]=="no-cache-accounting"
+assert not [x for x in events if x["event"]=="fire"]
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+assert_python "unknown fields and init/keepalive noise do not create turns" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+assert len([x for x in events if x["event"]=="turn"])==2
+assert {x["event"] for x in events}=={"turn","attempt_end"}
+assert all("task_end" not in x.values() for x in events)
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+assert_python "attempt.json has the complete pinned field set and non-null first_byte_at" '
+p=json.loads(pathlib.Path(sys.argv[1]).read_text())
+expected={"schema_version","task_id","attempt","mode","model","ctx_window","ctx_window_source","started_at","first_byte_at","cli_exit_code","tap_status_final","fired","events_path"}
+assert set(p)==expected and p["first_byte_at"]=="2026-08-25T00:00:01Z"
+assert p["tap_status_final"]=="no-cache-accounting"
+' "$case_root/artifact/attempts/001/attempt.json"
+
+case_root="$TMP_ROOT/blind-three"
+make_attempt "$case_root"
+run_monitor_fixture blind-three.jsonl "$case_root/artifact/attempts/001"
+assert_python "three consecutive blind turns disable evaluation and stay out of series" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+turns=[x for x in events if x["event"]=="turn"]
+end=[x for x in events if x["event"]=="attempt_end"][0]
+assert len(turns)==4 and [x["tap_status"] for x in turns[:3]]==["blind"]*3
+assert not [x for x in events if x["event"]=="fire"]
+assert end["tap_status"]=="blind" and end["injected_summary"]=={"max":0,"last3_mean":0}
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+
+case_root="$TMP_ROOT/blind-short"
+make_attempt "$case_root"
+run_monitor_fixture blind-short.jsonl "$case_root/artifact/attempts/001"
+assert_python "short all-zero run is reported blind immediately" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+assert [x for x in events if x["event"]=="attempt_end"][0]["tap_status"]=="blind"
+assert all(x["tap_status"]=="blind" for x in events if x["event"]=="turn")
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+
+case_root="$TMP_ROOT/absent"
+make_attempt "$case_root"
+run_monitor_fixture absent.jsonl "$case_root/artifact/attempts/001"
+assert_python "absent usage remains distinct and first_byte_at is null" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+end=[x for x in events if x["event"]=="attempt_end"][0]
+receipt=json.loads(pathlib.Path(sys.argv[2]).read_text())
+assert end["tap_status"]=="absent" and not [x for x in events if x["event"]=="turn"]
+assert receipt["first_byte_at"] is None
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl" "$case_root/artifact/attempts/001/attempt.json"
+
+case_root="$TMP_ROOT/compaction"
+make_attempt "$case_root"
+run_monitor_fixture compaction.jsonl "$case_root/artifact/attempts/001" active
+assert_python "compaction reset excludes pre-drop series and withdraws pending nudge" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+end=[x for x in events if x["event"]=="attempt_end"][0]
+assert end["compaction_suspected"] is True
+assert end["injected_summary"]=={"max":50000,"last3_mean":50000.0}
+assert not pathlib.Path(sys.argv[2]).exists()
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl" "$case_root/artifact/attempts/001/overflow-nudge.pending"
+
+# Claude's cache fields are disjoint, so cached-inclusion normalization is N/A.
+# The exclusive-addition golden above is the oracle for the double-count mutant.
+pass "cached-inclusion removal is N/A for Claude; exclusive-addition mutant oracle is active"
+
+adapter_root="$TMP_ROOT/e2e"
+make_attempt "$adapter_root"
+attempt="$adapter_root/artifact/attempts/001"
+capture="$adapter_root/stdin.capture"
+cwd_capture="$adapter_root/cwd.capture"
+env_capture="$adapter_root/env.capture"
+printf '{"sentinel":"driver-owned"}\n' >"$attempt/step-result.json"
+step_result_before=$(shasum -a 256 "$attempt/step-result.json" | awk '{print $1}')
+set +e
+OVF_SENTINEL=shadow OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" \
+MOCK_STDIN_PATH="$capture" MOCK_CWD_PATH="$cwd_capture" MOCK_ENV_PATH="$env_capture" \
+MOCK_MARKER=passed-through MOCK_STREAM_FILE="$FIXTURES/realistic.jsonl" MOCK_STDERR='mock stderr exact' \
+  "$ADAPTER" "$adapter_root/workspace/task.md" "$adapter_root/workspace" "$attempt" 1 \
+  >"$adapter_root/stdout" 2>"$adapter_root/stderr"
+adapter_rc=$?
+set -e
+[[ "$adapter_rc" -eq 0 ]] && pass "mock CLI exit zero propagates" || fail_case "mock CLI exit zero propagates" "$adapter_rc"
+cmp -s "$attempt/prompt.md" "$capture" && pass "prompt reaches CLI stdin verbatim" || fail_case "prompt reaches CLI stdin verbatim" "bytes differ"
+expected_cwd=$(cd "$adapter_root/workspace" && pwd -P)
+[[ "$(cat "$cwd_capture")" == "$expected_cwd" ]] && pass "CLI cwd is workspace" || fail_case "CLI cwd is workspace" "$(cat "$cwd_capture")"
+[[ "$(cat "$env_capture")" == passed-through ]] && pass "CLI environment passes marker through" || fail_case "CLI environment passes marker through" "missing marker"
+grep -Fqx 'mock stderr exact' "$adapter_root/stderr" && pass "CLI stderr passes through adapter stderr" || fail_case "CLI stderr passes through adapter stderr" "$(cat "$adapter_root/stderr")"
+cmp -s "$adapter_root/stdout" "$attempt/stream.jsonl" && pass "model.stdout tee is byte-identical to stream.jsonl" || fail_case "model.stdout tee is byte-identical to stream.jsonl" "bytes differ"
+[[ -f "$attempt/overflow-stream.eof" ]] && pass "EOF marker is written" || fail_case "EOF marker is written" "missing"
+grep -Fq '"event": "attempt_end"' "$attempt/sentinel-events.jsonl" && pass "attempt_end is finalized before adapter exit" || fail_case "attempt_end is finalized before adapter exit" "missing"
+step_result_after=$(shasum -a 256 "$attempt/step-result.json" | awk '{print $1}')
+[[ "$step_result_before" == "$step_result_after" ]] && pass "adapter never touches step-result.json" || fail_case "adapter never touches step-result.json" "digest changed"
+
+off_root="$TMP_ROOT/off"
+make_attempt "$off_root"
+off_attempt="$off_root/artifact/attempts/001"
+set +e
+OVF_STEP_CMD="$MOCK_CLI" MOCK_STDOUT='raw model stdout' MOCK_STDERR='off stderr' \
+  "$ADAPTER" "$off_root/workspace/task.md" "$off_root/workspace" "$off_attempt" 1 \
+  >"$off_root/stdout" 2>"$off_root/stderr"
+off_rc=$?
+set -e
+[[ "$off_rc" -eq 0 && "$(cat "$off_root/stdout")" == 'raw model stdout' ]] \
+  && pass "OVF_SENTINEL unset preserves direct stdout" \
+  || fail_case "OVF_SENTINEL unset preserves direct stdout" "rc=$off_rc stdout=$(cat "$off_root/stdout")"
+if find "$off_root/artifact" -name 'sentinel-events.jsonl' -o -name 'overflow-nudge.pending' \
+  -o -name 'attempt.json' -o -name 'stream.jsonl' -o -name 'overflow-stream.eof' \
+  -o -name 'overflow-sentinel-state.json' | grep -q .; then
+  fail_case "OVF_SENTINEL unset creates zero sentinel artifacts" "unexpected artifact"
+else
+  pass "OVF_SENTINEL unset creates zero sentinel artifacts"
+fi
+
+invalid_root="$TMP_ROOT/invalid"
+make_attempt "$invalid_root"
+invalid_attempt="$invalid_root/artifact/attempts/001"
+invalid_cases='OVF_SENTINEL=bad
+OVF_T_ABS=0
+OVF_T_ABS=x
+OVF_W_PCT=0
+OVF_W_PCT=100
+OVF_W_PCT=x
+OVF_CTX_WINDOW=0
+OVF_CTX_WINDOW=x
+OVF_COMPACTION_OWNER=bad
+OVF_FINALIZE_TIMEOUT_S=0
+OVF_FINALIZE_TIMEOUT_S=x
+OVF_STEP_CMD=missing-overflow-command'
+while IFS= read -r invalid_case; do
+  invalid_name=${invalid_case%%=*}
+  invalid_value=${invalid_case#*=}
+  rm -f "$invalid_root/called"
+  set +e
+  env OVF_SENTINEL=active OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" \
+    MOCK_STDIN_PATH="$invalid_root/called" "$invalid_name=$invalid_value" \
+    "$ADAPTER" "$invalid_root/workspace/task.md" "$invalid_root/workspace" "$invalid_attempt" 1 \
+    >"$invalid_root/out" 2>"$invalid_root/err"
+  invalid_rc=$?
+  set -e
+  if [[ "$invalid_rc" -eq 2 && ! -e "$invalid_root/called" ]]; then
+    pass "invalid $invalid_name=$invalid_value exits 2 before spawn"
+  else
+    fail_case "invalid $invalid_name=$invalid_value exits 2 before spawn" "rc=$invalid_rc called=$([[ -e "$invalid_root/called" ]] && printf yes || printf no)"
+  fi
+done <<<"$invalid_cases"
+
+set +e
+OVF_SENTINEL=active OVF_COMPACTION_OWNER=sentinel OVF_HF_CONFIG="$TMP_ROOT/missing-hf.json" \
+OVF_STEP_CMD="$MOCK_CLI" MOCK_STDIN_PATH="$invalid_root/called-hf" \
+  "$ADAPTER" "$invalid_root/workspace/task.md" "$invalid_root/workspace" "$invalid_attempt" 1 \
+  >"$invalid_root/out" 2>"$invalid_root/err"
+invalid_hf_rc=$?
+set -e
+[[ "$invalid_hf_rc" -eq 2 && ! -e "$invalid_root/called-hf" ]] \
+  && pass "invalid OVF_HF_CONFIG exits 2 before spawn" \
+  || fail_case "invalid OVF_HF_CONFIG exits 2 before spawn" "rc=$invalid_hf_rc"
+
+warning_root="$TMP_ROOT/warning"
+make_attempt "$warning_root"
+OVF_SENTINEL=shadow OVF_STEP_CMD="$MOCK_CLI" MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
+  "$ADAPTER" "$warning_root/workspace/task.md" "$warning_root/workspace" \
+  "$warning_root/artifact/attempts/001" 1 >"$warning_root/out" 2>"$warning_root/err"
+grep -Fqx 'warning: OVF_COMPACTION_OWNER is unset; overflow sentinel owns compaction detection' "$warning_root/err" \
+  && pass "unset compaction owner emits exact lowercase warning" \
+  || fail_case "unset compaction owner emits exact lowercase warning" "$(cat "$warning_root/err")"
+
+host_root="$TMP_ROOT/host"
+make_attempt "$host_root"
+OVF_SENTINEL=active OVF_COMPACTION_OWNER=host OVF_STEP_CMD="$MOCK_CLI" MOCK_STREAM_FILE="$FIXTURES/fire.jsonl" \
+  "$ADAPTER" "$host_root/workspace/task.md" "$host_root/workspace" \
+  "$host_root/artifact/attempts/001" 1 >"$host_root/out" 2>"$host_root/err"
+assert_python "host compaction owner records disabled-host attempt_end" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+assert {x["event"] for x in events}=={"attempt_end"}
+assert events[0]["tap_status"]=="disabled-host"
+' "$host_root/artifact/attempts/001/sentinel-events.jsonl"
+
+shadow_root="$TMP_ROOT/shadow"
+make_attempt "$shadow_root"
+OVF_SENTINEL=shadow OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" MOCK_STREAM_FILE="$FIXTURES/fire.jsonl" \
+  "$ADAPTER" "$shadow_root/workspace/task.md" "$shadow_root/workspace" \
+  "$shadow_root/artifact/attempts/001" 1 >"$shadow_root/out" 2>"$shadow_root/err"
+[[ ! -e "$shadow_root/artifact/attempts/001/overflow-nudge.pending" ]] \
+  && pass "shadow fire writes no pending nudge" || fail_case "shadow fire writes no pending nudge" "pending exists"
+
+lifecycle_root="$TMP_ROOT/lifecycle"
+make_attempt "$lifecycle_root" 001
+first_attempt="$lifecycle_root/artifact/attempts/001"
+OVF_SENTINEL=active OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" \
+MOCK_STREAM_FILE="$FIXTURES/fire.jsonl" MOCK_STEP_RESULT='{"step_complete":true}' \
+  "$ADAPTER" "$lifecycle_root/workspace/task.md" "$lifecycle_root/workspace" "$first_attempt" 1 \
+  >"$lifecycle_root/one.out" 2>"$lifecycle_root/one.err"
+[[ -f "$first_attempt/overflow-nudge.pending" ]] && pass "run N fire leaves pending nudge" || fail_case "run N fire leaves pending nudge" "missing"
+assert_python "terminal firing attempt records suppressed disposition" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+end=[x for x in events if x["event"]=="attempt_end"][0]
+assert end["nudge_disposition_final"]=="suppressed"
+' "$first_attempt/sentinel-events.jsonl"
+make_attempt "$lifecycle_root" 002
+second_attempt="$lifecycle_root/artifact/attempts/002"
+shown_capture="$lifecycle_root/shown.prompt"
+OVF_SENTINEL=active OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" \
+MOCK_STREAM_FILE="$FIXTURES/fire.jsonl" MOCK_STDIN_PATH="$shown_capture" MOCK_STEP_RESULT='{"step_complete":true}' \
+  "$ADAPTER" "$lifecycle_root/workspace/task.md" "$lifecycle_root/workspace" "$second_attempt" 2 \
+  >"$lifecycle_root/two.out" 2>"$lifecycle_root/two.err"
+grep -Fq '1. Goal' "$shown_capture" && pass "run N+1 prepends pending nudge" || fail_case "run N+1 prepends pending nudge" "missing text"
+[[ ! -e "$first_attempt/overflow-nudge.pending" && ! -e "$second_attempt/overflow-nudge.pending" ]] \
+  && pass "shown nudge is deleted and cross-attempt hysteresis suppresses repeat" \
+  || fail_case "shown nudge is deleted and cross-attempt hysteresis suppresses repeat" "pending remains"
+assert_python "run N+1 attempt_end records shown disposition" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+end=[x for x in events if x["event"]=="attempt_end"][0]
+assert end["nudge_disposition_final"]=="shown" and not end["fired_turns"]
+' "$second_attempt/sentinel-events.jsonl"
+
+w_root="$TMP_ROOT/w-pct"
+make_attempt "$w_root"
+OVF_SENTINEL=shadow OVF_COMPACTION_OWNER=sentinel OVF_W_PCT=5 OVF_CTX_WINDOW=10000 \
+OVF_STEP_CMD="$MOCK_CLI" MOCK_STREAM_FILE="$FIXTURES/fire.jsonl" \
+  "$ADAPTER" "$w_root/workspace/task.md" "$w_root/workspace" "$w_root/artifact/attempts/001" 1 \
+  >"$w_root/out" 2>"$w_root/err"
+assert_python "OVF_W_PCT converts through division by one hundred" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+fire=[x for x in events if x["event"]=="fire"][0]
+assert fire["run_meta"]["w"]==0.05
+' "$w_root/artifact/attempts/001/sentinel-events.jsonl"
+exit_root="$TMP_ROOT/exit"
+make_attempt "$exit_root"
+set +e
+OVF_SENTINEL=shadow OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" MOCK_EXIT=7 \
+MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
+  "$ADAPTER" "$exit_root/workspace/task.md" "$exit_root/workspace" "$exit_root/artifact/attempts/001" 1 \
+  >"$exit_root/out" 2>"$exit_root/err"
+exit_rc=$?
+set -e
+[[ "$exit_rc" -eq 7 ]] && pass "mock CLI exit code N propagates exactly" || fail_case "mock CLI exit code N propagates exactly" "$exit_rc"
+
+hang_root="$TMP_ROOT/hang"
+make_attempt "$hang_root"
+alive_marker="$hang_root/child-alive"
+_CATY_TESTING=1 _CATY_OVF_TEST_TTFB_FLOOR_S=0 OVF_SENTINEL=active \
+OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
+MOCK_SLEEP_S=0.2 MOCK_ALIVE_PATH="$alive_marker" \
+  "$ADAPTER" "$hang_root/workspace/task.md" "$hang_root/workspace" "$hang_root/artifact/attempts/001" 1 \
+  >"$hang_root/out" 2>"$hang_root/err"
+assert_python "hang fixture writes one alert, zero fire, and leaves child alive" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+assert len([x for x in events if x["event"]=="alert"])==1
+assert len([x for x in events if x["event"]=="fire"])==0
+assert pathlib.Path(sys.argv[2]).read_text().strip()=="alive"
+' "$hang_root/artifact/attempts/001/sentinel-events.jsonl" "$alive_marker"
+
+tier_root="$TMP_ROOT/ttfb-tier"
+make_attempt "$tier_root"
+printf '%s\n' '{"last_fire_ma":{},"last_run_injected_ma":60000,"schema_version":1}' \
+  >"$tier_root/artifact/overflow-sentinel-state.json"
+_CATY_TESTING=1 _CATY_OVF_TEST_ELAPSED_S=151 OVF_SENTINEL=shadow \
+OVF_COMPACTION_OWNER=sentinel CLAUDE_MODEL=claude-sonnet-4-5 OVF_STEP_CMD="$MOCK_CLI" \
+MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
+  "$ADAPTER" "$tier_root/workspace/task.md" "$tier_root/workspace" "$tier_root/artifact/attempts/001" 1 \
+  >"$tier_root/out" 2>"$tier_root/err"
+assert_python "prior-attempt 60k MA makes the live alert use the 150-second tier" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+alerts=[x for x in events if x["event"]=="alert"]
+assert len(alerts)==1 and alerts[0]["floor_applied"]==150
+' "$tier_root/artifact/attempts/001/sentinel-events.jsonl"
+
+unknown_tier_root="$TMP_ROOT/ttfb-unknown"
+make_attempt "$unknown_tier_root"
+_CATY_TESTING=1 _CATY_OVF_TEST_ELAPSED_S=241 OVF_SENTINEL=shadow \
+OVF_COMPACTION_OWNER=sentinel CLAUDE_MODEL=claude-sonnet-4-5 OVF_STEP_CMD="$MOCK_CLI" \
+MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
+  "$ADAPTER" "$unknown_tier_root/workspace/task.md" "$unknown_tier_root/workspace" \
+  "$unknown_tier_root/artifact/attempts/001" 1 >"$unknown_tier_root/out" 2>"$unknown_tier_root/err"
+assert_python "no prior state makes the live alert use the unknown 240-second tier" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+alerts=[x for x in events if x["event"]=="alert"]
+assert len(alerts)==1 and alerts[0]["floor_applied"]==240
+' "$unknown_tier_root/artifact/attempts/001/sentinel-events.jsonl"
+assert_python "turn fire alert and attempt_end use the complete DESIGN wire names" '
+fire_events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+alert_events=[json.loads(x) for x in pathlib.Path(sys.argv[2]).read_text().splitlines()]
+turn=next(x for x in fire_events if x["event"]=="turn")
+fire=next(x for x in fire_events if x["event"]=="fire")
+end=next(x for x in fire_events if x["event"]=="attempt_end")
+alert=next(x for x in alert_events if x["event"]=="alert")
+assert {"event","schema_version","ts","task_id","attempt","turn_idx","input_tokens","cache_read_tokens","cache_creation_tokens","output_tokens","model","tap_status"} <= set(turn)
+assert {"event","schema_version","ts","started_at","task_id","attempt","turn_idx","axis","injected_ma","injected_last","value_kind","threshold_hit","ctx_window","ctx_window_source","slope","projection_turns","decision","nudge_disposition","model","runtime","tap_status","run_meta"} <= set(fire)
+assert {"event","schema_version","ts","task_id","attempt","turn_idx","ttfb_ms","floor_applied","model","runtime"} <= set(alert)
+assert {"event","schema_version","ts","started_at","task_id","attempt","outcome","window_error","runtime_compaction","compaction_suspected","total_tokens","injected_summary","fired_turns","alert_turns","nudge_disposition_final","tap_status","run_meta","elapsed_s"} <= set(end)
+assert end["outcome"] in {"step_completed","aborted","overflowed"}
+' "$w_root/artifact/attempts/001/sentinel-events.jsonl" "$tier_root/artifact/attempts/001/sentinel-events.jsonl"
+
+timeout_root="$TMP_ROOT/finalize-timeout"
+make_attempt "$timeout_root"
+set +e
+_CATY_TESTING=1 _CATY_OVF_TEST_HANG_FINALIZE=1 OVF_FINALIZE_TIMEOUT_S=1 \
+OVF_SENTINEL=shadow OVF_COMPACTION_OWNER=sentinel OVF_STEP_CMD="$MOCK_CLI" MOCK_EXIT=7 \
+MOCK_STREAM_FILE="$FIXTURES/absent.jsonl" \
+  "$ADAPTER" "$timeout_root/workspace/task.md" "$timeout_root/workspace" \
+  "$timeout_root/artifact/attempts/001" 1 >"$timeout_root/out" 2>"$timeout_root/err"
+timeout_rc=$?
+set -e
+if [[ "$timeout_rc" -eq 7 ]] && grep -Fqx 'warning: overflow sentinel finalize timeout; records may be incomplete' "$timeout_root/err"; then
+  pass "hung monitor timeout warns without changing CLI exit code"
+else
+  fail_case "hung monitor timeout warns without changing CLI exit code" "rc=$timeout_rc stderr=$(cat "$timeout_root/err")"
+fi
+
+if (( failures )); then
+  printf '%s overflow sentinel tap test(s) failed; %s passed\n' "$failures" "$passes" >&2
+  exit 1
+fi
+printf '%s overflow sentinel tap tests passed\n' "$passes"

--- a/tests/overflow-sentinel.test.sh
+++ b/tests/overflow-sentinel.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP_ROOT=${TMPDIR:-/tmp}/caty-overflow-sentinel-core.$$
+trap 'rm -rf "$TMP_ROOT"' EXIT
+mkdir -p "$TMP_ROOT"
+passes=0
+failures=0
+
+pass() { printf 'ok - %s\n' "$1"; passes=$((passes + 1)); }
+fail_case() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+
+run_python_case() {
+  local name=$1
+  local body=$2
+  if ROOT="$ROOT" TMP_ROOT="$TMP_ROOT" CASE_BODY="$body" python3 -B - <<'PY'
+import os
+import sys
+sys.path.insert(0, os.path.join(os.environ["ROOT"], "scripts"))
+from lib_overflow_sentinel import *
+exec(os.environ["CASE_BODY"], globals(), globals())
+PY
+  then
+    pass "$name"
+  else
+    fail_case "$name"
+  fi
+}
+
+run_python_case "level comparator is strict and min selects absolute threshold" '
+at = evaluate_series([80000], t_abs=80000, w=.9, ctx=200000)["turns"][0]
+above = evaluate_series([80001], t_abs=80000, w=.9, ctx=200000)["turns"][0]
+assert at["axis"] is None and "threshold_hit" not in at
+assert above["axis"] == "level" and above["threshold_hit"] == "abs"
+'
+
+run_python_case "min selects ratio threshold" '
+at = evaluate_series([50000], t_abs=80000, w=.5, ctx=100000)["turns"][0]
+above = evaluate_series([50001], t_abs=80000, w=.5, ctx=100000)["turns"][0]
+assert at["axis"] is None and above["axis"] == "level"
+assert above["threshold_hit"] == "ratio"
+'
+
+run_python_case "partial mean uses all available turns 1 and 2" '
+turns = evaluate_series([10, 20], t_abs=1000, w=.9, ctx=10000)["turns"]
+assert [turn["injected_ma"] for turn in turns] == [10.0, 15.0]
+'
+
+run_python_case "slope is undefined before turn 4 and slope fire works" '
+turns = evaluate_series([10000, 20000, 30000, 40000], t_abs=90000, w=.9, ctx=50000)["turns"]
+assert all(turn["slope"] is None for turn in turns[:3])
+assert turns[3]["axis"] == "slope" and turns[3]["projection_turns"] <= 10
+'
+
+run_python_case "axis both is emitted when level and slope fire" '
+turn = evaluate_series([10000, 20000, 30000, 100000], t_abs=30000, w=.9, ctx=100000)["turns"][-1]
+assert turn["axis"] == "both"
+'
+
+run_python_case "per-axis hysteresis re-arms at exact plus ten percent" '
+last = {"level": 100000.0, "slope": 90000.0}
+assert eligible_fire_axes("both", 109999.0, 100000, last) == ["slope"]
+assert eligible_fire_axes("both", 110000.0, 100000, last) == ["level", "slope"]
+'
+
+run_python_case "compaction reset boundary is strict below sixty percent" '
+assert not compaction_suspected(100, 61)
+assert not compaction_suspected(100, 60)
+assert compaction_suspected(100, 59)
+'
+
+run_python_case "context-window ladder resolves all four sources offline" '
+import json
+from pathlib import Path
+root = Path(os.environ["TMP_ROOT"])
+hf = root / "hf-config.json"
+hf.write_text(json.dumps({"max_position_embeddings": 131072}), encoding="utf-8")
+assert resolve_ctx_window(64000, str(hf), "claude-x") == (64000, "config")
+assert resolve_ctx_window(None, str(hf), "claude-x") == (131072, "hf-config")
+assert resolve_ctx_window(None, None, "claude-sonnet-4-5") == (200000, "catalog")
+assert resolve_ctx_window(None, None, "unlisted") == (200000, "default")
+'
+
+run_python_case "TTFB tiers use strict token boundaries and conservative unknowns" '
+assert ttfb_floor_seconds(None, "claude-sonnet-4-5") == 240
+assert ttfb_floor_seconds(50000, "claude-sonnet-4-5") == 90
+assert ttfb_floor_seconds(50001, "claude-sonnet-4-5") == 150
+assert ttfb_floor_seconds(100000, "claude-sonnet-4-5") == 150
+assert ttfb_floor_seconds(100001, "claude-sonnet-4-5") == 240
+assert ttfb_floor_seconds(100, "unknown-model") == 240
+assert ttfb_floor_seconds(100, "glm-5.3") == 300
+'
+
+run_python_case "outcome vocabulary maps completion overflow and abort" '
+assert outcome_from_result(0, {"step_complete": True}) == "step_completed"
+assert outcome_from_result(1, {"step_complete": True}) == "aborted"
+assert outcome_from_result(0, {"window_error": True}) == "overflowed"
+assert outcome_from_result(124, {"error_class": "timeout"}) == "aborted"
+'
+
+run_python_case "state load and atomic write preserve task-scoped hysteresis" '
+from pathlib import Path
+path = Path(os.environ["TMP_ROOT"]) / "state" / "overflow-sentinel-state.json"
+save_state(path, {"level": 90000.0}, 85000.0)
+state = load_state(path)
+assert state["last_fire_ma"] == {"level": 90000.0}
+assert state["last_run_injected_ma"] == 85000.0
+assert eligible_fire_axes("level", 99999.0, 100000, state["last_fire_ma"]) == []
+assert eligible_fire_axes("level", 100000.0, 100000, state["last_fire_ma"]) == ["level"]
+assert list(path.parent.glob("overflow-sentinel-state.json.*")) == []
+'
+
+run_python_case "non-firing turn omits threshold_hit" '
+turn = evaluate_series([1], t_abs=100, w=.5, ctx=1000)["turns"][0]
+assert turn["axis"] is None and "threshold_hit" not in turn
+'
+
+if (( failures )); then
+  printf '%s overflow sentinel core test(s) failed; %s passed\n' "$failures" "$passes" >&2
+  exit 1
+fi
+printf '%s overflow sentinel core tests passed\n' "$passes"

--- a/tests/overflow-sentinel.test.sh
+++ b/tests/overflow-sentinel.test.sh
@@ -51,6 +51,23 @@ run_python_case "slope is undefined before turn 4 and slope fire works" '
 turns = evaluate_series([10000, 20000, 30000, 40000], t_abs=90000, w=.9, ctx=50000)["turns"]
 assert all(turn["slope"] is None for turn in turns[:3])
 assert turns[3]["axis"] == "slope" and turns[3]["projection_turns"] <= 10
+assert "threshold_hit" not in turns[3]
+'
+
+run_python_case "slope uses the moving-average series rather than raw injected values" '
+turn = evaluate_series([10000, 10000, 10000, 62000], t_abs=80000, w=.5, ctx=200000)["turns"][-1]
+raw_slope = (62000 - 10000) / 3.0
+raw_projection = (200000 - (82000 / 3.0)) / raw_slope
+assert raw_projection <= M
+assert turn["injected_ma"] == 82000 / 3.0
+assert turn["projection_turns"] > M and turn["axis"] is None
+'
+
+run_python_case "slope projection fires at exact M and not just above M" '
+at = evaluate_series([100, 400, 400, 400], t_abs=5000, w=.99, ctx=1400)["turns"][-1]
+above = evaluate_series([100, 400, 400, 399], t_abs=5000, w=.99, ctx=1400)["turns"][-1]
+assert at["projection_turns"] == M and at["axis"] == "slope"
+assert above["projection_turns"] > M and above["axis"] is None
 '
 
 run_python_case "axis both is emitted when level and slope fire" '
@@ -79,6 +96,7 @@ hf.write_text(json.dumps({"max_position_embeddings": 131072}), encoding="utf-8")
 assert resolve_ctx_window(64000, str(hf), "claude-x") == (64000, "config")
 assert resolve_ctx_window(None, str(hf), "claude-x") == (131072, "hf-config")
 assert resolve_ctx_window(None, None, "claude-sonnet-4-5") == (200000, "catalog")
+assert resolve_ctx_window(None, None, "claude-unknown") == (200000, "default")
 assert resolve_ctx_window(None, None, "unlisted") == (200000, "default")
 '
 
@@ -89,6 +107,7 @@ assert ttfb_floor_seconds(50001, "claude-sonnet-4-5") == 150
 assert ttfb_floor_seconds(100000, "claude-sonnet-4-5") == 150
 assert ttfb_floor_seconds(100001, "claude-sonnet-4-5") == 240
 assert ttfb_floor_seconds(100, "unknown-model") == 240
+assert ttfb_floor_seconds(100, "claude-unknown") == 240
 assert ttfb_floor_seconds(100, "glm-5.3") == 300
 '
 

--- a/tests/pause-contract.test.sh
+++ b/tests/pause-contract.test.sh
@@ -282,6 +282,15 @@ assert_paused_automation_capture "paused Hermes spawn" "$ws" hermes-spawn-step
 assert_eq "paused Hermes spawn leaves exact workspace snapshot" "$spawn_before" "$(snapshot_workspace "$ws")"
 cover adapters/hermes/spawn_step.sh exit-0-status
 
+overflow_spawn_before=$(snapshot_workspace "$ws")
+capture_run overflow-spawn-paused env MODEL_SENTINEL="$model_sentinel" OVF_STEP_CMD="$fake_model" \
+  "$ROOT/adapters/claude-code/spawn_step.sh" "$TMP/missing-task-is-allowed-while-paused.md" "$ws" \
+  "$TMP/missing-attempt-is-allowed-while-paused" 1
+assert_paused_automation_capture "paused Claude Code overflow spawn" "$ws" overflow-spawn-step
+assert_eq "paused Claude Code overflow spawn leaves exact workspace snapshot" \
+  "$overflow_spawn_before" "$(snapshot_workspace "$ws")"
+cover adapters/claude-code/spawn_step.sh exit-0-status
+
 bundle_dir="$ws/loop/artifacts/pause-verify"
 mkdir -p "$bundle_dir"
 verify_before=$(snapshot_workspace "$ws")


### PR DESCRIPTION
Implements the overflow sentinel v1 for the claude-code runtime — opt-in, measured per-turn firing per DESIGN v0.5.2/#159 (design lane MERGED via PR #166). Closes #180.

## What ships

- `scripts/lib_overflow_sentinel.py` — frozen §4 predicate (MA N=3, level = MA > min(T_abs, w×ctx), slope K=3 on the MA series, projection ≤ M=10, strict <0.60× compaction reset, per-axis +10%×ctx hysteresis), 4-rung offline ctx ladder, TTFB floors, append-only event writers (turn / fire / alert / attempt_end).
- `adapters/claude-code/spawn_step.sh` — hermes-parity TR_SPAWN_STEP adapter; fail-closed `OVF_*` config; **unset = true passthrough** (no python, no tee, no artifacts, no budget change); switcher C-3; bounded-join finalize; never writes step-result.json.
- `adapters/claude-code/overflow_sentinel_monitor.py` — passive sibling tailer; exclusive addition; message.id dedup; sub-agent (`parent_tool_use_id`) exclusion; blind-path C-2 (`blind` / `absent` / `no-cache-accounting` / `disabled-host` distinct); first byte = first assistant line; compact_boundary → runtime_compaction; nudge pending file (propose-only, next-step boundary).
- Tests: core 14 + tap/golden 61 + pause-contract cover row; 13 golden fixtures; mutants A/B-cache/C demonstrated RED (evidence below).
- Docs: engineering/reference (+ja) sentinel sections; INSTALL enablement + C-1 guidance + pause-label limitation; DESIGN v0.5.3 changelog (80k/50% writeback + recorded application deltas).

Note on file names: the two Python files use underscores (`lib_overflow_sentinel.py`, `overflow_sentinel_monitor.py`) where the WIP declaration wrote hyphens — forced by Python importability; set-semantics unchanged.

## Review history (all seats heterogeneous vs writer=Codex GPT-5.6 Sol; records in #180 comments + private review dir)

- L1-9 implementation-plan review (pre-code): codex/glm/grok — v1 NO-GO → v2 → v2.1 → 3-seat cumulative GO.
- Implementation review r1 (candidate c6618c75): opus/glm/kimi — 3× GO-with-conditions. 3-seat convergence: exclusive-addition oracle gap (mutant B survived). Opus demonstrated sub-agent turn corruption; GLM found the driver-side pause-label mismatch (task-runner.sh:410, out of lane scope → follow-up).
- Fix round (adjudication ADJUDICATION-impl-r1: B1–B3 blocking, N1–N13 adopted, D1–D7 documented) → delta re-review of 0f424584: **opus GO / glm GO / kimi GO** — cumulative 3-seat GO. Opus and kimi independently re-ran the scratch-copy mutant probes (B-cache now red at the derived-sum site; sub-agent filter removal red); kimi independently re-ran the full suite (36 PASS, 0 FAIL).
- SHA supersession note (L1-8): seats reviewed 0f424584; origin/main's #181 merge commit was subsequently replaced upstream (48aa5ca → 1762aa5), so the same two commits were rebased onto current origin/main → head **66c38e99**. Content identity proven by `git range-diff 48aa5ca..0f42458 origin/main..66c38e9` = both commits `=` (no interdiff). Post-rebase re-verification: `make lint` 77 OK, `make test` (see CI/evidence row).

## L1-7 completion record

Candidate SHA: `66c38e992c31387c58d6b539c1e4b1f8f6044565` (= PR head; if it moves, superseding record per L1-8).
Implementer: Codex GPT-5.6 Sol (implementation + fix round). Orchestration/final inspection: Alpha (Fable 5). Reviewers: see table above — implementer and every merge-gating reviewer are different models (L1-3/L1-10).

| Done when | Verdict | Evidence (inline, 2026-08-25) |
|---|---|---|
| 1. Core predicate + unit tests | PASS | `tests/overflow-sentinel.test.sh` → `14 overflow sentinel core tests passed`; boundary pins: 80,000 no-fire vs 80,001 fire; 59/60/61 compaction; turn-4 slope; exact-M projection; +10% re-arm |
| 2. Tap + golden-file tests | PASS | `tests/overflow-sentinel-tap.test.sh` → `61 overflow sentinel tap tests passed`; exclusive addition pinned by cache-boundary golden (true-sum threshold straddle); keepalive/init/unknown-field exclusion; message.id dedup |
| 3. Events + attempt.json | PASS | wire-name assertions for turn/fire/alert/attempt_end; attempt.json full pinned key set incl. nullable first_byte_at; non-fired runs emit attempt_end; append-only (no in-place edits) |
| 4. TTFB alert-only | PASS | hang fixture: init+keepalive past floor → exactly 1 alert, 0 fire, child alive; tiers 90/150/240 strict at 50k/100k; unknown/no-prior = 240s; never kills |
| 5. Opt-in config + INSTALL | PASS | 13 invalid-value cases exit 2 pre-spawn; unset ⇒ zero artifacts + direct exec + unreduced budget (tests); INSTALL.md enablement section |
| 6. Switcher C-3 | PASS | unset owner → lowercase `warning:` + continue (exact-prefix test); `host` → `disabled-host` record + attempt_end |
| 7. Blind-path C-2 | PASS | first all-zero-with-keys turn = blind immediately; zeros excluded from series and drop detector; 3-consecutive stop + disabled attempt_end; blind/absent/no-cache-accounting distinct (goldens) |
| 8. Mutant proof | PASS | A: predicate `>`→`>=` → 2 core red. B-cache: double-count cache_read at derived sum → `cache-heavy boundary fires only above the true exclusive-sum threshold` red. C: dedup removal → 2 tap red. All reverted; orchestrator independently re-ran A (5 red → revert 12 green). r1 seats demonstrated the original B-input-site evidence was insufficient; refreshed at the correct site |
| 9. Docs (+ja, T-6) | PASS | engineering/reference + .ja sections; cli-conventions lowercase `warning:` with exact-prefix test |
| 10. Manifest + CI green | PASS (local gates) | activation-manifest: spawn_step guarded `overflow-spawn-step` + both .py exempt; pause-contract cover row; `make lint` → 77 shell files OK; `make test` → `Suite Summary: 36 PASS, 0 FAIL` (post-rebase re-verification per L0-7). GitHub CI on PR head 66c38e99: ALL GREEN — test-lint/test (17m9s) + test-macos (23m8s) + lint pass; gitleaks/history-check/risk-review-gate pass; pr-size pass via owner-applied `size-exempt` label (2026-08-25) |
| 11. README「提供中」 | N/A (deferred by issue) | explicitly out of this lane; follow-up delta after lane A (recorded in #180 Done when) |
| 12. FV update | N/A (deferred by issue) | executes at ship time on owner decision (recorded in #180 Done when) |

Declared files vs diff: `git diff --stat origin/main...HEAD` = 26 files (+2006/−7) — the 13 declared entries + L0-2 re-declared `tests/pause-contract.test.sh` + fixtures dir contents (13 files, dir declared with trailing slash). No undeclared files; forbidden files (install.sh / task-runner.sh / Makefile / README* / docs/benchmark*) untouched.
CI status: all checks green on 66c38e99 (see row 10). release: **v0.17.0 (proposal — ship-grade: new user-facing feature; owner decision pending)**. previous release: v0.16.0 (#170) — fulfilled: https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.16.0 (Latest, verified 2026-08-25).

Follow-up issues (opened): #186 driver pause-label parameterization (task-runner.sh:410 hardcodes hermes-spawn-step — D1); #187 sentinel↔task-runner ledger confluence + task-level task_end (P1 deferral); #188 network-backed HF ctx rung (A9 deferral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
