### PR TITLE
overflow sentinel: opt-in network-backed HF config.json rung for the ctx_window ladder (#188)

### DIFF
--- a/adapters/claude-code/INSTALL.md
+++ b/adapters/claude-code/INSTALL.md
@@ -263,19 +263,23 @@ scripts/task-runner.sh "$WS"
 `TR_STEP_TIMEOUT_S` must be exported; a shell-local task-runner setting is not
 visible to this child adapter. Set `CLAUDE_MODEL` to the actual model identifier
 so the context-window catalog and TTFB floor can select a known entry. If it is
-unset, the adapter records `claude-unknown`, which deliberately uses the default
-context window and conservative 240-second TTFB floor.
+unset, the adapter records `claude-unknown`, which is short-circuited to the
+default context window before catalog lookup and uses the conservative
+240-second TTFB floor.
 
 `OVF_HF_NETWORK=1` adds one best-effort HF config rung after `OVF_HF_CONFIG` and
 before the catalog fallback. When enabled, `OVF_HF_CACHE_DIR` is required and is
-validated as a writable non-symlink directory, created if missing, and forced to
-mode `0700` before the step starts. The monitor then validates `CLAUDE_MODEL` as
-a plain HF repo id, fetches exactly one
+validated as a writable cache directory whose leaf path is not a symlink
+(symlinked ancestors are accepted), created if missing, and forced to mode
+`0700` before the step starts. The cache entry file leaf is also required to be
+non-symlink while symlinked ancestors remain accepted. The monitor then
+validates `CLAUDE_MODEL` as a plain HF repo id, fetches exactly one
 `https://huggingface.co/<model>/resolve/main/config.json` with stdlib `urllib`
 and a hard 5-second timeout, writes a flat `sha256(model).json` cache entry, and
-uses it only after re-reading that cache entry successfully. Any HF id, cache,
-or fetch failure warns and falls through to the catalog/default ladder without
-changing the model-step exit status.
+uses it only after a bounded re-read of that cache entry succeeds. Both the
+download and cache re-read accept payloads up to exactly 1 MiB and reject
+anything larger. Any HF id, cache, or fetch failure warns and falls through to
+the catalog/default ladder without changing the model-step exit status.
 
 Optional snippet:
 

--- a/adapters/claude-code/INSTALL.md
+++ b/adapters/claude-code/INSTALL.md
@@ -266,6 +266,24 @@ so the context-window catalog and TTFB floor can select a known entry. If it is
 unset, the adapter records `claude-unknown`, which deliberately uses the default
 context window and conservative 240-second TTFB floor.
 
+`OVF_HF_NETWORK=1` adds one best-effort HF config rung after `OVF_HF_CONFIG` and
+before the catalog fallback. When enabled, `OVF_HF_CACHE_DIR` is required and is
+validated as a writable non-symlink directory, created if missing, and forced to
+mode `0700` before the step starts. The monitor then validates `CLAUDE_MODEL` as
+a plain HF repo id, fetches exactly one
+`https://huggingface.co/<model>/resolve/main/config.json` with stdlib `urllib`
+and a hard 5-second timeout, writes a flat `sha256(model).json` cache entry, and
+uses it only after re-reading that cache entry successfully. Any HF id, cache,
+or fetch failure warns and falls through to the catalog/default ladder without
+changing the model-step exit status.
+
+Optional snippet:
+
+```sh
+export OVF_HF_NETWORK=1
+export OVF_HF_CACHE_DIR="$WS/loop/.cache/overflow-sentinel-hf"
+```
+
 After inspecting `sentinel-events.jsonl`, select `OVF_SENTINEL=active` to allow
 the adapter to prepare a five-point delta nudge. The nudge is shown at the next
 task-runner step boundary, not injected into the running `claude -p` process.

--- a/adapters/claude-code/overflow_sentinel_monitor.py
+++ b/adapters/claude-code/overflow_sentinel_monitor.py
@@ -167,7 +167,13 @@ def monitor(args: argparse.Namespace) -> int:
         started_monotonic -= max(0.0, float(os.environ["_CATY_OVF_TEST_ELAPSED_S"]))
     state = load_state(state_path)
     last_fire_ma = dict(state["last_fire_ma"])
-    ctx_window, ctx_source = resolve_ctx_window(args.ctx_window, args.hf_config, args.model)
+    ctx_window, ctx_source = resolve_ctx_window(
+        args.ctx_window,
+        args.hf_config,
+        args.model,
+        hf_network=args.hf_network,
+        hf_cache_dir=args.hf_cache_dir,
+    )
     floor_s = ttfb_floor_seconds(state["last_run_injected_ma"], args.model)
     if os.environ.get("_CATY_TESTING") == "1" and os.environ.get("_CATY_OVF_TEST_TTFB_FLOOR_S"):
         floor_s = max(0, int(os.environ["_CATY_OVF_TEST_TTFB_FLOOR_S"]))
@@ -435,6 +441,8 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--w", required=True, type=float)
     parser.add_argument("--ctx-window", type=int)
     parser.add_argument("--hf-config")
+    parser.add_argument("--hf-network", action="store_true")
+    parser.add_argument("--hf-cache-dir")
     parser.add_argument("--tap-status", default="enabled", choices=("enabled", "disabled-host"))
     parser.add_argument("--nudge-shown", action="store_true")
     parser.add_argument("--poll-interval", type=float, default=0.02)

--- a/adapters/claude-code/spawn_step.sh
+++ b/adapters/claude-code/spawn_step.sh
@@ -126,6 +126,18 @@ if [[ -n "$ovf_hf_config" ]]; then
     || config_fail 'OVF_HF_CONFIG must name a validated local HF config.json'
 fi
 
+ovf_hf_network=${OVF_HF_NETWORK:-}
+case "$ovf_hf_network" in
+  ''|0|1) ;;
+  *) config_fail 'OVF_HF_NETWORK must be unset, 0, or 1' ;;
+esac
+ovf_hf_cache_dir=${OVF_HF_CACHE_DIR:-}
+if [[ "$ovf_hf_network" == 1 ]]; then
+  [[ -n "$ovf_hf_cache_dir" ]] || config_fail 'OVF_HF_CACHE_DIR must be set when OVF_HF_NETWORK=1'
+  python3 -B "$repo_root/scripts/lib_overflow_sentinel.py" prepare-hf-cache "$ovf_hf_cache_dir" >/dev/null \
+    || config_fail 'OVF_HF_CACHE_DIR must name a writable non-symlink cache directory'
+fi
+
 ovf_step_timeout_s=540
 if [[ -n "${TR_STEP_TIMEOUT_S:-}" && "$TR_STEP_TIMEOUT_S" =~ ^[1-9][0-9]*$ ]]; then
   if (( TR_STEP_TIMEOUT_S > ovf_finalize_timeout_s + 2 )); then
@@ -212,6 +224,9 @@ monitor_args=(
 )
 [[ -z "$ovf_ctx_window" ]] || monitor_args+=(--ctx-window "$ovf_ctx_window")
 [[ -z "$ovf_hf_config" ]] || monitor_args+=(--hf-config "$ovf_hf_config")
+if [[ "$ovf_hf_network" == 1 ]]; then
+  monitor_args+=(--hf-network --hf-cache-dir "$ovf_hf_cache_dir")
+fi
 [[ "$ovf_owner" != host ]] || monitor_args+=(--tap-status disabled-host)
 (( nudge_shown == 0 )) || monitor_args+=(--nudge-shown)
 
