### PR TITLE
chore: unify copyright holder to Sho Jikumaru

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Caty
+Copyright (c) 2026 Sho Jikumaru
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Part of caty-ai/family-os#128

Unify the copyright holder to `Sho Jikumaru` (owner decision 2026-08-25). Product / org / project names using "Caty" are untouched; no `.github/workflows/**` files touched; LICENSE years unchanged.

## Changed files
- `LICENSE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Completion record (L1-7)
- Candidate SHA (PR head): `abb9178c83c40a8f13237584c75fd56fa1cc8d7b`
- Done when (this repo's slice of family-os#128), measured 2026-08-25:
  - LICENSE holder line — PASS: `sed -n 3p LICENSE` @ head → `Copyright (c) 2026 Sho Jikumaru`
  - Residual old-holder lines — PASS: `git grep -E 'Copyright \(c\) 2026 (Caty|Shoji Kumaru)|© 2026 Caty|© Caty'` @ head → 0 hits
  - Years / product-name "Caty" / `.github/workflows/**` untouched — PASS: hunk-purity audit by all 3 review seats (record: caty-ai/family-os#128 issuecomment-5412434724)
- Declared file set vs diff — MATCH:
  - `LICENSE`
- Writer: Alpha (Claude Fable 5); commit author/committer `shojikumaru <184229851+shojikumaru@users.noreply.github.com>` (verified on head)
- Review: heterogeneous 3-seat panel GLM-5.3 / Kimi-K3 / Grok-4.6 — round 1 NO-GO (single converged MAJOR: persona-engine yearless footers) → delta `830db60` (persona-engine only) → **cumulative GO 3/3** bound to the per-repo HEADs incl. this SHA. No self-approve; writer is seat-disjoint.
- CI: green at record time (risk-review-gate human label pending where noted in #128)
- release: deferred — this change rides the repo's next regular release (owner decision recorded in family-os#128; no release forced for a copyright-holder text change). Exit trigger: next `vX.Y.Z` release of this repo.
- previous release: unchanged by this lane (no tag created or moved)
