### PR TITLE
task-runner: accept any *-spawn-step pause entrypoint label (#186)

### DIFF
--- a/adapters/claude-code/INSTALL.md
+++ b/adapters/claude-code/INSTALL.md
@@ -279,12 +279,6 @@ and sends `prompt.md` on stdin. `OVF_STEP_CMD` defaults to
 whitespace-split argv, never shell-expanded. The model session—not this
 adapter—owns `step-result.json`.
 
-Known pause limitation: startup pause is handled before the model starts, but a
-workspace paused while this adapter is already running is currently classified
-by the task-runner driver against the Hermes pause label. That mid-run pause can
-therefore be misclassified. Driver-side pause-label parameterization is a
-follow-up; this adapter does not change `task-runner.sh` in v1.
-
 The passive monitor writes `stream.jsonl`, `overflow-stream.eof`,
 `sentinel-events.jsonl`, `attempt.json`, and, after an active fire,
 `overflow-nudge.pending` in the attempt directory. Task-scoped hysteresis state

--- a/scripts/task-runner.sh
+++ b/scripts/task-runner.sh
@@ -404,13 +404,15 @@ spawn_step_pause_record_matches() {
   local workspace_path=$2
   [[ -f "$stderr_file" && ! -L "$stderr_file" ]] || return 1
   python3 - "$stderr_file" "$workspace_path" <<'PY'
+import re
 import sys
 
 stderr_file, workspace = sys.argv[1:3]
-expected = f"status=paused workspace={workspace} entrypoint=hermes-spawn-step".encode("utf-8")
+prefix = f"status=paused workspace={workspace} entrypoint=".encode("utf-8")
+pattern = re.escape(prefix) + rb"[a-z0-9][a-z0-9-]*-spawn-step(?:\n)?"
 with open(stderr_file, "rb") as f:
     actual = f.read()
-raise SystemExit(0 if actual in (expected, expected + b"\n") else 1)
+raise SystemExit(0 if re.fullmatch(pattern, actual) else 1)
 PY
 }
 

--- a/tests/task-runner.test.sh
+++ b/tests/task-runner.test.sh
@@ -145,6 +145,26 @@ SH
   chmod +x "$path"
 }
 