@@ -256,6 +271,8 @@ if (( monitor_timed_out == 1 )); then
 elif (( monitor_status != 0 )); then
   printf 'warning: overflow sentinel monitor failed; continuing without complete sentinel records\n' >&2
   [[ ! -s "$monitor_stderr" ]] || cat "$monitor_stderr" >&2
+elif [[ -s "$monitor_stderr" ]]; then
+  cat "$monitor_stderr" >&2
 fi
 
 exit "$step_status"

--- a/docs/design/159-overflow-sentinel/DESIGN.md
+++ b/docs/design/159-overflow-sentinel/DESIGN.md
@@ -175,9 +175,14 @@ alert       = ts_first_byte 不在のまま TTFB 床超過（fire とは別イ�
 | M（射影ホライズン） | 10 turns | 保守的（v1 の誤発火コスト= ログ1行+ナッジ1回） |
 | TTFB 床 | 90/150/240s + reasoning floor 表 + unknown=240s | Hermes 実装値 + hermes#89241 の逆張り |
 
-**ctx_window の4段梯子**: config 明示上書き > HF config.json（公開モデル・**訓練上限≠提供窓に注意**、
-過大方向は T_abs 併置で無害化） > モデルカタログ > 保守既定 200k。採用段を `ctx_window_source` として
-ログに記録。128k 実窓モデルに 200k 既定が当たる過大方向の見逃しも T_abs が受ける。
+**ctx_window の5段梯子**: config 明示上書き > HF config.json（公開モデル・**訓練上限≠提供窓に注意**、
+過大方向は T_abs 併置で無害化） > opt-in の HF network cache rung（`CLAUDE_MODEL` を plain な HF repo id
+として検証し、`https://huggingface.co/<model>/resolve/main/config.json` を stdlib `urllib` の 1 fetch /
+hard 5s timeout で取得、`OVF_HF_CACHE_DIR` 配下へ flat な `sha256(model).json` を atomic write して
+再読込に成功した場合のみ採用） > モデルカタログ > 保守既定 200k。採用段を `ctx_window_source` として
+ログに記録し、network rung の source 名は fresh/cached とも `hf-network-cached` に固定する。
+HF id / cache validation / cache I/O / fetch の失敗は warning を 1 行出して catalog/default へ fall through
+する。128k 実窓モデルに 200k 既定が当たる過大方向の見逃しも T_abs が受ける。
 
 ## 6. 発火時の動作（D3: v1 は提案のみ + 発火実測ログ）
 

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -148,20 +148,22 @@ sentinel の動作も無効です。CLI は `prompt.md` を stdin から直接�
 | `OVF_CTX_WINDOW` | optional の 1 以上の整数。context-window 梯子の第 1 段 |
 | `OVF_HF_CONFIG` | optional の local・non-symlink HF `config.json` path（またはその directory）。network lookup なし |
 | `OVF_HF_NETWORK` | unset/空/`0` = 無効、`1` = best-effort の HF network rung を有効化 |
-| `OVF_HF_CACHE_DIR` | `OVF_HF_NETWORK=1` のとき必須。writable・non-symlink の cache dir。作成時/再利用時に mode `0700` を強制 |
+| `OVF_HF_CACHE_DIR` | `OVF_HF_NETWORK=1` のとき必須。leaf path 自体は symlink でない writable cache dir で、cache-entry file の leaf も symlink 不可（ancestor の symlink は許容）。作成時/再利用時に mode `0700` を強制 |
 | `OVF_COMPACTION_OWNER` | `sentinel` または `host`。unset は warning 後 `sentinel`、`host` は `disabled-host` を記録 |
 | `OVF_STEP_CMD` | whitespace 分割の CLI argv。既定 `claude -p --output-format stream-json --verbose` |
 | `OVF_FINALIZE_TIMEOUT_S` | 1 以上の整数。既定 `10`。CLI 終了後の monitor join 上限 |
-| `CLAUDE_MODEL` | 実際の model identifier。unset は `claude-unknown` を記録し、`claude-` catalog prefix には一致しない unknown として扱う |
+| `CLAUDE_MODEL` | 実際の model identifier。unset は `claude-unknown` を記録し、catalog lookup 前に `default` へ short-circuit されるため `claude-` catalog prefix には一致しない |
 
 context-window は config、検証済み local HF config、opt-in の HF network cache rung、
 Claude-family prefix catalog、200k 既定の順で解決します。network rung は `CLAUDE_MODEL` を
 plain な HF repo id として検証し、stdlib `urllib` で
 `https://huggingface.co/<model>/resolve/main/config.json` を hard 5 秒 timeout で 1 回だけ取得し、
 `OVF_HF_CACHE_DIR` 配下の flat な `sha256(model).json` cache entry へ atomic に書いてから、
-その cache entry を再読込して採用します。採用 source は `config`、`hf-config`、
+その cache entry を同じ 1 MiB 制限で再読込して採用します。cache directory の leaf と
+cache-entry file の leaf はどちらも symlink 不可で、ancestor の symlink は許容します。
+network payload と cached entry はどちらもその上限ちょうどまでは受け入れ、1 byte でも大きければ reject します。採用 source は `config`、`hf-config`、
 `hf-network-cached`、`catalog`、`default` のいずれかで記録します。placeholder の
-`claude-unknown` は常に `default` を使います。HF id の検証、cache の検証、cache I/O、
+`claude-unknown` は catalog lookup 前に `default` へ short-circuit されます。HF id の検証、cache の検証、cache I/O、
 fetch の失敗は stderr へ warning を 1 行出したうえで、model-step の exit status を変えずに
 catalog/default へ fall through します。
 

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -147,14 +147,23 @@ sentinel の動作も無効です。CLI は `prompt.md` を stdin から直接�
 | `OVF_W_PCT` | 1–99 の整数。既定 `50`、100 で割って変換 |
 | `OVF_CTX_WINDOW` | optional の 1 以上の整数。context-window 梯子の第 1 段 |
 | `OVF_HF_CONFIG` | optional の local・non-symlink HF `config.json` path（またはその directory）。network lookup なし |
+| `OVF_HF_NETWORK` | unset/空/`0` = 無効、`1` = best-effort の HF network rung を有効化 |
+| `OVF_HF_CACHE_DIR` | `OVF_HF_NETWORK=1` のとき必須。writable・non-symlink の cache dir。作成時/再利用時に mode `0700` を強制 |
 | `OVF_COMPACTION_OWNER` | `sentinel` または `host`。unset は warning 後 `sentinel`、`host` は `disabled-host` を記録 |
 | `OVF_STEP_CMD` | whitespace 分割の CLI argv。既定 `claude -p --output-format stream-json --verbose` |
 | `OVF_FINALIZE_TIMEOUT_S` | 1 以上の整数。既定 `10`。CLI 終了後の monitor join 上限 |
-| `CLAUDE_MODEL` | 実際の Claude model identifier。unset は `claude-unknown` を記録し、`claude-` catalog prefix には一致しない unknown として扱う |
+| `CLAUDE_MODEL` | 実際の model identifier。unset は `claude-unknown` を記録し、`claude-` catalog prefix には一致しない unknown として扱う |
 
