### PR TITLE
fix(#204): set overflow-sentinel off-budget case TR budget from measured macOS overhead

### DIFF
--- a/tests/overflow-sentinel-tap.test.sh
+++ b/tests/overflow-sentinel-tap.test.sh
@@ -278,10 +278,14 @@ else
   pass "OVF_SENTINEL unset creates zero sentinel artifacts"
 fi
 
+# Measured bound for #204 from ci-matrix macOS run 33007204524: adapter overhead
+# (elapsed minus the 1.2s mock sleep) was 0.92-1.16s, so the old 2s budget left
+# only 0.8s headroom and flaked intermittently. 12s leaves 10.8s headroom while
+# staying <= finalize(10)+2, so a wrongly shaved sentinel budget is still 1s < 1.2s.
 off_budget_root="$TMP_ROOT/off-budget"
 make_attempt "$off_budget_root"
 set +e
-TR_STEP_TIMEOUT_S=2 OVF_FINALIZE_TIMEOUT_S=garbage OVF_T_ABS=garbage \
+TR_STEP_TIMEOUT_S=12 OVF_FINALIZE_TIMEOUT_S=garbage OVF_T_ABS=garbage \
 OVF_STEP_CMD="$MOCK_CLI" MOCK_SLEEP_S=1.2 MOCK_STDOUT='budget preserved' \
   "$ADAPTER" "$off_budget_root/workspace/task.md" "$off_budget_root/workspace" \
   "$off_budget_root/artifact/attempts/001" 1 >"$off_budget_root/out" 2>"$off_budget_root/err"


### PR DESCRIPTION
Closes #204.

## What

Test-only fix for the macOS-only intermittent timeout (rc=124) in
`tests/overflow-sentinel-tap.test.sh` case "OVF_SENTINEL unset retains the full
exported TR step budget": raise the case's `TR_STEP_TIMEOUT_S` from 2 to 12, with an
in-file comment citing the measurement. One file, +5/−1.

## Why (measured, not guessed)

The case gave the adapter a 2s budget against a 1.2s mock sleep → 0.8s overhead
headroom. Measured adapter overhead (12 timed iterations of the exact invocation per
cell, generous 60s budget, throwaway branch `measure/204-overhead`, ci-matrix
workflow_dispatch run [33007204524](https://github.com/caty-ai/caty-agent-harness/actions/runs/33007204524)):

| cell | overhead (s) |
| --- | --- |
| macos-b32-enus | 0.922–1.124 |
| macos-b5-enus | 0.975–1.129 |
| macos-b32-c | 0.995–1.156 |
| ubuntu ×4 | 0.820–0.839 |

Every macOS sample exceeded the 0.8s headroom — nominal elapsed (2.12–2.36s) always
exceeded the 2s budget on macOS runners; the intermittency came from `run_bounded`'s
1s-poll / integer-`$SECONDS` timeout-detection granularity (`scripts/lib-bounded.sh`).

TR=12 → headroom 10.8s = 9.3× max measured macOS overhead. 12 is also the **maximum**
value preserving the case's discrimination property: 12 ≤ default finalize(10)+2, so a
regression that wrongly routes the OVF-unset path through the sentinel budget
derivation still shaves the budget to 1s < the 1.2s sleep → rc=124 → the case still
fails. Verified empirically by shaved-budget mutants (3 review seats built independent
mutants; all observed rc=124 under TR=12). Sleep unchanged → suite wall-time unchanged
(~2.05s for this case on success).

## 完了記録 (L1-7)

**Candidate SHA**: `199039aa0ef7d7c0a5dd247d1326ca2581b81eb3` (= PR head)
**Implementer**: Codex GPT-5.6 Sol (`--profile sol`), orchestration/design Alpha (Claude Code)
**Declared file set vs diff**: WIP declared `tests/overflow-sentinel-tap.test.sh` only → `git diff --name-only origin/main...HEAD` = `tests/overflow-sentinel-tap.test.sh` only. Match. `scripts/task-runner.sh` (frozen #187 lane) and `adapters/claude-code/spawn_step.sh` untouched (diff empty for both).

### Done when — verdicts

1. **Timeout bound measured on macOS runner, set from measurement, not guess — PASS.**
   Evidence: ci-matrix dispatch run [33007204524](https://github.com/caty-ai/caty-agent-harness/actions/runs/33007204524) on `measure/204-overhead` (2026-08-27); MEASURE204 log lines, per-cell overhead table above; max macOS overhead 1.156s; bound 12 = 9.3× max measured overhead and the discrimination-constrained maximum. Full numbers also posted to [#204](https://github.com/caty-ai/caty-agent-harness/issues/204#issuecomment-5430599690).
2. **ci-matrix green on macos-b32-enus and macos-b5-enus for the fix commit — PASS (2 consecutive dispatch runs).**
   Evidence: run 1 [33013665611](https://github.com/caty-ai/caty-agent-harness/actions/runs/33013665611) all 8 cells success; run 2 [33015662917](https://github.com/caty-ai/caty-agent-harness/actions/runs/33015662917) all 8 cells success — both on `fix/204-flaky-macos-timeout` @ 199039a (2026-08-27). Note: ci-matrix is a post-merge net; these are pre-merge `workflow_dispatch --ref` runs per the lane plan, and a post-merge main run will follow the merge as usual.
3. **No behavior change to the sentinel contract (test-only) — PASS.**
   Evidence: diff touches only the test file (+5/−1: one env value + comment); local suite 61/61 pass (2026-08-27, `bash tests/overflow-sentinel-tap.test.sh`); full `make test` rc=0, "Suite Summary: 39 PASS, 0 FAIL"; shaved-budget mutant still fails the case (rc=124, reproduced independently by Alpha + 3 seats). No product race found → no re-scope needed.

### Review (異種3席, loom-seats S panel, writer=codex-sol)

Blind, fresh-context, read-only seats; full reviews on file (session scratchpad `seats-204/*/out.md`):

| seat | requested/actual | verdict | key evidence |
| --- | --- | --- | --- |
| GLM 5.3 | glm-5.3 / glm-5.3 | **GO** | Built mutants C/D: derivation-in-off-path mutant → rc=124 @ TR=12 (caught); confirmed 12 is the largest safe integer (TR=13 → derived 2s ≈ real elapsed → racy oracle). MINOR: oracle coupled to finalize default 10 — mitigated by existing `only 9s` warning case pinning default+formula; no action needed. |
| Kimi K3 | kimi-k3 / kimi-k3 | **GO** | Independent worktree-copy mutant: exactly 1 failure (the guarded case, rc=124); independent local measurement (overhead 0.845–0.856s > old 0.8s headroom); neighbor cases (TR=20 warning, TR=4 partial-timeout) verified unaffected. MINOR ×2: pre-existing harness properties (0.2s mutant-catch margin vs poll granularity; finalize-default dependency), not introduced by this diff. |
| Grok 4.6 | grok-4.6 / grok-4.6 | **GO** | Temp-dir mutant → rc=124; scope/diff match verified by command; happy-path wall-time measured 2.058s (no suite-time impact). No findings. |

Convergence: all 3 seats independently hunted the named worst failure shape ("flake gone
while the proof is gone") and independently confirmed via mutants that it does not occur.
No CRITICAL/MAJOR from any seat; MINORs are pre-existing design properties, recorded above.

**CI**: pre-merge `test-lint` on this PR = see checks below (gate); ci-matrix evidence = the two dispatch runs above.
**release**: N/A — docs/10 T-5 類型② (test-only internal change: no user-facing behavior, public API, or distributed artifact changes).
**previous release**: v0.19.3 (#203, 2026-08-26) — fulfilled: annotated tag + GitHub Release exist ([v0.19.3](https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.19.3), listed Latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