+write_overflow_paused_step() {
+  local path=$1
+  cat >"$path" <<'SH'
+#!/usr/bin/env bash
+printf 'status=paused workspace=%s entrypoint=%s\n' "$2" overflow-spawn-step >&2
+exit 0
+SH
+  chmod +x "$path"
+}
+
+write_invalid_pause_label_step() {
+  local path=$1
+  cat >"$path" <<'SH'
+#!/usr/bin/env bash
+printf 'status=paused workspace=%s entrypoint=%s\n' "$2" evil-step >&2
+exit 0
+SH
+  chmod +x "$path"
+}
+
 write_nonpause_status_step() {
   local path=$1
   cat >"$path" <<'SH'
@@ -2442,6 +2462,30 @@ case_paused_step_requeues_without_charge() {
   fi
 }
 
+case_overflow_paused_step_requeues_without_charge() {
+  local name=overflow-paused-step-requeues-without-charge
+  local ws canonical_ws paused_step
+  ws=$(make_ws)
+  canonical_ws=$(cd "$ws" && pwd -P)
+  copy_task "$FIX_BASIC" "$ws" tr-basic
+  paused_step="$ws/overflow-paused-step.sh"
+  write_overflow_paused_step "$paused_step"
+  run_tick_with_step "$ws" "$paused_step" >/dev/null 2>&1
+  if [[ "$(state_value "$ws" tr-basic status)" = queued ]] \
+    && [[ "$(state_value "$ws" tr-basic attempts_used)" = 0 ]] \
+    && [[ "$(state_value "$ws" tr-basic active_seconds_used)" = 0 ]] \
+    && [[ "$(state_value "$ws" tr-basic infra_retries)" = 0 ]] \
+    && [[ "$(driver_value "$ws" tr-basic outcome)" = paused ]] \
+    && [[ "$(driver_value "$ws" tr-basic classified)" = paused ]] \
+    && [[ "$(driver_value "$ws" tr-basic exit_code)" = 0 ]] \
+    && [[ -f "$ws/loop/tasks/queue/tr-basic.task.md" ]] \
+    && grep -Fqx "status=paused workspace=$canonical_ws entrypoint=overflow-spawn-step" "$ws/loop/artifacts/tr-basic/attempts/001/model.stderr"; then
+    pass "$name"
+  else
+    fail "$name" "overflow pause did not requeue cleanly: status=$(state_value "$ws" tr-basic status) attempts=$(state_value "$ws" tr-basic attempts_used) active=$(state_value "$ws" tr-basic active_seconds_used) outcome=$(driver_value "$ws" tr-basic outcome)"
+  fi
+}
+
 case_paused_step_crash_recovery() {
   local name=paused-step-crash-recovery
   local ws paused_step first_rc
@@ -2515,6 +2559,25 @@ case_nonpause_status_record_is_not_paused() {
     pass "$name"
   else
     fail "$name" "malformed paused record was misclassified as paused: status=$(state_value "$ws" tr-basic status) attempts=$(state_value "$ws" tr-basic attempts_used) infra=$(state_value "$ws" tr-basic infra_retries) classified=$(driver_value "$ws" tr-basic classified)"
+  fi
+}
+
+case_invalid_pause_label_is_not_paused() {
+  local name=invalid-pause-label-is-not-paused
+  local ws invalid_pause_step
+  ws=$(make_ws)
+  copy_task "$FIX_BASIC" "$ws" tr-basic
+  invalid_pause_step="$ws/invalid-pause-label-step.sh"
+  write_invalid_pause_label_step "$invalid_pause_step"
+  run_tick_with_step "$ws" "$invalid_pause_step" >/dev/null 2>&1 || true
+  if [[ "$(state_value "$ws" tr-basic status)" = queued ]] \
+    && [[ "$(state_value "$ws" tr-basic attempts_used)" = 1 ]] \
+    && [[ "$(state_value "$ws" tr-basic infra_retries)" = 0 ]] \
+    && [[ "$(driver_value "$ws" tr-basic outcome)" = ok ]] \
+    && [[ "$(driver_value "$ws" tr-basic classified)" = '' ]]; then
+    pass "$name"
+  else
+    fail "$name" "invalid pause label was misclassified as paused: status=$(state_value "$ws" tr-basic status) attempts=$(state_value "$ws" tr-basic attempts_used) infra=$(state_value "$ws" tr-basic infra_retries) outcome=$(driver_value "$ws" tr-basic outcome) classified=$(driver_value "$ws" tr-basic classified)"
   fi
 }
 
@@ -2906,9 +2969,11 @@ case_prompt_budget_time_boundary_wind_down
 case_prompt_budget_time_above_boundary_no_wind_down
 case_paused_step_old_behavior_red
 case_paused_step_requeues_without_charge
+case_overflow_paused_step_requeues_without_charge
 case_paused_step_crash_recovery
 case_paused_step_crash_before_stamp_recovery
 case_nonpause_status_record_is_not_paused
+case_invalid_pause_label_is_not_paused
 case_prior_verifier_finding
 case_prior_verifier_pass_is_none
 case_prior_verifier_step_scoped


### PR DESCRIPTION
Closes #186.

The task-runner driver's mid-run pause classifier required `entrypoint=hermes-spawn-step` byte-exactly, so any other adapter's correct pause record (e.g. claude-code's `overflow-spawn-step`) was misclassified: the driver saw no pause, treated the attempt as ok, and churned attempts through the pause instead of the clean paused requeue. The matcher now accepts the suffix contract `[a-z0-9][a-z0-9-]*-spawn-step` via `re.fullmatch` over the entire stderr, keeping the byte-exact `status=paused workspace=<ws> entrypoint=` prefix (re.escape-protected) and the optional single trailing newline. Extra fields, foreign labels, multi-record stderr, and workspace mismatches still fail closed.

## Files touched (WIP declaration ↔ diff)

Declared: scripts/task-runner.sh / tests/pause-contract.test.sh / tests/task-runner.test.sh / adapters/claude-code/INSTALL.md.
Actual `git diff --stat origin/main...e5554c9` (2026-08-26):

```
 adapters/claude-code/INSTALL.md |  6 ----
 scripts/task-runner.sh          |  6 ++--
 tests/task-runner.test.sh       | 65 +++++++++++++++++++++++++++++++++++++++++
 3 files changed, 69 insertions(+), 8 deletions(-)
```

Subset of the declaration (pause-contract.test.sh needed no change — the driver-path tests live in task-runner.test.sh). No out-of-declaration files.

## Completion record (L1-7)

Candidate SHA: `e5554c9` (PR head at review time).

| Done when | verdict | evidence (inline, 2026-08-26) |
|---|---|---|
| driver accepts a parameterized/allowlisted entrypoint label (or matches the prefix contract) for pause records | PASS | task-runner.sh:404-417 now fullmatches `re.escape(prefix) + rb"[a-z0-9][a-z0-9-]*-spawn-step(?:\n)?"`. GLM seat verified 33/33 adversarial byte-cases correct (injection, unicode, multi-record, substring — out-glm/review.md); driver-path test `overflow-paused-step-requeues-without-charge` passes (status=queued, attempts_used=0, classified=paused via :2103→:2116). |
| test covering a non-hermes adapter pause mid-run | PASS | New `case_overflow_paused_step_requeues_without_charge` (label `overflow-spawn-step`, driver path) + negative `case_invalid_pause_label_is_not_paused` (`evil-step` → charged attempt, not paused). Orchestrator re-run 2026-08-26: `bash tests/task-runner.test.sh` → `TOTAL pass=97 fail=0`; `bash tests/pause-contract.test.sh` → all ok. |
| INSTALL.md limitation note removed | PASS | adapters/claude-code/INSTALL.md -6 lines: the "Known pause limitation" paragraph (was :282-286) deleted; nothing else in the file touched. |

- Tests (T-3): 2 driver-path tests added; both suites green in writer run AND independent orchestrator re-run (`pass=97 fail=0`; `bash -n scripts/task-runner.sh` clean).
- Mutant verification (both seats, private copies): M1 (drop `-spawn-step` suffix) → suite fails exactly `invalid-pause-label-is-not-paused`; M2 (`fullmatch`→`search`) → suite fails exactly `nonpause-status-record-is-not-paused`. Mutants confirmed live before suite runs (Kimi direct probes).
- Implementer: Codex GPT-5.6 Sol (`codex exec --profile sol`, sitter run 20260826T112925Z). Reviewers (blind, fresh-context, read-only; requested=actual): Grok 4.6 → GO / Kimi K3 → GO (formal file delivery) / GLM 5.3 → GO. All seats pairwise-distinct and distinct from the writer (L1-10); records: `~/claude-workspace/experiments/ev006/impl-186/out-{grok,kimi,glm}/review.md`. Blocking findings: 0. Non-blocking follow-ups (GLM): document the `*-spawn-step` label contract for adapter authors; consider a pause-streak cap (pre-existing posture, unchanged by this diff).
- CI: pending at record time (runs start with this PR) — merge blocked until green (T-4). Will be updated on the PR before merge.
- release: v0.17.3 (behavior fix in the shipped driver = 出荷相当; annotated tag + GitHub Release at merge, after owner GO)
- previous release: v0.17.2 — fulfilled (annotated tag + Release live: https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.17.2)

Merge, tag, and release execution wait for owner (翔さん) decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