-context-window は config、検証済み local HF config、Claude-family prefix catalog、200k 既定の順で
-解決します。採用 source は `config`、`hf-config`、`catalog`、`default` のいずれかで記録します。
-placeholder の `claude-unknown` は常に `default` を使います。
+context-window は config、検証済み local HF config、opt-in の HF network cache rung、
+Claude-family prefix catalog、200k 既定の順で解決します。network rung は `CLAUDE_MODEL` を
+plain な HF repo id として検証し、stdlib `urllib` で
+`https://huggingface.co/<model>/resolve/main/config.json` を hard 5 秒 timeout で 1 回だけ取得し、
+`OVF_HF_CACHE_DIR` 配下の flat な `sha256(model).json` cache entry へ atomic に書いてから、
+その cache entry を再読込して採用します。採用 source は `config`、`hf-config`、
+`hf-network-cached`、`catalog`、`default` のいずれかで記録します。placeholder の
+`claude-unknown` は常に `default` を使います。HF id の検証、cache の検証、cache I/O、
+fetch の失敗は stderr へ warning を 1 行出したうえで、model-step の exit status を変えずに
+catalog/default へ fall through します。
 
 TTFB は run start から最初の `assistant` stream line までです。token tier は 90 秒、前 attempt の
 last injected MA が厳密に 50k 超なら 150 秒、厳密に 100k 超なら 240 秒です。prior state がない場合と

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -149,15 +149,25 @@ is created.
 | `OVF_W_PCT` | integer 1–99; default `50`, converted by dividing by 100 |
 | `OVF_CTX_WINDOW` | optional integer >= 1; first context-window ladder rung |
 | `OVF_HF_CONFIG` | optional local non-symlink HF `config.json` path (or its directory); no network lookup |
+| `OVF_HF_NETWORK` | unset/empty/`0` = disabled; `1` enables one best-effort HF network rung |
+| `OVF_HF_CACHE_DIR` | required when `OVF_HF_NETWORK=1`; writable non-symlink cache dir, created/forced as mode `0700` |
 | `OVF_COMPACTION_OWNER` | `sentinel` or `host`; unset warns and selects `sentinel`; `host` records `disabled-host` |
 | `OVF_STEP_CMD` | whitespace-split CLI argv; default `claude -p --output-format stream-json --verbose` |
 | `OVF_FINALIZE_TIMEOUT_S` | integer >= 1; default `10`; bounded monitor join after CLI exit |
-| `CLAUDE_MODEL` | actual Claude model identifier; unset records `claude-unknown`, treated as unknown rather than matching the `claude-` catalog prefix |
+| `CLAUDE_MODEL` | actual model identifier; unset records `claude-unknown`, treated as unknown rather than matching the `claude-` catalog prefix |
 
-Context-window resolution is config, validated local HF config, a Claude-family
-prefix catalog, then the 200k default. The selected source is logged as `config`,
-`hf-config`, `catalog`, or `default`; the `claude-unknown` placeholder always uses
-`default`.
+Context-window resolution is config, validated local HF config, an opt-in HF
+network cache rung, a Claude-family prefix catalog, then the 200k default. The
+network rung validates `CLAUDE_MODEL` as a plain HF repo id, performs one
+stdlib `urllib` fetch against
+`https://huggingface.co/<model>/resolve/main/config.json` with a hard 5-second
+timeout, writes a flat `sha256(model).json` cache entry under `OVF_HF_CACHE_DIR`,
+then re-reads that cache entry before accepting it. The selected source is
+logged as `config`, `hf-config`, `hf-network-cached`, `catalog`, or `default`;
+the `claude-unknown` placeholder always uses `default`. Any HF id validation,
+cache validation, cache I/O, or fetch failure emits one warning to stderr and
+falls through to the catalog/default ladder without changing the model-step exit
+status.
 
 TTFB is run start to the first `assistant` stream line. The token tiers are 90s,
 150s when the prior attempt's last injected MA is strictly above 50k, and 240s

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -150,11 +150,11 @@ is created.
 | `OVF_CTX_WINDOW` | optional integer >= 1; first context-window ladder rung |
 | `OVF_HF_CONFIG` | optional local non-symlink HF `config.json` path (or its directory); no network lookup |
 | `OVF_HF_NETWORK` | unset/empty/`0` = disabled; `1` enables one best-effort HF network rung |
-| `OVF_HF_CACHE_DIR` | required when `OVF_HF_NETWORK=1`; writable non-symlink cache dir, created/forced as mode `0700` |
+| `OVF_HF_CACHE_DIR` | required when `OVF_HF_NETWORK=1`; writable cache dir whose leaf path is not a symlink, with a non-symlink cache-entry file leaf as well (symlinked ancestors allowed), created/forced as mode `0700` |
 | `OVF_COMPACTION_OWNER` | `sentinel` or `host`; unset warns and selects `sentinel`; `host` records `disabled-host` |
 | `OVF_STEP_CMD` | whitespace-split CLI argv; default `claude -p --output-format stream-json --verbose` |
 | `OVF_FINALIZE_TIMEOUT_S` | integer >= 1; default `10`; bounded monitor join after CLI exit |
-| `CLAUDE_MODEL` | actual model identifier; unset records `claude-unknown`, treated as unknown rather than matching the `claude-` catalog prefix |
+| `CLAUDE_MODEL` | actual model identifier; unset records `claude-unknown`, which is short-circuited to `default` before catalog lookup rather than matching the `claude-` catalog prefix |
 
 Context-window resolution is config, validated local HF config, an opt-in HF
 network cache rung, a Claude-family prefix catalog, then the 200k default. The
@@ -162,10 +162,15 @@ network rung validates `CLAUDE_MODEL` as a plain HF repo id, performs one
 stdlib `urllib` fetch against
 `https://huggingface.co/<model>/resolve/main/config.json` with a hard 5-second
 timeout, writes a flat `sha256(model).json` cache entry under `OVF_HF_CACHE_DIR`,
-then re-reads that cache entry before accepting it. The selected source is
+then re-reads that cache entry with the same 1 MiB limit before accepting it.
+Both the cache directory leaf and the cache entry file leaf must not be
+symlinks, while symlinked ancestors are accepted. Both the network payload and
+cached entry accept bytes up to that exact limit and reject anything larger. The
+selected source is
 logged as `config`, `hf-config`, `hf-network-cached`, `catalog`, or `default`;
-the `claude-unknown` placeholder always uses `default`. Any HF id validation,
-cache validation, cache I/O, or fetch failure emits one warning to stderr and
+the `claude-unknown` placeholder is short-circuited to `default` before catalog
+lookup. Any HF id validation, cache validation, cache I/O, or fetch failure emits
+one warning to stderr and
 falls through to the catalog/default ladder without changing the model-step exit
 status.
 

--- a/scripts/lib_overflow_sentinel.py
+++ b/scripts/lib_overflow_sentinel.py
@@ -4,9 +4,16 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import queue
+import re
 import tempfile
+import threading
+import time
+import urllib.parse
+import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
@@ -18,6 +25,11 @@ M = 10
 DEFAULT_T_ABS = 80000
 DEFAULT_W = 0.50
 DEFAULT_CTX_WINDOW = 200000
+HF_CACHE_SCHEMA_VERSION = 1
+HF_NETWORK_TIMEOUT_S = 5
+HF_NETWORK_MAX_BYTES = 1024 * 1024
+HF_MODEL_ID_RE = re.compile(r"^(?:[A-Za-z0-9][A-Za-z0-9._-]*/)?[A-Za-z0-9][A-Za-z0-9._-]*$")
+HF_CTX_WINDOW_KEYS = ("max_position_embeddings", "n_positions", "max_seq_len", "model_max_length")
 
 # Prefix catalog only.  Provider training limits are deliberately not inferred.
 CTX_WINDOW_CATALOG = (
@@ -55,6 +67,29 @@ def atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
         except OSError:
             pass
         raise
+
+
+def atomic_write_private_json(path: Path, payload: Mapping[str, Any]) -> None:
+    """Write private JSON data atomically with a 0600 file mode."""
+    fd, temporary = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=True, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, str(path))
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def warn_ctx_window_fallback(message: str) -> None:
+    print(f"warning: overflow sentinel HF fallback: {message}", file=os.sys.stderr)
 
 
 def load_state(path: Path) -> Dict[str, Any]:
@@ -193,6 +228,16 @@ def compaction_suspected(previous: Optional[int], current: int) -> bool:
     return previous is not None and current < 0.60 * previous
 
 
+def _window_from_payload(payload: Any, source_name: str) -> int:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{source_name} must contain a JSON object")
+    for key in HF_CTX_WINDOW_KEYS:
+        value = payload.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 1:
+            return value
+    raise ValueError(f"{source_name} has no positive supported context-window field")
+
+
 def _hf_window(config_path: Path) -> int:
     candidate = config_path / "config.json" if config_path.is_dir() else config_path
     if not candidate.is_file() or candidate.is_symlink():
@@ -202,17 +247,175 @@ def _hf_window(config_path: Path) -> int:
             payload = json.load(handle)
     except (OSError, ValueError) as exc:
         raise ValueError("HF config is not readable JSON") from exc
-    if not isinstance(payload, dict):
-        raise ValueError("HF config must contain a JSON object")
-    for key in ("max_position_embeddings", "n_positions", "max_seq_len", "model_max_length"):
-        value = payload.get(key)
-        if isinstance(value, int) and not isinstance(value, bool) and value >= 1:
-            return value
-    raise ValueError("HF config has no positive supported context-window field")
+    return _window_from_payload(payload, "HF config")
+
+
+def validate_hf_model_id(model_id: str) -> str:
+    normalized = str(model_id or "").strip()
+    if not normalized:
+        raise ValueError("HF model id must be non-empty")
+    if HF_MODEL_ID_RE.fullmatch(normalized) is None:
+        raise ValueError("HF model id must be a plain repo id such as namespace/name")
+    return normalized
+
+
+def _validate_non_symlink_path(path: Path, label: str) -> None:
+    current = path
+    while True:
+        if current.is_symlink():
+            raise ValueError(f"{label} must not be a symlink: {current}")
+        parent = current.parent
+        if parent == current:
+            return
+        current = parent
+
+
+def prepare_hf_cache_dir(cache_dir: str) -> Path:
+    raw_cache_dir = str(cache_dir or "").strip()
+    if not raw_cache_dir:
+        raise ValueError("HF cache dir must be non-empty")
+    candidate = Path(raw_cache_dir)
+    _validate_non_symlink_path(candidate, "HF cache dir")
+    try:
+        candidate.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ValueError(f"HF cache dir is not writable: {candidate}") from exc
+    if candidate.is_symlink() or not candidate.is_dir():
+        raise ValueError(f"HF cache dir must be a non-symlink directory: {candidate}")
+    try:
+        os.chmod(candidate, 0o700)
+    except OSError as exc:
+        raise ValueError(f"HF cache dir mode cannot be set: {candidate}") from exc
+    return candidate
+
+
+def _hf_cache_file(cache_dir: Path, model_id: str) -> Path:
+    digest = hashlib.sha256(model_id.encode("utf-8")).hexdigest()
+    return cache_dir / f"{digest}.json"
+
+
+def _read_hf_network_cache(cache_path: Path, model_id: str) -> int:
+    if not cache_path.exists():
+        raise ValueError("cache miss")
+    if cache_path.is_symlink() or not cache_path.is_file():
+        raise ValueError("cache entry must be a non-symlink regular file")
+    _validate_non_symlink_path(cache_path.parent, "HF cache dir")
+    if not cache_path.parent.is_dir():
+        raise ValueError("cache dir must be a directory")
+    if cache_path.parent.stat().st_mode & 0o077:
+        raise ValueError("cache dir must be mode 0700")
+    try:
+        with cache_path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError, TypeError) as exc:
+        raise ValueError("cache entry is not readable JSON") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != HF_CACHE_SCHEMA_VERSION:
+        raise ValueError("cache entry schema mismatch")
+    if payload.get("model_id") != model_id:
+        raise ValueError("cache entry model mismatch")
+    return _window_from_payload(payload, "HF network cache")
+
+
+def _read_cached_hf_window(cache_path: Path, model_id: str) -> Optional[int]:
+    try:
+        return _read_hf_network_cache(cache_path, model_id)
+    except Exception as exc:
+        if str(exc) != "cache miss":
+            raise
+        return None
+
+
+def _write_hf_network_cache(cache_path: Path, model_id: str, ctx_window: int) -> None:
+    payload = {
+        "schema_version": HF_CACHE_SCHEMA_VERSION,
+        "model_id": model_id,
+        "fetched_at": time.time(),
+        "max_position_embeddings": ctx_window,
+    }
+    atomic_write_private_json(cache_path, payload)
+
+
+def _hf_network_url(model_id: str) -> str:
+    segments = [urllib.parse.quote(part, safe="._-") for part in model_id.split("/")]
+    return "https://huggingface.co/{}/resolve/main/config.json".format("/".join(segments))
+
+
+def _fetch_hf_window(model_id: str) -> int:
+    request = urllib.request.Request(
+        _hf_network_url(model_id),
+        headers={"Accept": "application/json", "User-Agent": "caty-overflow-sentinel/1"},
+    )
+    with urllib.request.urlopen(request, timeout=HF_NETWORK_TIMEOUT_S) as response:
+        raw_payload = response.read(HF_NETWORK_MAX_BYTES + 1)
+    if len(raw_payload) > HF_NETWORK_MAX_BYTES:
+        raise ValueError("HF network config exceeds size limit")
+    payload = json.loads(raw_payload)
+    return _window_from_payload(payload, "HF network config")
+
+
+def _fetch_hf_window_with_deadline(model_id: str, fetcher: Any, timeout_s: float) -> int:
+    result_queue: "queue.Queue[Tuple[bool, Any]]" = queue.Queue(maxsize=1)
+
+    def run_fetch() -> None:
+        try:
+            result_queue.put((True, fetcher(model_id)))
+        except Exception as exc:
+            result_queue.put((False, exc))
+
+    thread = threading.Thread(target=run_fetch, daemon=True)
+    thread.start()
+    try:
+        ok, payload = result_queue.get(timeout=timeout_s)
+    except queue.Empty as exc:
+        raise TimeoutError("HF network fetch exceeded hard timeout") from exc
+    if ok:
+        return payload
+    raise payload
+
+
+def _resolve_hf_network_ctx_window(
+    hf_model_id: str,
+    hf_cache_dir: str,
+    fetcher: Any = None,
+    fetch_timeout_s: float = HF_NETWORK_TIMEOUT_S,
+) -> Optional[Tuple[int, str]]:
+    try:
+        try:
+            model_id = validate_hf_model_id(hf_model_id)
+            cache_dir = prepare_hf_cache_dir(hf_cache_dir)
+            cache_path = _hf_cache_file(cache_dir, model_id)
+        except Exception as exc:
+            warn_ctx_window_fallback(str(exc) or exc.__class__.__name__)
+            return None
+        try:
+            cached_window = _read_cached_hf_window(cache_path, model_id)
+        except Exception as exc:
+            warn_ctx_window_fallback(str(exc) or exc.__class__.__name__)
+            cached_window = None
+        if cached_window is not None:
+            return cached_window, "hf-network-cached"
+        fetch = _fetch_hf_window if fetcher is None else fetcher
+        try:
+            ctx_window = _fetch_hf_window_with_deadline(model_id, fetch, fetch_timeout_s)
+            _write_hf_network_cache(cache_path, model_id, ctx_window)
+            cached_window = _read_hf_network_cache(cache_path, model_id)
+        except Exception as exc:
+            warn_ctx_window_fallback(str(exc) or exc.__class__.__name__)
+            return None
+        return cached_window, "hf-network-cached"
+    except Exception as exc:
+        warn_ctx_window_fallback(str(exc) or exc.__class__.__name__)
+        return None
 
 
 def resolve_ctx_window(
-    configured: Optional[int], hf_config: Optional[str], model: str
+    configured: Optional[int],
+    hf_config: Optional[str],
+    model: str,
+    hf_network: bool = False,
+    hf_cache_dir: Optional[str] = None,
+    hf_fetcher: Any = None,
+    hf_fetch_timeout_s: float = HF_NETWORK_TIMEOUT_S,
 ) -> Tuple[int, str]:
     if configured is not None:
         if configured < 1:
@@ -220,6 +423,15 @@ def resolve_ctx_window(
         return configured, "config"
     if hf_config:
         return _hf_window(Path(hf_config)), "hf-config"
+    if hf_network:
+        network_window = _resolve_hf_network_ctx_window(
+            model,
+            hf_cache_dir or "",
+            fetcher=hf_fetcher,
+            fetch_timeout_s=hf_fetch_timeout_s,
+        )
+        if network_window is not None:
+            return network_window
     normalized = model.lower().split("/")[-1]
     if normalized == "claude-unknown":
         return DEFAULT_CTX_WINDOW, "default"
@@ -267,10 +479,19 @@ def _main(argv: Optional[Sequence[str]] = None) -> int:
     evaluate.add_argument("--ctx", type=int, default=DEFAULT_CTX_WINDOW)
     validate_hf = sub.add_parser("validate-hf")
     validate_hf.add_argument("path")
+    prepare_hf_cache = sub.add_parser("prepare-hf-cache")
+    prepare_hf_cache.add_argument("path")
     args = parser.parse_args(argv)
     if args.command == "eval-series":
         values = [int(part) for part in args.series.split(",") if part]
         print(json.dumps(evaluate_series(values, args.t_abs, args.w, args.ctx), sort_keys=True))
+        return 0
+    if args.command == "prepare-hf-cache":
+        try:
+            print(prepare_hf_cache_dir(args.path))
+        except ValueError as exc:
+            print(str(exc), file=os.sys.stderr)
+            return 2
         return 0
     try:
         print(_hf_window(Path(args.path)))

--- a/scripts/lib_overflow_sentinel.py
+++ b/scripts/lib_overflow_sentinel.py
@@ -259,15 +259,9 @@ def validate_hf_model_id(model_id: str) -> str:
     return normalized
 
 
-def _validate_non_symlink_path(path: Path, label: str) -> None:
-    current = path
-    while True:
-        if current.is_symlink():
-            raise ValueError(f"{label} must not be a symlink: {current}")
-        parent = current.parent
-        if parent == current:
-            return
-        current = parent
+def _validate_non_symlink_leaf(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise ValueError(f"{label} must not be a symlink: {path}")
 
 
 def prepare_hf_cache_dir(cache_dir: str) -> Path:
@@ -275,7 +269,7 @@ def prepare_hf_cache_dir(cache_dir: str) -> Path:
     if not raw_cache_dir:
         raise ValueError("HF cache dir must be non-empty")
     candidate = Path(raw_cache_dir)
-    _validate_non_symlink_path(candidate, "HF cache dir")
+    _validate_non_symlink_leaf(candidate, "HF cache dir")
     try:
         candidate.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
@@ -299,15 +293,21 @@ def _read_hf_network_cache(cache_path: Path, model_id: str) -> int:
         raise ValueError("cache miss")
     if cache_path.is_symlink() or not cache_path.is_file():
         raise ValueError("cache entry must be a non-symlink regular file")
-    _validate_non_symlink_path(cache_path.parent, "HF cache dir")
+    _validate_non_symlink_leaf(cache_path.parent, "HF cache dir")
     if not cache_path.parent.is_dir():
         raise ValueError("cache dir must be a directory")
     if cache_path.parent.stat().st_mode & 0o077:
         raise ValueError("cache dir must be mode 0700")
     try:
-        with cache_path.open(encoding="utf-8") as handle:
-            payload = json.load(handle)
+        with cache_path.open("rb") as handle:
+            raw_payload = handle.read(HF_NETWORK_MAX_BYTES + 1)
     except (OSError, ValueError, TypeError) as exc:
+        raise ValueError("cache entry is not readable JSON") from exc
+    if len(raw_payload) > HF_NETWORK_MAX_BYTES:
+        raise ValueError("cache entry exceeds size limit")
+    try:
+        payload = json.loads(raw_payload)
+    except (ValueError, TypeError) as exc:
         raise ValueError("cache entry is not readable JSON") from exc
     if not isinstance(payload, dict) or payload.get("schema_version") != HF_CACHE_SCHEMA_VERSION:
         raise ValueError("cache entry schema mismatch")

--- a/tests/overflow-sentinel-hf-network.test.sh
+++ b/tests/overflow-sentinel-hf-network.test.sh
@@ -158,6 +158,62 @@ assert "cache entry is not readable JSON" in log
 assert "offline" in log
 '
 
+run_python_case "cached entry at the exact size cap is accepted" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-exact-cap"
+cache_dir.mkdir(parents=True)
+cache_path = lib._hf_cache_file(cache_dir, "org/model")
+payload = {
+    "schema_version": lib.HF_CACHE_SCHEMA_VERSION,
+    "model_id": "org/model",
+    "fetched_at": 1,
+    "max_position_embeddings": 131072,
+    "padding": "",
+}
+raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+payload["padding"] = "x" * (lib.HF_NETWORK_MAX_BYTES - len(raw))
+raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+assert len(raw) == lib.HF_NETWORK_MAX_BYTES
+cache_path.write_bytes(raw)
+
+stderr = io.StringIO()
+with contextlib.redirect_stderr(stderr):
+    result = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+    )
+
+assert result == (131072, "hf-network-cached")
+assert stderr.getvalue() == ""
+'
+
+run_python_case "oversized cached entry warns and falls through" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-oversize"
+cache_dir.mkdir(parents=True)
+cache_path = lib._hf_cache_file(cache_dir, "org/model")
+cache_path.write_bytes(b"x" * (lib.HF_NETWORK_MAX_BYTES + 1))
+
+stderr = io.StringIO()
+with contextlib.redirect_stderr(stderr):
+    result = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=lambda _: (_ for _ in ()).throw(OSError("offline")),
+    )
+
+assert result == (200000, "default")
+log = stderr.getvalue()
+assert "cache entry exceeds size limit" in log
+assert "offline" in log
+'
+
 run_python_case "HTTPError during fetch warns and falls through without creating cache" '
 root = Path(os.environ["TMP_ROOT"])
 cache_dir = root / "cache-http-error"
@@ -184,6 +240,44 @@ with contextlib.redirect_stderr(stderr):
 
 assert result == (200000, "default")
 assert "HTTP Error 404: not found" in stderr.getvalue()
+assert list(cache_dir.glob("*.json")) == []
+'
+
+run_python_case "oversized fetched payload warns and falls through" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-fetch-oversize"
+stderr = io.StringIO()
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+    def read(self, _):
+        return self.payload
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+def fake_urlopen(request, timeout):
+    assert timeout == lib.HF_NETWORK_TIMEOUT_S
+    return FakeResponse(b"x" * (lib.HF_NETWORK_MAX_BYTES + 1))
+
+old_urlopen = lib.urllib.request.urlopen
+lib.urllib.request.urlopen = fake_urlopen
+try:
+    with contextlib.redirect_stderr(stderr):
+        result = resolve_ctx_window(
+            None,
+            None,
+            "org/model",
+            hf_network=True,
+            hf_cache_dir=str(cache_dir),
+        )
+finally:
+    lib.urllib.request.urlopen = old_urlopen
+
+assert result == (200000, "default")
+assert "HF network config exceeds size limit" in stderr.getvalue()
 assert list(cache_dir.glob("*.json")) == []
 '
 
@@ -263,6 +357,67 @@ assert "HF network config has no positive supported context-window field" in std
 assert list(cache_dir.glob("*.json")) == []
 '
 
+run_python_case "cache entry symlinks are rejected and fall through" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-entry-symlink"
+cache_dir.mkdir(parents=True)
+os.chmod(cache_dir, 0o700)
+target = root / "cache-entry-target.json"
+target.write_text(json.dumps({
+    "schema_version": lib.HF_CACHE_SCHEMA_VERSION,
+    "model_id": "org/model",
+    "fetched_at": 1,
+    "max_position_embeddings": 131072,
+}) + "\n", encoding="utf-8")
+cache_path = lib._hf_cache_file(cache_dir, "org/model")
+cache_path.symlink_to(target)
+
+stderr = io.StringIO()
+with contextlib.redirect_stderr(stderr):
+    result = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=lambda _: (_ for _ in ()).throw(OSError("offline")),
+    )
+
+assert result == (200000, "default")
+log = stderr.getvalue()
+assert "cache entry must be a non-symlink regular file" in log
+assert "offline" in log
+'
+
+run_python_case "cached model mismatches warn and fall through" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-model-mismatch"
+cache_dir.mkdir(parents=True)
+cache_path = lib._hf_cache_file(cache_dir, "org/model")
+cache_path.write_text(json.dumps({
+    "schema_version": lib.HF_CACHE_SCHEMA_VERSION,
+    "model_id": "other/model",
+    "fetched_at": 1,
+    "max_position_embeddings": 131072,
+}) + "\n", encoding="utf-8")
+
+stderr = io.StringIO()
+with contextlib.redirect_stderr(stderr):
+    result = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=lambda _: (_ for _ in ()).throw(OSError("offline")),
+    )
+
+assert result == (200000, "default")
+log = stderr.getvalue()
+assert "cache entry model mismatch" in log
+assert "offline" in log
+'
+
 run_python_case "invalid model ids and unsafe cache dirs warn and fall through without escaping" '
 root = Path(os.environ["TMP_ROOT"])
 target = root / "cache-target"
@@ -285,6 +440,48 @@ assert symlink_cache == (200000, "default")
 assert "HF model id must be a plain repo id such as namespace/name" in log
 assert "HF cache dir must be non-empty" in log
 assert "HF cache dir must not be a symlink" in log
+'
+
+run_python_case "symlinked ancestors are accepted for cache prep and network reuse" '
+root = Path(os.environ["TMP_ROOT"])
+real_parent = root / "real-parent"
+real_parent.mkdir(parents=True)
+linked_parent = root / "linked-parent"
+linked_parent.symlink_to(real_parent, target_is_directory=True)
+cache_dir = linked_parent / "nested" / "cache"
+calls = []
+
+def fetcher(model_id):
+    calls.append(model_id)
+    return 131072
+
+prepared = lib.prepare_hf_cache_dir(str(cache_dir))
+stderr = io.StringIO()
+with contextlib.redirect_stderr(stderr):
+    first = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=fetcher,
+    )
+    second = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=lambda _: (_ for _ in ()).throw(RuntimeError("should not refetch")),
+    )
+
+assert prepared == cache_dir
+assert first == (131072, "hf-network-cached")
+assert second == (131072, "hf-network-cached")
+assert stderr.getvalue() == ""
+assert calls == ["org/model"]
+assert cache_dir.is_dir()
+assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o700
 '
 
 run_python_case "malicious HF ids are rejected before fetch" '
@@ -371,7 +568,11 @@ assert elapsed < 0.3
 assert "HF network fetch exceeded hard timeout" in stderr.getvalue()
 '
 
-prep_cache="$TMP_ROOT/prepared-cache"
+prep_real_parent="$TMP_ROOT/prepare-real-parent"
+prep_link_parent="$TMP_ROOT/prepare-link-parent"
+mkdir -p "$prep_real_parent"
+ln -s "$prep_real_parent" "$prep_link_parent"
+prep_cache="$prep_link_parent/prepared-cache"
 prep_output=$(python3 -B "$ROOT/scripts/lib_overflow_sentinel.py" prepare-hf-cache "$prep_cache")
 prep_mode=$(python3 -B - "$prep_cache" <<'PY'
 import os
@@ -381,9 +582,9 @@ print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode)))
 PY
 )
 if [[ "$prep_output" == "$prep_cache" ]] && [[ "$prep_mode" == "0o700" ]]; then
-  pass "prepare-hf-cache creates and normalizes a private cache directory"
+  pass "prepare-hf-cache accepts symlinked ancestors and normalizes a private cache directory"
 else
-  fail_case "prepare-hf-cache creates and normalizes a private cache directory"
+  fail_case "prepare-hf-cache accepts symlinked ancestors and normalizes a private cache directory"
 fi
 
 set +e

--- a/tests/overflow-sentinel-hf-network.test.sh
+++ b/tests/overflow-sentinel-hf-network.test.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP_BASE=$(cd "${TMPDIR:-/tmp}" && pwd -P)
+TMP_ROOT=$TMP_BASE/caty-overflow-sentinel-hf-network.$$
+trap 'rm -rf "$TMP_ROOT"' EXIT
+mkdir -p "$TMP_ROOT"
+passes=0
+failures=0
+
+pass() { printf 'ok - %s\n' "$1"; passes=$((passes + 1)); }
+fail_case() { printf 'not ok - %s\n' "$1" >&2; failures=$((failures + 1)); }
+
+run_python_case() {
+  local name=$1
+  local body=$2
+  if ROOT="$ROOT" TMP_ROOT="$TMP_ROOT" CASE_BODY="$body" python3 -B - <<'PY'
+import contextlib
+import io
+import hashlib
+import json
+import os
+import stat
+import sys
+import time
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.environ["ROOT"], "scripts"))
+import lib_overflow_sentinel as lib
+from lib_overflow_sentinel import *
+
+exec(os.environ["CASE_BODY"], globals(), globals())
+PY
+  then
+    pass "$name"
+  else
+    fail_case "$name"
+  fi
+}
+
+run_python_case "network rung write-through returns hf-network-cached and reuses the hashed cache entry" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-reuse"
+calls = []
+
+def fetcher(model_id):
+    calls.append(model_id)
+    return 131072
+
+stderr = io.StringIO()
+with contextlib.redirect_stderr(stderr):
+    first = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=fetcher,
+    )
+    second = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=lambda _: (_ for _ in ()).throw(RuntimeError("should not refetch")),
+    )
+
+assert stderr.getvalue() == ""
+assert first == (131072, "hf-network-cached")
+assert second == (131072, "hf-network-cached")
+assert calls == ["org/model"]
+assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o700
+cache_entries = list(cache_dir.glob("*.json"))
+assert len(cache_entries) == 1
+expected_name = hashlib.sha256(b"org/model").hexdigest() + ".json"
+assert cache_entries[0].name == expected_name
+payload = json.loads(cache_entries[0].read_text(encoding="utf-8"))
+assert payload["model_id"] == "org/model"
+assert payload["max_position_embeddings"] == 131072
+'
+
+run_python_case "local HF config keeps precedence over the opt-in network rung" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-local-wins"
+local = root / "local-config.json"
+local.write_text(json.dumps({"max_position_embeddings": 64000}), encoding="utf-8")
+
+def fetcher(_):
+    raise AssertionError("network rung should not run when local HF config is present")
+
+assert resolve_ctx_window(
+    None,
+    str(local),
+    "org/model",
+    hf_network=True,
+    hf_cache_dir=str(cache_dir),
+    hf_fetcher=fetcher,
+) == (64000, "hf-config")
+'
+
+run_python_case "network disabled or unset never creates cache and never calls fetcher" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-disabled"
+calls = []
+
+def fetcher(_):
+    calls.append("called")
+    raise AssertionError("fetcher should not run when OVF network is disabled")
+
+assert resolve_ctx_window(
+    None,
+    None,
+    "claude-sonnet-4-5",
+    hf_cache_dir=str(cache_dir),
+    hf_fetcher=fetcher,
+) == (200000, "catalog")
+assert resolve_ctx_window(
+    None,
+    None,
+    "claude-sonnet-4-5",
+    hf_network=False,
+    hf_cache_dir=str(cache_dir),
+    hf_fetcher=fetcher,
+) == (200000, "catalog")
+assert calls == []
+assert not cache_dir.exists()
+'
+
+run_python_case "network URL uses the exact resolve endpoint" '
+assert lib._hf_network_url("org/model") == "https://huggingface.co/org/model/resolve/main/config.json"
+assert lib._hf_network_url("org.with.dots/model_name") == "https://huggingface.co/org.with.dots/model_name/resolve/main/config.json"
+'
+
+run_python_case "invalid cache content plus fetch failure warns once per failure path and falls through" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-fallback"
+cache_dir.mkdir(parents=True)
+cache_path = lib._hf_cache_file(cache_dir, "org/model")
+cache_path.write_text("{not json}\n", encoding="utf-8")
+
+stderr = io.StringIO()
+with contextlib.redirect_stderr(stderr):
+    result = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=lambda _: (_ for _ in ()).throw(OSError("offline")),
+    )
+
+log = stderr.getvalue()
+assert result == (200000, "default")
+assert "cache entry is not readable JSON" in log
+assert "offline" in log
+'
+
+run_python_case "HTTPError during fetch warns and falls through without creating cache" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-http-error"
+stderr = io.StringIO()
+
+def fetcher(_):
+    raise urllib.error.HTTPError(
+        "https://huggingface.co/org/model/resolve/main/config.json",
+        404,
+        "not found",
+        hdrs=None,
+        fp=None,
+    )
+
+with contextlib.redirect_stderr(stderr):
+    result = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=fetcher,
+    )
+
+assert result == (200000, "default")
+assert "HTTP Error 404: not found" in stderr.getvalue()
+assert list(cache_dir.glob("*.json")) == []
+'
+
+run_python_case "fetched invalid JSON warns and falls through" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-invalid-json"
+stderr = io.StringIO()
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+    def read(self, _):
+        return self.payload
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+def fake_urlopen(request, timeout):
+    assert timeout == lib.HF_NETWORK_TIMEOUT_S
+    return FakeResponse(b"not json")
+
+old_urlopen = lib.urllib.request.urlopen
+lib.urllib.request.urlopen = fake_urlopen
+try:
+    with contextlib.redirect_stderr(stderr):
+        result = resolve_ctx_window(
+            None,
+            None,
+            "org/model",
+            hf_network=True,
+            hf_cache_dir=str(cache_dir),
+        )
+finally:
+    lib.urllib.request.urlopen = old_urlopen
+
+assert result == (200000, "default")
+assert "Expecting value" in stderr.getvalue()
+assert list(cache_dir.glob("*.json")) == []
+'
+
+run_python_case "fetched JSON without a supported window warns and falls through" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-no-window"
+stderr = io.StringIO()
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+    def read(self, _):
+        return self.payload
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+def fake_urlopen(request, timeout):
+    assert timeout == lib.HF_NETWORK_TIMEOUT_S
+    return FakeResponse(json.dumps({"architectures": ["TestModel"]}).encode("utf-8"))
+
+old_urlopen = lib.urllib.request.urlopen
+lib.urllib.request.urlopen = fake_urlopen
+try:
+    with contextlib.redirect_stderr(stderr):
+        result = resolve_ctx_window(
+            None,
+            None,
+            "org/model",
+            hf_network=True,
+            hf_cache_dir=str(cache_dir),
+        )
+finally:
+    lib.urllib.request.urlopen = old_urlopen
+
+assert result == (200000, "default")
+assert "HF network config has no positive supported context-window field" in stderr.getvalue()
+assert list(cache_dir.glob("*.json")) == []
+'
+
+run_python_case "invalid model ids and unsafe cache dirs warn and fall through without escaping" '
+root = Path(os.environ["TMP_ROOT"])
+target = root / "cache-target"
+target.mkdir(parents=True)
+symlink_dir = root / "cache-link"
+if symlink_dir.exists() or symlink_dir.is_symlink():
+    symlink_dir.unlink()
+symlink_dir.symlink_to(target, target_is_directory=True)
+
+stderr = io.StringIO()
+with contextlib.redirect_stderr(stderr):
+    invalid_id = resolve_ctx_window(None, None, "bad/id/extra", hf_network=True, hf_cache_dir=str(target))
+    empty_cache = resolve_ctx_window(None, None, "org/model", hf_network=True, hf_cache_dir="")
+    symlink_cache = resolve_ctx_window(None, None, "org/model", hf_network=True, hf_cache_dir=str(symlink_dir))
+
+log = stderr.getvalue()
+assert invalid_id == (200000, "default")
+assert empty_cache == (200000, "default")
+assert symlink_cache == (200000, "default")
+assert "HF model id must be a plain repo id such as namespace/name" in log
+assert "HF cache dir must be non-empty" in log
+assert "HF cache dir must not be a symlink" in log
+'
+
+run_python_case "malicious HF ids are rejected before fetch" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-malicious-id"
+calls = []
+stderr = io.StringIO()
+
+def fetcher(_):
+    calls.append("called")
+    raise AssertionError("fetcher should not run for invalid model ids")
+
+with contextlib.redirect_stderr(stderr):
+    first = resolve_ctx_window(
+        None,
+        None,
+        "../../x",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=fetcher,
+    )
+    second = resolve_ctx_window(
+        None,
+        None,
+        "http://evil",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=fetcher,
+    )
+
+assert first == (200000, "default")
+assert second == (200000, "default")
+assert calls == []
+log = stderr.getvalue()
+assert log.count("HF model id must be a plain repo id such as namespace/name") == 2
+'
+
+run_python_case "cache dir mode drift is normalized back to 0700 before cached reuse" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-mode"
+cache_dir.mkdir(parents=True)
+os.chmod(cache_dir, 0o755)
+cache_path = lib._hf_cache_file(cache_dir, "org/model")
+cache_path.write_text(json.dumps({
+    "schema_version": lib.HF_CACHE_SCHEMA_VERSION,
+    "model_id": "org/model",
+    "fetched_at": 1,
+    "max_position_embeddings": 131072,
+}) + "\n", encoding="utf-8")
+
+stderr = io.StringIO()
+with contextlib.redirect_stderr(stderr):
+    result = resolve_ctx_window(None, None, "org/model", hf_network=True, hf_cache_dir=str(cache_dir))
+
+assert result == (131072, "hf-network-cached")
+assert stderr.getvalue() == ""
+assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o700
+'
+
+run_python_case "hard fetch deadline returns promptly on a blocking fetcher" '
+root = Path(os.environ["TMP_ROOT"])
+cache_dir = root / "cache-timeout"
+started = time.monotonic()
+stderr = io.StringIO()
+
+def fetcher(_):
+    time.sleep(0.5)
+    return 131072
+
+with contextlib.redirect_stderr(stderr):
+    result = resolve_ctx_window(
+        None,
+        None,
+        "org/model",
+        hf_network=True,
+        hf_cache_dir=str(cache_dir),
+        hf_fetcher=fetcher,
+        hf_fetch_timeout_s=0.05,
+    )
+
+elapsed = time.monotonic() - started
+assert result == (200000, "default")
+assert elapsed < 0.3
+assert "HF network fetch exceeded hard timeout" in stderr.getvalue()
+'
+
+prep_cache="$TMP_ROOT/prepared-cache"
+prep_output=$(python3 -B "$ROOT/scripts/lib_overflow_sentinel.py" prepare-hf-cache "$prep_cache")
+prep_mode=$(python3 -B - "$prep_cache" <<'PY'
+import os
+import stat
+import sys
+print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode)))
+PY
+)
+if [[ "$prep_output" == "$prep_cache" ]] && [[ "$prep_mode" == "0o700" ]]; then
+  pass "prepare-hf-cache creates and normalizes a private cache directory"
+else
+  fail_case "prepare-hf-cache creates and normalizes a private cache directory"
+fi
+
+set +e
+python3 -B "$ROOT/scripts/lib_overflow_sentinel.py" prepare-hf-cache "" \
+  >"$TMP_ROOT/prepare-empty.out" 2>"$TMP_ROOT/prepare-empty.err"
+prepare_empty_rc=$?
+set -e
+if [[ "$prepare_empty_rc" -eq 2 ]] && grep -Fq 'HF cache dir must be non-empty' "$TMP_ROOT/prepare-empty.err"; then
+  pass "prepare-hf-cache exits 2 on an empty cache dir"
+else
+  fail_case "prepare-hf-cache exits 2 on an empty cache dir"
+fi
+
+if (( failures )); then
+  printf '%s overflow sentinel HF network test(s) failed; %s passed\n' "$failures" "$passes" >&2
+  exit 1
+fi
+printf '%s overflow sentinel HF network tests passed\n' "$passes"


### PR DESCRIPTION
Closes #188.

Adds the opt-in network-backed HF config.json rung to the ctx_window ladder, between the local `OVF_HF_CONFIG` file and the model catalog. With `OVF_HF_NETWORK=1` + `OVF_HF_CACHE_DIR`, the resolver validates the model id against a strict HF repo-id pattern, fetches `https://huggingface.co/<id>/resolve/main/config.json` (stdlib urllib, single attempt, hard 5s timeout, 1 MiB bounded read, daemon-thread guard), and caches the validated window atomically (sha256 filename, leaf-non-symlink, 0700/0600). `ctx_window_source` reports `hf-network-cached` for fresh and cached hits. Every failure falls through to catalog/default with one warning — the step is never blocked. With `OVF_HF_NETWORK` unset, behavior is byte-identical to main (verified diff-driven and behaviorally by review seats).

## Files touched (WIP declaration ↔ diff)

Re-declared on #188 (2026-08-26, scope-grow comment): scripts/lib_overflow_sentinel.py / adapters/claude-code/spawn_step.sh / adapters/claude-code/overflow_sentinel_monitor.py / adapters/claude-code/INSTALL.md (OVF config section, hunk @266 — does not touch the pause paragraph owned by #186) / docs/reference.md / docs/reference.ja.md / docs/design/159-overflow-sentinel/DESIGN.md / tests/overflow-sentinel-hf-network.test.sh (new).
Actual `git diff --stat origin/main...ee66b30` (2026-08-26): exactly those 8 files (+715/-23 then +245/-33 fix commit). No out-of-declaration files.

## Completion record (L1-7)

Candidate SHA: `ee66b30` (= 10932e8 implementation + ee66b30 review-fix; PR head at review time).

| Done when | verdict | evidence (inline, 2026-08-26) |
|---|---|---|
| opt-in resolver fetches and caches HF config.json for public models | PASS | `OVF_HF_NETWORK=1` gate in spawn_step.sh config block; resolver `_resolve_hf_network_ctx_window` with strict id validation → per-segment-quoted URL (Grok seat: "model ids cannot change the fetch host"); atomic mkstemp+fsync+os.replace cache write, sha256(model) filename. Test suite: 20 HF-network tests green (orchestrator re-run). |
| never blocking the step on network failure | PASS | Single attempt, 5s hard timeout + daemon-thread guard, bounded read; all fetch/cache/validation failures contained inside resolve_ctx_window → warn + fall through (mutant M2: removing containment → 5 never-block tests fail; with containment → green, all three seats). Kimi F1 hard-fail path (macOS ancestor-symlink rejection) found in r1 and FIXED in ee66b30: leaf-only posture, probes `/tmp` + `$TMPDIR` exit 0 (before: exit 2), symlinked leaf dir/entry still rejected (adversarially re-verified by Kimi r2). |
| cache validated | PASS | Read path: leaf symlink check, 0700/0600 mode check, byte cap = fetch cap (1 MiB, Kimi F2 fix), schema/model_id/window validation, post-fetch re-read-before-accept (GLM seat table). Negative tests: symlinked entry, oversize fetch, oversize cache, mismatched model_id (added in ee66b30). |
| ctx_window_source distinguishes cached-network from local-file | PASS | Local file keeps `hf-config`; network rung reports `hf-network-cached` (fresh and cached); tests pin both labels. |
| docs updated | PASS | INSTALL.md OVF section, docs/reference.md + .ja.md ladder description (4→5 rungs), DESIGN.md §5 application note (declared in the WIP re-declaration), `claude-unknown` wording drift fixed (Grok finding). |

- Tests (T-3): new suite tests/overflow-sentinel-hf-network.test.sh (20 tests incl. regression through a symlinked ancestor); sentinel core 14 + tap 61 green; full `make test`: **38 suites PASS, 0 FAIL** re-run after the fix commit (orchestrator, 2026-08-26).
- Review (blind r1 → delta): Grok 4.6 GO / GLM 5.3 GO / Kimi K3 NO-GO (F1 MAJOR: macOS stock-path hard fail, reproduced; convergent with a Grok residual) → fix ee66b30 → **Kimi r2 GO** (flip conditions met with evidence; leaf property adversarially re-verified). Cumulative: all three seats GO. Writer: Codex GPT-5.6 Sol; all seats pairwise-distinct and distinct from writer (L1-10); requested=actual; records: `~/claude-workspace/experiments/ev006/impl-188/out-{grok,glm,kimi,kimi-r2}/review.md`. Non-adopted follow-ups (recorded): cache TTL knob (GLM F1, safe direction), fetch-discard-on-cache-write-failure behavior note (GLM F2).
- Mutants (all seats, private copies, sites specified): M1 (id validation removed) → malicious-id tests fail; M2 (containment removed) → never-block tests fail.
- CI: pending at record time (runs start with this PR) — merge blocked until green (T-4). Will be updated on the PR before merge.
- release: v0.18.0 (new opt-in user-facing feature = 出荷相当, MINOR; annotated tag + GitHub Release at merge, after owner GO)
- previous release: at record time, the latest shipped merge is v0.17.2 — fulfilled (https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.17.2). PR #197 (#186) declares v0.17.3; if it merges first, its fulfillment will be re-checked here before this merge (L1-7⑦).

Merge, tag, and release execution wait for owner (翔さん) decision. Merge-order note: this PR and #197 touch disjoint files; either order works with a rebase + re-verify of the second (L0-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
