### PR TITLE
task-runner: sentinel ledger confluence + task-level task_end (#187)

### DIFF
--- a/docs/design/159-overflow-sentinel/DESIGN.md
+++ b/docs/design/159-overflow-sentinel/DESIGN.md
@@ -295,3 +295,7 @@ task_end: {ts, started_at, task_id, outcome: completed|overflowed|decomposed|abo
   task-level `task_end` は ledger-confluence follow-up へ延期する。nudge delivery は next-step boundary のため、
   発火 attempt で task が終了した場合は nudge 未配送となる。TTFB v1 は run-start→first assistant byte のみで、
   inter-turn stall detection は passive stream で request boundary を観測できる joint-design follow-up へ延期する
+- v0.5.4（2026-08-27・#187 application note）: `sentinel-events.jsonl` を task-runner sole-writer の
+  per-task `ledger.jsonl` へ bounded・fail-open に fold し、driver の実 terminal state から distinct な
+  task-level `task_end` と atomic `task-end.json` receipt を生成する ledger-confluence を適用。
+  per-run `attempt_end` と monitor の schema/state は変更しない。

--- a/docs/design/159-overflow-sentinel/DESIGN.md
+++ b/docs/design/159-overflow-sentinel/DESIGN.md
@@ -299,4 +299,6 @@ task_end: {ts, started_at, task_id, outcome: completed|overflowed|decomposed|abo
   per-task `ledger.jsonl` へ bounded・fail-open に fold し、driver の実 terminal state から distinct な
   task-level `task_end` と atomic `task-end.json` receipt を生成する ledger-confluence を適用。
   `window-error` は infra として fresh-session retry し、retry を焼き切った最終 driver も `window-error` の場合だけ exhausted DLQ を `overflowed` に写像する。
+  outcome ownership は裁定済み設計として FINAL burned attempt の分類に属し（codex r2 の any-attempt derivation は棄却）、途中に overflow evidence があっても最終 attempt が non-window failure の mixed run は `aborted` とし、overflow evidence は folded `attempt_end` records に保持する。
+  また `maximum context length` / `context window` は error-shape guard 付きのままとする（main の unguarded arm に対する deliberate prose-hardening であり、retry fix 後のコストは outcome label だけで retry budget には影響しない）。
   per-run `attempt_end` と monitor の schema/state は変更しない。

--- a/docs/design/159-overflow-sentinel/DESIGN.md
+++ b/docs/design/159-overflow-sentinel/DESIGN.md
@@ -298,4 +298,5 @@ task_end: {ts, started_at, task_id, outcome: completed|overflowed|decomposed|abo
 - v0.5.4（2026-08-27・#187 application note）: `sentinel-events.jsonl` を task-runner sole-writer の
   per-task `ledger.jsonl` へ bounded・fail-open に fold し、driver の実 terminal state から distinct な
   task-level `task_end` と atomic `task-end.json` receipt を生成する ledger-confluence を適用。
+  `window-error` は infra として fresh-session retry し、retry を焼き切った最終 driver も `window-error` の場合だけ exhausted DLQ を `overflowed` に写像する。
   per-run `attempt_end` と monitor の schema/state は変更しない。

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -132,6 +132,24 @@ review notification、48時間を超える沈黙、設定 threshold 以上の ze
   または PATH lookup 前提の設定は runner 実行前に移行してください。`HERMES_STEP_CMD`、
   `HERMES_PROBE_CMD`、`TR_PUSH_CMD` は whitespace で分割して argv 配列にし、PATH 解決される
   通常の実行可能ファイル名も使えます。
+- `TR_LEDGER_FOLD_TOTAL_MAX_BYTES` は attempt ごとの sentinel fold budget（既定 16 MiB）です。
+  `TR_LEDGER_FOLD_MAX_BYTES` は bounded fold loop の chunk size（既定 4 MiB）であり、pass 全体の
+  上限ではありません。total budget を使い切った attempt は以後 permanent に fold-quiescent となり、
+  receipt は `fold_complete:false` のままです。
+
+feature-era の各 task artifact には append-only の `ledger.jsonl` があります。writer は task runner
+だけです。runner は `init` を追加し、各 attempt の `sentinel-events.jsonl` の complete line を
+driver 所有の task/attempt/run/seq identity で fold し、version 付き task-level `task_end` を projection
+します。不正な source line も `schema:"raw"` と `parse_error:true` を付けて保持し、budget または
+oversize による loss は `fold_done`、`fold_oversize_line`、terminal な `fold_exhausted` に明示します。
+ledger failure は fail-open の telemetry failure であり、delivered/DLQ transition を rollback しません。
+
+`task-end.json` は atomic な task-level receipt です。最初の `ts`、`started_at`、`outcome`、
+`terminal_reason` は immutable です。reconcile は folded-state fingerprint が変わった場合だけ
+`receipt_version` を増やして evidence aggregate を修復し、`fold_complete` を再計算します。また、
+現 receipt version の valid な ledger projection が 1 件あることを独立に保証します。`delivered` は
+常に `completed`、DLQ は final driver classification が `window-error` の場合だけ `overflowed`、
+それ以外は `aborted` です。sentinel の `window_error` は evidence であり outcome を決めません。
 
 ### Claude Code overflow sentinel の環境変数
 
@@ -183,7 +201,8 @@ append-only の `turn` series から再構成できます。slope-only fire で�
 `threshold_hit` を省略します。
 
 `sentinel-events.jsonl` は append-only で、`turn`、`fire`、`alert`、run ごとの
-`attempt_end` を収録します。task-level の `task_end` は ledger-confluence integration へ延期します。
+`attempt_end` を収録します。task runner はこれらを per-task ledger へ fold し、上記の distinct な
+task-level `task_end` を emit します。
 `attempt.json` は厳密に `schema_version`、`task_id`、`attempt`、`mode`、`model`、
 `ctx_window`、`ctx_window_source`、`started_at`、nullable な `first_byte_at`、
 `cli_exit_code`、`tap_status_final`、`fired`、`events_path` の field で atomic に確定します。attempt identity は

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -158,6 +158,29 @@ configuration.
   before running the runner. `HERMES_STEP_CMD`, `HERMES_PROBE_CMD`, and
   `TR_PUSH_CMD` are whitespace-split into argv arrays and may use PATH-resolved
   regular executable names.
+- `TR_LEDGER_FOLD_TOTAL_MAX_BYTES` is the per-attempt sentinel fold budget
+  (default 16 MiB). `TR_LEDGER_FOLD_MAX_BYTES` is the bounded fold loop chunk
+  size (default 4 MiB), not a per-pass ceiling. When the total budget is
+  exhausted, that attempt becomes permanently fold-quiescent and its receipt
+  remains `fold_complete:false`.
+
+Each feature-era task artifact has an append-only `ledger.jsonl`. The task
+runner is its sole writer: it adds the `init` record, folds complete lines from
+each attempt's `sentinel-events.jsonl` under driver-owned task/attempt/run/seq
+identity, and projects versioned task-level `task_end` records. Malformed source
+lines are retained with `schema:"raw"` and `parse_error:true`; budget or
+oversize loss is explicit in `fold_done`, `fold_oversize_line`, and the terminal
+`fold_exhausted` record. Ledger failures are fail-open telemetry failures and do
+not roll back a delivered/DLQ transition.
+
+`task-end.json` is the atomic task-level receipt. Its first `ts`, `started_at`,
+`outcome`, and `terminal_reason` are immutable. Reconciliation increments
+`receipt_version` only when the folded-state fingerprint changes, repairs the
+evidence aggregates, recomputes `fold_complete`, and independently ensures one
+valid ledger projection for the current receipt version. `delivered` always
+maps to `completed`; a DLQ maps to `overflowed` only when the final driver
+classification is `window-error`, otherwise to `aborted`. Sentinel
+`window_error` is evidence and never controls that outcome.
 
 ### Claude Code overflow sentinel environment
 
@@ -219,8 +242,9 @@ series. On slope-only fires, `threshold_hit` is omitted because neither level
 threshold crossed.
 
 `sentinel-events.jsonl` is append-only and contains `turn`, `fire`, `alert`, and
-per-run `attempt_end` records. The task-level `task_end` event is deferred to the
-ledger-confluence integration. `attempt.json` is atomically finalized with exactly
+per-run `attempt_end` records. The task runner folds those records into the
+per-task ledger and emits the distinct task-level `task_end` described above.
+`attempt.json` is atomically finalized with exactly
 these fields: `schema_version`, `task_id`, `attempt`, `mode`, `model`,
 `ctx_window`, `ctx_window_source`, `started_at`, nullable `first_byte_at`,
 `cli_exit_code`, `tap_status_final`, `fired`, and `events_path`. Attempt identity

--- a/scripts/lib-classify.sh
+++ b/scripts/lib-classify.sh
@@ -66,12 +66,20 @@ _classify_read_bounded() {
 
 _classify_is_window_error() {
   local evidence=${1-}
+  local allow_legacy_stderr=${2:-0}
   local line
   while IFS= read -r line; do
     case "$line" in
       *context_length_exceeded*|*'prompt is too long'*|*'input length and max_tokens exceed context limit'*)
         return 0
         ;;
+    esac
+    if [[ "$allow_legacy_stderr" = 1 ]]; then
+      case "$line" in
+        *'context length exceeded'*|*context-length-exceeded*|*'context overflow'*|*'too many tokens'*) return 0 ;;
+      esac
+    fi
+    case "$line" in
       *'maximum context length'*|*'context window'*)
         # These phrases are common in ordinary prose; require the same line to
         # look like a persisted error diagnostic.
@@ -127,7 +135,7 @@ classify_failure() {
       return 0
       ;;
   esac
-  if _classify_is_window_error "$stderr_lower"; then
+  if _classify_is_window_error "$stderr_lower" 1; then
     printf '%s\n' window-error
     return 0
   fi

--- a/scripts/lib-classify.sh
+++ b/scripts/lib-classify.sh
@@ -64,6 +64,26 @@ _classify_read_bounded() {
   fi
 }
 
+_classify_is_window_error() {
+  local evidence=${1-}
+  local line
+  while IFS= read -r line; do
+    case "$line" in
+      *context_length_exceeded*|*'prompt is too long'*|*'input length and max_tokens exceed context limit'*)
+        return 0
+        ;;
+      *'maximum context length'*|*'context window'*)
+        # These phrases are common in ordinary prose; require the same line to
+        # look like a persisted error diagnostic.
+        case "$line" in
+          *error*|*exception*|*fail*|*invalid*|*exceed*|*'too long'*|*limit*|*'status code 4'*|*'status code 5'*) return 0 ;;
+        esac
+        ;;
+    esac
+  done <<<"$evidence"
+  return 1
+}
+
 classify_failure() {
   local exit_code=$1
   local stderr_file=$2
@@ -72,6 +92,8 @@ classify_failure() {
   local stdout_message=''
   local stderr_cleaned=''
   local stdout_cleaned=''
+  local stderr_lower=''
+  local stdout_lower=''
   local LC_ALL=C
   export LC_ALL
 
@@ -86,16 +108,14 @@ classify_failure() {
   stdout_message=$(_classify_read_bounded "$stdout_file")
   stderr_cleaned=$(printf '%s' "$stderr_message" | tr -d '[:space:]')
   stdout_cleaned=$(printf '%s' "$stdout_message" | tr -d '[:space:]')
+  stderr_lower=$(printf '%s' "$stderr_message" | tr '[:upper:]' '[:lower:]')
+  stdout_lower=$(printf '%s' "$stdout_message" | tr '[:upper:]' '[:lower:]')
 
   # Stderr is the authoritative diagnostics stream. If it matches any bucket,
   # its verdict wins; stdout is consulted only when stderr matches no bucket.
   case "$stderr_message" in
     *' 408 '*|*'"status":408'*|*'"status": 408'*|*'408 Request Timeout'*|*'status code 408'*|*' 429 '*|*'"status":429'*|*'"status": 429'*|*'429 Too Many Requests'*|*'status code 429'*|*'returned error: 429'*|*'"code":429'*|*'"code": 429'*|*'rate_limit_error'*)
       printf '%s\n' transient
-      return 0
-      ;;
-    *'context_length_exceeded'*|*'context length exceeded'*|*'context-length-exceeded'*|*'context overflow'*|*'maximum context length'*|*'too many tokens'*)
-      printf '%s\n' context-overflow
       return 0
       ;;
     *' 401 '*|*'"status":401'*|*'"status": 401'*|*'401 Unauthorized'*|*'status code 401'*|*' 403 '*|*'"status":403'*|*'"status": 403'*|*'403 Forbidden'*|*'status code 403'*|*'authentication_error'*|*'invalid_api_key'*|*'invalid api key'*|*'unauthorized'*|*'forbidden'*|*'Not logged in'*|*'not logged in'*|*'Please run /login'*|*'login required'*|*'Login required'*|*'permission_error'*|*'billing_error'*|*'invalid_grant'*)
@@ -107,17 +127,17 @@ classify_failure() {
       return 0
       ;;
   esac
+  if _classify_is_window_error "$stderr_lower"; then
+    printf '%s\n' window-error
+    return 0
+  fi
 
   # Stdout intentionally excludes prose-prone markers: bare space-delimited 4xx
   # numbers; unauthorized/forbidden; invalid api key/request/input/parameter/model;
-  # context length/overflow/token prose variants; and lowercase login banners.
+  # unrestricted context-window prose; and lowercase login banners.
   case "$stdout_message" in
     *'"status":408'*|*'"status": 408'*|*'408 Request Timeout'*|*'status code 408'*|*'"status":429'*|*'"status": 429'*|*'429 Too Many Requests'*|*'status code 429'*|*'returned error: 429'*|*'"code":429'*|*'"code": 429'*|*'rate_limit_error'*)
       printf '%s\n' transient
-      return 0
-      ;;
-    *'context_length_exceeded'*)
-      printf '%s\n' context-overflow
       return 0
       ;;
     *'"status":401'*|*'"status": 401'*|*'401 Unauthorized'*|*'status code 401'*|*'"status":403'*|*'"status": 403'*|*'403 Forbidden'*|*'status code 403'*|*'authentication_error'*|*'invalid_api_key'*|*'Not logged in'*|*'Please run /login'*|*'Login required'*|*'permission_error'*|*'billing_error'*|*'invalid_grant'*)
@@ -129,6 +149,10 @@ classify_failure() {
       return 0
       ;;
   esac
+  if _classify_is_window_error "$stdout_lower"; then
+    printf '%s\n' window-error
+    return 0
+  fi
 
   if [[ -z "$stderr_cleaned" && -z "$stdout_cleaned" ]]; then
     printf '%s\n' degenerate

--- a/scripts/task-runner.sh
+++ b/scripts/task-runner.sh
@@ -752,6 +752,43 @@ def reconcile_signature():
     }
 
 
+def reconcile_sources_are_folded(signature):
+    for attempt in signature.get("attempts", []):
+        source_size = attempt.get("source_size")
+        expected_size = 0 if source_size is None else source_size
+        fold_path = os.path.join(artifact_dir, attempt["path"], ".ledger-fold.json")
+        fold_state = read_json(fold_path) or {}
+        if bool(fold_state.get("exhausted")):
+            continue
+        folded_size = fold_state.get("source_bytes_at_fold", 0)
+        if not isinstance(folded_size, int) or folded_size != expected_size:
+            return False
+    return True
+
+
+def reconcile_signature_after_writes(entry_signature):
+    receipt_path = os.path.join(artifact_dir, "task-end.json")
+    receipt = read_json(receipt_path) or {}
+    receipt_stat = file_signature(receipt_path)
+    attempts = []
+    for entry_attempt in entry_signature.get("attempts", []):
+        attempt = dict(entry_attempt)
+        path = os.path.join(artifact_dir, attempt["path"])
+        attempt["fold_state"] = file_signature(os.path.join(path, ".ledger-fold.json"))
+        attempt["attempt_receipt"] = file_signature(os.path.join(path, "attempt.json"))
+        attempts.append(attempt)
+    signature = dict(entry_signature)
+    signature.update({
+        "ledger": file_signature(ledger_path),
+        "state": file_signature(os.path.join(artifact_dir, "state.json")),
+        "receipt_version": receipt.get("receipt_version"),
+        "receipt_mtime_ns": receipt_stat["mtime_ns"] if receipt_stat else None,
+        "receipt_size": receipt_stat["size"] if receipt_stat else None,
+        "attempts": attempts,
+    })
+    return signature
+
+
 def catchup():
     ensure_init()
     for path, number in all_attempt_dirs():
@@ -997,14 +1034,14 @@ def reconcile_terminal():
     reconcile_path = os.path.join(artifact_dir, ".ledger-reconcile.json")
     signature = reconcile_signature()
     previous = read_json(reconcile_path)
-    if previous and previous.get("signature") == signature:
+    if previous and previous.get("signature") == signature and reconcile_sources_are_folded(signature):
         return
     catchup()
     emit_receipt()
     project_receipt()
     atomic_json(reconcile_path, {
         "schema": 1,
-        "signature": reconcile_signature(),
+        "signature": reconcile_signature_after_writes(signature),
     })
 
 

--- a/scripts/task-runner.sh
+++ b/scripts/task-runner.sh
@@ -18,10 +18,12 @@ TR_SPAWN_STEP=${TR_SPAWN_STEP:-}
 TR_PUSH_CMD=${TR_PUSH_CMD:-}
 TR_CRASH_AFTER=${TR_CRASH_AFTER:-}
 TR_TEMPLATE_OVERRIDE=${TR_TEMPLATE_OVERRIDE:-}
+TR_LEDGER_FOLD_TOTAL_MAX_BYTES=${TR_LEDGER_FOLD_TOTAL_MAX_BYTES-16777216}
+TR_LEDGER_FOLD_MAX_BYTES=${TR_LEDGER_FOLD_MAX_BYTES-4194304}
 # Replay payload cap: values are clamped to a 64-byte floor and 1048576-byte ceiling.
 TR_GATE_REPLAY_MAX_BYTES=${TR_GATE_REPLAY_MAX_BYTES-4096}
 
-for integer_var in TR_STEP_TIMEOUT_S TR_GRACE_S TR_DONECHECK_TIMEOUT_S TR_GATE_REPLAY_MAX_BYTES; do
+for integer_var in TR_STEP_TIMEOUT_S TR_GRACE_S TR_DONECHECK_TIMEOUT_S TR_GATE_REPLAY_MAX_BYTES TR_LEDGER_FOLD_TOTAL_MAX_BYTES TR_LEDGER_FOLD_MAX_BYTES; do
   integer_value=${!integer_var}
   case "$integer_value" in
     ''|*[!0-9]*|0[0-9]*)
@@ -30,11 +32,15 @@ for integer_var in TR_STEP_TIMEOUT_S TR_GRACE_S TR_DONECHECK_TIMEOUT_S TR_GATE_R
       ;;
   esac
 done
+if (( TR_LEDGER_FOLD_MAX_BYTES == 0 )); then
+  printf 'TR_LEDGER_FOLD_MAX_BYTES must be greater than zero\n' >&2
+  exit 2
+fi
 
 case "$TR_CRASH_AFTER" in
-  ''|spawn|stamp|infra-requeue|infra-terminal|verifying|donecheck-pass|deliver-terminal|dlq-terminal) ;;
+  ''|spawn|stamp|infra-requeue|infra-terminal|verifying|donecheck-pass|deliver-terminal|dlq-terminal|terminal-pre-ledger) ;;
   *)
-    printf 'TR_CRASH_AFTER must be one of: spawn, stamp, infra-requeue, infra-terminal, verifying, donecheck-pass, deliver-terminal, dlq-terminal\n' >&2
+    printf 'TR_CRASH_AFTER must be one of: spawn, stamp, infra-requeue, infra-terminal, verifying, donecheck-pass, deliver-terminal, dlq-terminal, terminal-pre-ledger\n' >&2
     exit 2
     ;;
 esac
@@ -274,6 +280,7 @@ init_state_if_missing() {
     lease_owner_sentinel=''
     terminal_reason=''
     write_state "$state_file"
+    ensure_ledger_init "$(dirname "$state_file")"
   fi
 }
 
@@ -282,6 +289,705 @@ utc_now() {
 from datetime import datetime, timezone
 print(datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
 PY
+}
+
+# The driver is the sole ledger writer. Every ledger read/append and every
+# derived receipt update is routed through this fail-open boundary so telemetry
+# can never abort queue progress under `set -e`.
+ledger_append_best_effort() {
+  local operation=$1
+  local artifact_dir=$2
+  local attempt_dir=${3:-}
+  local attempt=${4:-}
+  local force_marker=${5:-0}
+  local failure_reason=''
+  if ! failure_reason=$(python3 -B - "$operation" "$artifact_dir" "$attempt_dir" "$attempt" \
+    "$force_marker" "$TR_LEDGER_FOLD_TOTAL_MAX_BYTES" "$TR_LEDGER_FOLD_MAX_BYTES" <<'PY'
+import datetime
+import glob
+import hashlib
+import json
+import math
+import os
+import sys
+
+operation, artifact_dir, attempt_dir, attempt, force_text, total_text, chunk_text = sys.argv[1:8]
+ledger_path = os.path.join(artifact_dir, "ledger.jsonl")
+task_id = os.path.basename(os.path.normpath(artifact_dir))
+total_budget = int(total_text)
+chunk_bytes = int(chunk_text)
+
+
+def utc_now():
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def atomic_json(path, value):
+    tmp = "%s.tmp.%d" % (path, os.getpid())
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(value, handle, sort_keys=True, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    os.replace(tmp, path)
+
+
+def append_records(records):
+    if not records:
+        return
+    os.makedirs(artifact_dir, exist_ok=True)
+    repair_tail()
+    with open(ledger_path, "ab") as handle:
+        for record in records:
+            encoded = json.dumps(
+                record, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+            ).encode("utf-8", "surrogateescape")
+            handle.write(encoded + b"\n")
+
+
+def valid_ledger_records():
+    records = []
+    if not os.path.isfile(ledger_path):
+        return records
+    with open(ledger_path, "rb") as handle:
+        for raw in handle:
+            if not raw.endswith(b"\n"):
+                continue
+            try:
+                value = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+            if isinstance(value, dict):
+                records.append(value)
+    return records
+
+
+def ensure_init():
+    if os.path.exists(ledger_path):
+        return
+    append_records([{
+        "event": "init",
+        "ledger_schema": 1,
+        "task_id": task_id,
+    }])
+
+
+def read_json(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            value = json.load(handle)
+        return value if isinstance(value, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def attempt_run(path):
+    receipt = read_json(os.path.join(path, "attempt.json")) or {}
+    if receipt.get("started_at"):
+        return str(receipt["started_at"])
+    driver = read_json(os.path.join(path, "driver.json")) or {}
+    return "unknown-" + str(driver.get("started") or "unknown")
+
+
+def initial_fold_state(path, attempt_value, run):
+    state_path = os.path.join(path, ".ledger-fold.json")
+    state = read_json(state_path)
+    # Once assigned, the run key is immutable. In particular, a late
+    # attempt.json must not replace unknown-<driver.started> and reset cursor 0.
+    if state and state.get("attempt") == attempt_value and state.get("run"):
+        return state
+    state = {
+        "attempt": attempt_value,
+        "run": run,
+        "source_bytes_at_fold": 0,
+        "source_lines": 0,
+        "folded_lines": 0,
+        "folded_bytes": 0,
+        "dropped_lines": 0,
+        "dropped_bytes": 0,
+        "budget_remaining": total_budget,
+        "truncated": False,
+        "exhausted": False,
+        "quiescent": False,
+        "marker_written": False,
+    }
+    # Recover the last durable marker if the side receipt was lost after an
+    # append. The run key prevents a quarantined retry from borrowing state.
+    driver = read_json(os.path.join(path, "driver.json")) or {}
+    unknown_driver_run = "unknown-" + str(driver.get("started") or "unknown")
+    durable = valid_ledger_records()
+    recover_run = run
+    if not any(
+        record.get("event") == "fold_done"
+        and record.get("attempt") == attempt_value
+        and record.get("run") == run
+        for record in durable
+    ) and any(
+        record.get("event") == "fold_done"
+        and record.get("attempt") == attempt_value
+        and record.get("run") == unknown_driver_run
+        for record in durable
+    ):
+        recover_run = unknown_driver_run
+        state["run"] = recover_run
+    for record in durable:
+        if record.get("event") != "fold_done":
+            continue
+        if record.get("attempt") != attempt_value or record.get("run") != recover_run:
+            continue
+        for key in (
+            "source_bytes_at_fold", "source_lines", "folded_lines", "folded_bytes",
+            "dropped_lines", "dropped_bytes", "budget_remaining",
+            "truncated", "exhausted", "quiescent",
+        ):
+            if key in record:
+                state[key] = record[key]
+        state["marker_written"] = True
+    if any(
+        record.get("event") == "fold_exhausted"
+        and record.get("attempt") == attempt_value
+        and record.get("run") == run
+        for record in durable
+    ):
+        state["exhausted"] = True
+        state["truncated"] = True
+        state["budget_remaining"] = 0
+    return state
+
+
+def source_quiescent(path, source_exists):
+    if os.path.isfile(os.path.join(path, "overflow-stream.eof")):
+        return True
+    # attempt.json is written only after the monitor emits attempt_end and
+    # exits its processing loop, so it is also positive monitor-gone evidence.
+    if os.path.isfile(os.path.join(path, "attempt.json")):
+        return True
+    # With no sentinel artifacts at all, the monitor never ran.
+    if not source_exists:
+        return True
+    state = read_json(os.path.join(artifact_dir, "state.json")) or {}
+    if state.get("status") in ("delivered", "dlq") and state.get("lease") is None:
+        return True
+    lease = state.get("lease") if isinstance(state.get("lease"), dict) else {}
+    monitor_pid = lease.get("pid") if lease else None
+    if isinstance(monitor_pid, int) and monitor_pid > 0:
+        try:
+            os.kill(monitor_pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            return False
+        else:
+            return False
+    return False
+
+
+def envelope_source(raw, attempt_value, run, seq):
+    try:
+        source = json.loads(raw[:-1].decode("utf-8"))
+        if not isinstance(source, dict):
+            raise ValueError("source record is not an object")
+    except (UnicodeDecodeError, ValueError):
+        source = {
+            "schema": "raw",
+            "parse_error": True,
+            "raw": raw[:-1].decode("utf-8", "replace"),
+        }
+    record = dict(source)
+    if "task_id" in source and source.get("task_id") != task_id:
+        record["source_task_id"] = source.get("task_id")
+    if "attempt" in source and str(source.get("attempt")) != attempt_value:
+        record["source_attempt"] = source.get("attempt")
+    record.update({
+        "task_id": task_id,
+        "attempt": attempt_value,
+        "run": run,
+        "seq": seq,
+        "ledger_schema": 1,
+    })
+    return record
+
+
+def fold_one(path, attempt_value, force_marker=False):
+    ensure_init()
+    source_path = os.path.join(path, "sentinel-events.jsonl")
+    source_exists = os.path.isfile(source_path)
+    run = attempt_run(path)
+    state_path = os.path.join(path, ".ledger-fold.json")
+    state = initial_fold_state(path, attempt_value, run)
+    run = str(state.get("run") or run)
+    if bool(state.get("exhausted")):
+        return
+
+    cursor_before = int(state.get("source_bytes_at_fold", 0))
+    complete_end = 0
+    if source_exists:
+        source_size = os.path.getsize(source_path)
+        with open(source_path, "rb") as handle:
+            scan_end = source_size
+            while scan_end > 0:
+                scan_start = max(0, scan_end - chunk_bytes)
+                handle.seek(scan_start)
+                block = handle.read(scan_end - scan_start)
+                newline = block.rfind(b"\n")
+                if newline >= 0:
+                    complete_end = scan_start + newline + 1
+                    break
+                scan_end = scan_start
+    if complete_end < cursor_before:
+        # Append-only violation: preserve the old cursor and expose truncation.
+        complete_end = cursor_before
+    unseen_at_entry = complete_end - cursor_before
+    budget_at_entry = max(0, int(state.get("budget_remaining", total_budget)))
+    allowance = min(unseen_at_entry, budget_at_entry)
+    desired_start = complete_end - allowance
+
+    def count_newlines(start, end):
+        count = 0
+        with open(source_path, "rb") as handle:
+            handle.seek(start)
+            remaining = end - start
+            while remaining > 0:
+                block = handle.read(min(chunk_bytes, remaining))
+                if not block:
+                    break
+                count += block.count(b"\n")
+                remaining -= len(block)
+        return count
+
+    aligned_start = cursor_before
+    if source_exists and desired_start > cursor_before:
+        with open(source_path, "rb") as handle:
+            handle.seek(desired_start - 1)
+            if handle.read(1) == b"\n":
+                aligned_start = desired_start
+            else:
+                handle.seek(desired_start)
+                aligned_start = desired_start
+                while aligned_start < complete_end:
+                    block = handle.read(min(chunk_bytes, complete_end - aligned_start))
+                    newline = block.find(b"\n")
+                    if newline >= 0:
+                        aligned_start += newline + 1
+                        break
+                    aligned_start += len(block)
+
+    dropped_bytes_pass = aligned_start - cursor_before
+    dropped_lines_pass = count_newlines(cursor_before, aligned_start) if dropped_bytes_pass else 0
+    folded_lines_pass = 0
+    folded_bytes_pass = 0
+    folded_records = []
+    seq = int(state.get("source_lines", 0)) + dropped_lines_pass
+
+    # TR_LEDGER_FOLD_MAX_BYTES is a loop chunk size, never a pass ceiling.
+    chunk_used = 0
+    if source_exists:
+        with open(source_path, "rb") as handle:
+            handle.seek(aligned_start)
+            position = aligned_start
+            while position < complete_end:
+                parts = []
+                line_size = 0
+                oversize = False
+                while position < complete_end:
+                    part = handle.readline(min(chunk_bytes + 1, complete_end - position))
+                    if not part:
+                        break
+                    position += len(part)
+                    line_size += len(part)
+                    if not oversize:
+                        if line_size > chunk_bytes:
+                            parts = []
+                            oversize = True
+                        else:
+                            parts.append(part)
+                    if part.endswith(b"\n"):
+                        break
+                seq += 1
+                if oversize:
+                    dropped_lines_pass += 1
+                    dropped_bytes_pass += line_size
+                    state["truncated"] = True
+                    folded_records.append({
+                        "event": "fold_oversize_line",
+                        "task_id": task_id,
+                        "attempt": attempt_value,
+                        "run": run,
+                        "seq": seq,
+                        "line_bytes": line_size,
+                        "ledger_schema": 1,
+                    })
+                    chunk_used = 0
+                    continue
+                line = b"".join(parts)
+                if chunk_used and chunk_used + line_size > chunk_bytes:
+                    chunk_used = 0
+                folded_records.append(envelope_source(line, attempt_value, run, seq))
+                folded_lines_pass += 1
+                folded_bytes_pass += line_size
+                chunk_used += line_size
+
+    if dropped_bytes_pass:
+        state["truncated"] = True
+    if folded_bytes_pass + dropped_bytes_pass != unseen_at_entry:
+        raise RuntimeError("fold-accounting")
+
+    state["source_bytes_at_fold"] = cursor_before + unseen_at_entry
+    state["source_lines"] = int(state.get("source_lines", 0)) + dropped_lines_pass + folded_lines_pass
+    state["folded_lines"] = int(state.get("folded_lines", 0)) + folded_lines_pass
+    state["folded_bytes"] = int(state.get("folded_bytes", 0)) + folded_bytes_pass
+    state["dropped_lines"] = int(state.get("dropped_lines", 0)) + dropped_lines_pass
+    state["dropped_bytes"] = int(state.get("dropped_bytes", 0)) + dropped_bytes_pass
+    state["budget_remaining"] = max(0, budget_at_entry - unseen_at_entry)
+    new_quiescent = source_quiescent(path, source_exists)
+    quiescence_changed = bool(state.get("quiescent")) != new_quiescent
+    state["quiescent"] = new_quiescent
+
+    should_mark = bool(force_marker) or unseen_at_entry > 0 or quiescence_changed or not state.get("marker_written")
+    records = folded_records
+    exhausted_now = state["budget_remaining"] == 0 and unseen_at_entry > 0
+    if exhausted_now:
+        state["exhausted"] = True
+        state["truncated"] = True
+    if should_mark:
+        marker = {
+            "event": "fold_done",
+            "task_id": task_id,
+            "attempt": attempt_value,
+            "run": run,
+            "folded_lines": state["folded_lines"],
+            "folded_bytes": state["folded_bytes"],
+            "dropped_lines": state["dropped_lines"],
+            "dropped_bytes": state["dropped_bytes"],
+            "source_lines": state["source_lines"],
+            "source_bytes_at_fold": state["source_bytes_at_fold"],
+            "budget_remaining": state["budget_remaining"],
+            "truncated": bool(state["truncated"]),
+            "exhausted": bool(exhausted_now),
+            "quiescent": bool(state["quiescent"]),
+            "ledger_schema": 1,
+        }
+        records.append(marker)
+        state["marker_written"] = True
+    if exhausted_now:
+        records.append({
+            "event": "fold_exhausted",
+            "task_id": task_id,
+            "attempt": attempt_value,
+            "run": run,
+            "source_bytes_at_fold": state["source_bytes_at_fold"],
+            "folded_bytes": state["folded_bytes"],
+            "dropped_bytes": state["dropped_bytes"],
+            "ledger_schema": 1,
+        })
+    append_records(records)
+    atomic_json(state_path, state)
+
+
+def attempt_number(path):
+    base = os.path.basename(path)
+    return base.split(".", 1)[0]
+
+
+def all_attempt_dirs():
+    paths = []
+    for pattern in (
+        os.path.join(artifact_dir, "attempts", "*"),
+        os.path.join(artifact_dir, "attempts-infra", "*"),
+    ):
+        for path in glob.glob(pattern):
+            number = attempt_number(path)
+            if os.path.isdir(path) and number.isdigit():
+                paths.append((int(number), path, number.zfill(3)))
+    return [item[1:] for item in sorted(paths, key=lambda item: (item[0], item[1]))]
+
+
+def catchup():
+    ensure_init()
+    for path, number in all_attempt_dirs():
+        fold_one(path, number, False)
+
+
+def fold_vector():
+    vector = []
+    for path, number in all_attempt_dirs():
+        state = read_json(os.path.join(path, ".ledger-fold.json"))
+        if not state:
+            continue
+        vector.append({
+            "attempt": number,
+            "run": state.get("run"),
+            "folded_lines": int(state.get("folded_lines", 0)),
+            "source_bytes_at_fold": int(state.get("source_bytes_at_fold", 0)),
+            "truncated": bool(state.get("truncated")),
+            "exhausted": bool(state.get("exhausted")),
+            "quiescent": bool(state.get("quiescent")),
+        })
+    return vector
+
+
+def parse_time(value):
+    if not value:
+        return None
+    value = str(value)
+    if value.startswith("unknown-"):
+        value = value[len("unknown-"):]
+    try:
+        return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=datetime.timezone.utc
+        )
+    except ValueError:
+        return None
+
+
+def ordered_drivers():
+    drivers = []
+    for path, number in all_attempt_dirs():
+        driver = read_json(os.path.join(path, "driver.json"))
+        if driver:
+            drivers.append((int(number), str(driver.get("started") or ""), driver))
+    return [item[2] for item in sorted(drivers, key=lambda item: (item[0], item[1]))]
+
+
+def tagged_turns(attempt_value, values):
+    if not isinstance(values, list):
+        return []
+    return [{"attempt": attempt_value, "turn_idx": value} for value in values]
+
+
+def reducer(status, terminal_reason, emitted_at, vector):
+    records = valid_ledger_records()
+    folded = [
+        record for record in records
+        if record.get("run") is not None and record.get("attempt") is not None
+        and record.get("event") not in ("fold_done", "fold_exhausted", "fold_oversize_line")
+    ]
+    runs = {}
+    run_order = []
+    turn_values = []
+    for record in folded:
+        key = (str(record.get("attempt")), str(record.get("run")))
+        if key not in runs:
+            runs[key] = {"last_end": None, "started_at": record.get("started_at") or record.get("run")}
+            run_order.append(key)
+        if record.get("event") == "attempt_end":
+            runs[key]["last_end"] = record
+            runs[key]["started_at"] = record.get("started_at") or runs[key]["started_at"]
+        if record.get("event") == "turn":
+            value = record.get("injected_last")
+            if not isinstance(value, (int, float)):
+                parts = [record.get(name) for name in (
+                    "input_tokens", "cache_read_tokens", "cache_creation_tokens"
+                )]
+                if all(isinstance(part, (int, float)) for part in parts):
+                    value = sum(parts)
+            if isinstance(value, (int, float)) and math.isfinite(float(value)):
+                turn_values.append(float(value))
+
+    ends = [(key, runs[key]["last_end"]) for key in run_order if runs[key]["last_end"]]
+    latest = ends[-1][1] if ends else None
+    started_candidates = []
+    for key in run_order:
+        parsed = parse_time(runs[key].get("started_at"))
+        if parsed:
+            started_candidates.append(parsed)
+    drivers = ordered_drivers()
+    first_driver = drivers[0] if drivers else None
+    driver = drivers[-1] if drivers else None
+    if started_candidates:
+        started_dt = min(started_candidates)
+        started_at = started_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    elif first_driver and parse_time(first_driver.get("started")):
+        started_dt = parse_time(first_driver.get("started"))
+        started_at = first_driver.get("started")
+    else:
+        started_dt = None
+        started_at = None
+    emitted_dt = parse_time(emitted_at)
+    elapsed_s = max(0, int((emitted_dt - started_dt).total_seconds())) if emitted_dt and started_dt else None
+
+    def reduced_or(field):
+        sourced = [end.get(field) for _, end in ends if field in end]
+        return any(bool(value) for value in sourced) if sourced else None
+
+    window_error = reduced_or("window_error")
+    runtime_compaction = reduced_or("runtime_compaction")
+    compaction_suspected = reduced_or("compaction_suspected")
+    token_values = [
+        end.get("total_tokens") for _, end in ends
+        if isinstance(end.get("total_tokens"), (int, float))
+    ]
+    total_tokens = sum(token_values) if token_values else None
+    maxima = []
+    for _, end in ends:
+        summary = end.get("injected_summary")
+        if isinstance(summary, dict) and isinstance(summary.get("max"), (int, float)):
+            maxima.append(summary["max"])
+    injected_max = max(maxima) if maxima else None
+    injected_source = None
+    if turn_values:
+        last = turn_values[-3:]
+        last3_mean = sum(last) / float(len(last))
+    elif latest and isinstance(latest.get("injected_summary"), dict):
+        last3_mean = latest["injected_summary"].get("last3_mean")
+        injected_source = "attempt_summary"
+    else:
+        last3_mean = None
+    fired_turns = [] if any("fired_turns" in end for _, end in ends) else None
+    alert_turns = [] if any("alert_turns" in end for _, end in ends) else None
+    for key, end in ends:
+        if fired_turns is not None:
+            fired_turns.extend(tagged_turns(key[0], end.get("fired_turns")))
+        if alert_turns is not None:
+            alert_turns.extend(tagged_turns(key[0], end.get("alert_turns")))
+
+    if status == "delivered":
+        outcome = "completed"
+    else:
+        outcome = "overflowed" if driver and driver.get("classified") == "window-error" else "aborted"
+    any_sentinel = bool(folded)
+    result = {
+        "ledger_schema": 1,
+        "task_id": task_id,
+        "ts": emitted_at,
+        "started_at": started_at,
+        "elapsed_s": elapsed_s,
+        "outcome": outcome,
+        "terminal_reason": terminal_reason if status == "dlq" else None,
+        "window_error": window_error,
+        "runtime_compaction": runtime_compaction,
+        "compaction_suspected": compaction_suspected,
+        "total_tokens": total_tokens,
+        "injected_summary": {"max": injected_max, "last3_mean": last3_mean},
+        "fired_turns": fired_turns,
+        "alert_turns": alert_turns,
+        "nudge_disposition_final": latest.get("nudge_disposition_final") if latest else None,
+        "tap_status": latest.get("tap_status") if latest else (None if any_sentinel else "never-ran"),
+        "run_meta": latest.get("run_meta") if latest else None,
+    }
+    if injected_source:
+        result["injected_summary_source"] = injected_source
+    return result
+
+
+def emit_receipt():
+    ensure_init()
+    state = read_json(os.path.join(artifact_dir, "state.json"))
+    if not state or state.get("status") not in ("delivered", "dlq"):
+        return
+    vector = fold_vector()
+    canonical = json.dumps(vector, sort_keys=True, separators=(",", ":"))
+    fingerprint = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    quiescent = all(item["quiescent"] for item in vector)
+    truncated = any(item["truncated"] or item["exhausted"] for item in vector)
+    fold_complete = quiescent and not truncated
+    receipt_path = os.path.join(artifact_dir, "task-end.json")
+    old = read_json(receipt_path)
+    if old and old.get("fold_fingerprint") == fingerprint:
+        return
+    version = int(old.get("receipt_version", 0)) + 1 if old else 1
+    emitted_at = old.get("ts") if old else utc_now()
+    reduced = reducer(
+        str(state.get("status")),
+        state.get("terminal_reason"),
+        emitted_at,
+        vector,
+    )
+    if old:
+        for immutable in ("ts", "started_at", "elapsed_s", "outcome", "terminal_reason"):
+            reduced[immutable] = old.get(immutable)
+    reduced.update({
+        "receipt_version": version,
+        "fold_fingerprint": fingerprint,
+        "fold_state": vector,
+        "fold_complete": fold_complete,
+        "fold_incomplete": not fold_complete,
+    })
+    atomic_json(receipt_path, reduced)
+
+
+def repair_tail():
+    if not os.path.isfile(ledger_path) or os.path.getsize(ledger_path) == 0:
+        return
+    with open(ledger_path, "rb+") as handle:
+        handle.seek(-1, os.SEEK_END)
+        if handle.read(1) != b"\n":
+            handle.seek(0, os.SEEK_END)
+            handle.write(b"\n")
+
+
+def project_receipt():
+    receipt = read_json(os.path.join(artifact_dir, "task-end.json"))
+    if not receipt:
+        return
+    repair_tail()
+    version = receipt.get("receipt_version")
+    if any(
+        record.get("event") == "task_end"
+        and record.get("task_id") == task_id
+        and record.get("receipt_version") == version
+        for record in valid_ledger_records()
+    ):
+        return
+    projection = dict(receipt)
+    projection["event"] = "task_end"
+    projection["ledger_schema"] = 1
+    append_records([projection])
+    if not any(
+        record.get("event") == "task_end"
+        and record.get("task_id") == task_id
+        and record.get("receipt_version") == version
+        for record in valid_ledger_records()
+    ):
+        raise RuntimeError("task-end-projection-validation")
+
+
+try:
+    if operation == "init":
+        ensure_init()
+    elif operation == "fold":
+        fold_one(attempt_dir, attempt, force_text == "1")
+    elif operation == "catchup":
+        catchup()
+    elif operation == "receipt":
+        emit_receipt()
+    elif operation == "project":
+        project_receipt()
+    else:
+        raise ValueError("unknown-operation")
+except Exception as exc:
+    reason = getattr(exc, "errno", None)
+    if reason is not None:
+        reason = "errno-%s" % reason
+    else:
+        reason = str(exc).strip().replace("\n", " ") or exc.__class__.__name__
+    print(reason)
+    raise SystemExit(1)
+PY
+  ); then
+    failure_reason=${failure_reason%%$'\n'*}
+    [[ -n "$failure_reason" ]] || failure_reason=unknown
+    printf 'task-runner.sh: ledger write failed (%s) — telemetry degraded\n' "$failure_reason" >&2
+  fi
+  return 0
+}
+
+ensure_ledger_init() {
+  ledger_append_best_effort init "$1"
+}
+
+fold_attempt_sentinel() {
+  ledger_append_best_effort fold "$1" "$2" "$3" "${4:-0}"
+}
+
+fold_terminal_tail() {
+  ledger_append_best_effort catchup "$1"
+}
+
+emit_task_end_if_missing() {
+  ledger_append_best_effort receipt "$1"
+}
+
+project_task_end_if_stale() {
+  ledger_append_best_effort project "$1"
 }
 
 lease_age_s() {
@@ -386,6 +1092,8 @@ quarantine_infra_attempt() {
     printf 'quarantine_infra_attempt: destination exists, preserving source: %s\n' "$destination" >&2
     return 0
   fi
+  # Preserve the last sentinel snapshot before its source path changes.
+  fold_attempt_sentinel "$artifact_dir" "$attempt_dir" "$nnn" 1
   if ! python3 - "$attempt_dir" "$destination" <<'PY'
 import os, sys
 try:
@@ -1511,6 +2219,13 @@ dlq_task() {
   if [[ -n "$TR_PUSH_CMD" ]]; then
     push_dlq_report "$dest"
   fi
+  if [[ "$TR_CRASH_AFTER" = "terminal-pre-ledger" ]]; then
+    exit 137
+  fi
+  ensure_ledger_init "$artifact_dir"
+  fold_terminal_tail "$artifact_dir"
+  emit_task_end_if_missing "$artifact_dir"
+  project_task_end_if_stale "$artifact_dir"
 }
 
 deliver_task() {
@@ -1537,6 +2252,13 @@ deliver_task() {
     mv "$task_file" "$dest/$(basename "$task_file")"
   fi
   cp "$state_file" "$dest/state.json"
+  if [[ "$TR_CRASH_AFTER" = "terminal-pre-ledger" ]]; then
+    exit 137
+  fi
+  ensure_ledger_init "$artifact_dir"
+  fold_terminal_tail "$artifact_dir"
+  emit_task_end_if_missing "$artifact_dir"
+  project_task_end_if_stale "$artifact_dir"
 }
 
 reconcile_terminals() {
@@ -1548,9 +2270,15 @@ reconcile_terminals() {
       continue
     fi
     [[ "$status" = "delivered" || "$status" = "dlq" ]] || continue
-    local artifact_dir task_id dest task_file terminal_task report_missing
+    local artifact_dir task_id dest task_file terminal_task report_missing feature_era
     artifact_dir=$(dirname "$state_file")
     task_id=$(basename "$artifact_dir")
+    # Pre-#187 terminal artifacts have no ledger and must not be backfilled.
+    feature_era=0
+    if [[ -f "$artifact_dir/ledger.jsonl" ]]; then
+      feature_era=1
+      ensure_ledger_init "$artifact_dir"
+    fi
     if [[ "$status" = "delivered" ]]; then
       dest="$delivered_dir/$task_id"
     else
@@ -1581,6 +2309,12 @@ reconcile_terminals() {
         push_dlq_report "$dest"
       fi
     fi
+    if (( feature_era == 1 )); then
+      fold_terminal_tail "$artifact_dir"
+      emit_task_end_if_missing "$artifact_dir"
+      # Projection is intentionally independent of receipt creation/repair.
+      project_task_end_if_stale "$artifact_dir"
+    fi
   done
 }
 
@@ -1590,6 +2324,9 @@ finalize_attempt() {
   local attempt_dir=$3
   local charge_s=$4
   local state_file="$artifact_dir/state.json"
+  local finalized_attempt
+  finalized_attempt=$(basename "$attempt_dir")
+  fold_attempt_sentinel "$artifact_dir" "$attempt_dir" "$finalized_attempt" 1
   load_task_meta "$task_file"
   if ! caty_valid_receipt "$receipt"; then
     dlq_task "$task_file" "$artifact_dir" missing-receipt
@@ -1719,6 +2456,7 @@ recover_verifying() {
     [[ "$status" = "verifying" ]] || continue
     local artifact_dir
     artifact_dir=$(dirname "$state_file")
+    ensure_ledger_init "$artifact_dir"
     local task_id
     task_id=$(basename "$artifact_dir")
     local task_file="$queue_dir/$task_id.task.md"
@@ -1815,6 +2553,7 @@ reap_running() {
     [[ "$status" = "running" ]] || continue
     local artifact_dir
     artifact_dir=$(dirname "$state_file")
+    ensure_ledger_init "$artifact_dir"
     local task_id
     task_id=$(basename "$artifact_dir")
     local task_file="$queue_dir/$task_id.task.md"
@@ -1853,6 +2592,7 @@ reap_running() {
         kill_pgroup "$lease_pgid"
       else
         driver_write "$attempt_dir/driver.json" "${lease_started:-$(utc_now)}" "$(utc_now)" 0 manual-recovery "" unproven-pgid
+        fold_attempt_sentinel "$artifact_dir" "$attempt_dir" "$nnn" 1
         if [[ -f "$task_file" ]]; then
           dlq_task "$task_file" "$artifact_dir" unproven-pgid
         fi
@@ -1869,7 +2609,8 @@ except Exception:
     print("")
 PY
 )
-      if [[ "$recovered_class" = deterministic-auth || "$recovered_class" = deterministic-input ]]; then
+      if [[ "$recovered_class" = deterministic-auth || "$recovered_class" = deterministic-input || "$recovered_class" = window-error ]]; then
+        fold_attempt_sentinel "$artifact_dir" "$attempt_dir" "$nnn" 1
         dlq_task "$task_file" "$artifact_dir" "$recovered_class"
         continue
       fi
@@ -1897,6 +2638,7 @@ PY
           if [[ "$TR_CRASH_AFTER" = "infra-terminal" ]]; then
             exit 137
           fi
+          fold_attempt_sentinel "$artifact_dir" "$attempt_dir" "$nnn" 1
           dlq_task "$task_file" "$artifact_dir" infra
         else
           status=queued
@@ -2044,6 +2786,7 @@ run_one_attempt() {
   fi
   mkdir -p "$attempts_dir" "$artifact_dir/out"
   init_state_if_missing "$state_file"
+  ensure_ledger_init "$artifact_dir"
   if ! load_state "$state_file"; then
     quarantine_corrupt_state run_one_attempt "$state_file"
     return 0
@@ -2131,7 +2874,8 @@ run_one_attempt() {
     exit 137
   fi
 
-  if [[ "$classified" = deterministic-auth || "$classified" = deterministic-input ]]; then
+  if [[ "$classified" = deterministic-auth || "$classified" = deterministic-input || "$classified" = window-error ]]; then
+    fold_attempt_sentinel "$artifact_dir" "$attempt_dir" "$nnn" 1
     dlq_task "$task_file" "$artifact_dir" "$classified"
     return 0
   fi
@@ -2161,6 +2905,7 @@ run_one_attempt() {
       if [[ "$TR_CRASH_AFTER" = "infra-terminal" ]]; then
         exit 137
       fi
+      fold_attempt_sentinel "$artifact_dir" "$attempt_dir" "$nnn" 1
       dlq_task "$task_file" "$artifact_dir" infra
     else
       status=queued

--- a/scripts/task-runner.sh
+++ b/scripts/task-runner.sh
@@ -347,6 +347,10 @@ def valid_ledger_records():
     records = []
     if not os.path.isfile(ledger_path):
         return records
+    parse_marker = os.environ.get("TR_LEDGER_TEST_FULL_PARSE_MARKER")
+    if parse_marker:
+        with open(parse_marker, "a", encoding="utf-8") as marker:
+            marker.write("parse\n")
     with open(ledger_path, "rb") as handle:
         for raw in handle:
             if not raw.endswith(b"\n"):
@@ -527,6 +531,8 @@ def fold_one(path, attempt_value, force_marker=False):
                 scan_start = max(0, scan_end - chunk_bytes)
                 handle.seek(scan_start)
                 block = handle.read(scan_end - scan_start)
+                if not block:
+                    break
                 newline = block.rfind(b"\n")
                 if newline >= 0:
                     complete_end = scan_start + newline + 1
@@ -564,6 +570,8 @@ def fold_one(path, attempt_value, force_marker=False):
                 aligned_start = desired_start
                 while aligned_start < complete_end:
                     block = handle.read(min(chunk_bytes, complete_end - aligned_start))
+                    if not block:
+                        break
                     newline = block.find(b"\n")
                     if newline >= 0:
                         aligned_start += newline + 1
@@ -601,6 +609,8 @@ def fold_one(path, attempt_value, force_marker=False):
                             parts.append(part)
                     if part.endswith(b"\n"):
                         break
+                if line_size == 0:
+                    break
                 seq += 1
                 if oversize:
                     dropped_lines_pass += 1
@@ -698,6 +708,48 @@ def all_attempt_dirs():
             if os.path.isdir(path) and number.isdigit():
                 paths.append((int(number), path, number.zfill(3)))
     return [item[1:] for item in sorted(paths, key=lambda item: (item[0], item[1]))]
+
+
+def file_signature(path):
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return None
+    return {
+        "size": stat.st_size,
+        "mtime_ns": getattr(stat, "st_mtime_ns", int(stat.st_mtime * 1000000000)),
+    }
+
+
+def reconcile_signature():
+    receipt_path = os.path.join(artifact_dir, "task-end.json")
+    receipt = read_json(receipt_path) or {}
+    attempts = []
+    for path, number in all_attempt_dirs():
+        source_path = os.path.join(path, "sentinel-events.jsonl")
+        source_exists = os.path.isfile(source_path)
+        source_stat = file_signature(source_path)
+        attempts.append({
+            "attempt": number,
+            "path": os.path.relpath(path, artifact_dir),
+            "source_size": source_stat["size"] if source_stat else None,
+            "source_mtime_ns": source_stat["mtime_ns"] if source_stat else None,
+            "fold_state": file_signature(os.path.join(path, ".ledger-fold.json")),
+            "attempt_receipt": file_signature(os.path.join(path, "attempt.json")),
+            "driver": file_signature(os.path.join(path, "driver.json")),
+            "eof": file_signature(os.path.join(path, "overflow-stream.eof")),
+            "quiescent": source_quiescent(path, source_exists),
+        })
+    receipt_stat = file_signature(receipt_path)
+    return {
+        "schema": 1,
+        "ledger": file_signature(ledger_path),
+        "state": file_signature(os.path.join(artifact_dir, "state.json")),
+        "receipt_version": receipt.get("receipt_version"),
+        "receipt_mtime_ns": receipt_stat["mtime_ns"] if receipt_stat else None,
+        "receipt_size": receipt_stat["size"] if receipt_stat else None,
+        "attempts": attempts,
+    }
 
 
 def catchup():
@@ -940,6 +992,22 @@ def project_receipt():
         raise RuntimeError("task-end-projection-validation")
 
 
+def reconcile_terminal():
+    ensure_init()
+    reconcile_path = os.path.join(artifact_dir, ".ledger-reconcile.json")
+    signature = reconcile_signature()
+    previous = read_json(reconcile_path)
+    if previous and previous.get("signature") == signature:
+        return
+    catchup()
+    emit_receipt()
+    project_receipt()
+    atomic_json(reconcile_path, {
+        "schema": 1,
+        "signature": reconcile_signature(),
+    })
+
+
 try:
     if operation == "init":
         ensure_init()
@@ -951,6 +1019,8 @@ try:
         emit_receipt()
     elif operation == "project":
         project_receipt()
+    elif operation == "reconcile":
+        reconcile_terminal()
     else:
         raise ValueError("unknown-operation")
 except Exception as exc:
@@ -988,6 +1058,10 @@ emit_task_end_if_missing() {
 
 project_task_end_if_stale() {
   ledger_append_best_effort project "$1"
+}
+
+reconcile_terminal_ledger() {
+  ledger_append_best_effort reconcile "$1"
 }
 
 lease_age_s() {
@@ -1074,7 +1148,7 @@ except Exception:
 classified = d.get("classified")
 exit_code = d.get("exit_code")
 outcome = d.get("outcome")
-print("true" if classified in ("infra", "transient", "context-overflow", "degenerate") or (exit_code == 111 and outcome != "timeout") else "false")
+print("true" if classified in ("infra", "transient", "window-error", "degenerate") or (exit_code == 111 and outcome != "timeout") else "false")
 PY
 }
 
@@ -2277,7 +2351,6 @@ reconcile_terminals() {
     feature_era=0
     if [[ -f "$artifact_dir/ledger.jsonl" ]]; then
       feature_era=1
-      ensure_ledger_init "$artifact_dir"
     fi
     if [[ "$status" = "delivered" ]]; then
       dest="$delivered_dir/$task_id"
@@ -2310,10 +2383,10 @@ reconcile_terminals() {
       fi
     fi
     if (( feature_era == 1 )); then
-      fold_terminal_tail "$artifact_dir"
-      emit_task_end_if_missing "$artifact_dir"
-      # Projection is intentionally independent of receipt creation/repair.
-      project_task_end_if_stale "$artifact_dir"
+      # Catch-up, receipt repair, and independent projection share one
+      # fail-open process. Its persisted signature makes steady-state visits
+      # stat-only: no ledger parse and no receipt/projection rewrite.
+      reconcile_terminal_ledger "$artifact_dir"
     fi
   done
 }
@@ -2609,7 +2682,7 @@ except Exception:
     print("")
 PY
 )
-      if [[ "$recovered_class" = deterministic-auth || "$recovered_class" = deterministic-input || "$recovered_class" = window-error ]]; then
+      if [[ "$recovered_class" = deterministic-auth || "$recovered_class" = deterministic-input ]]; then
         fold_attempt_sentinel "$artifact_dir" "$attempt_dir" "$nnn" 1
         dlq_task "$task_file" "$artifact_dir" "$recovered_class"
         continue
@@ -2874,7 +2947,7 @@ run_one_attempt() {
     exit 137
   fi
 
-  if [[ "$classified" = deterministic-auth || "$classified" = deterministic-input || "$classified" = window-error ]]; then
+  if [[ "$classified" = deterministic-auth || "$classified" = deterministic-input ]]; then
     fold_attempt_sentinel "$artifact_dir" "$attempt_dir" "$nnn" 1
     dlq_task "$task_file" "$artifact_dir" "$classified"
     return 0

--- a/tests/lib-classify.test.sh
+++ b/tests/lib-classify.test.sh
@@ -131,6 +131,11 @@ window_prose="$test_tmp/window-prose.stdout"
 maximum_prose="$test_tmp/maximum-prose.stdout"
 window_auth="$test_tmp/window-auth.stderr"
 window_input="$test_tmp/window-input.stderr"
+window_legacy_length="$test_tmp/window-legacy-length.stderr"
+window_legacy_hyphen="$test_tmp/window-legacy-hyphen.stderr"
+window_legacy_overflow="$test_tmp/window-legacy-overflow.stderr"
+window_legacy_tokens="$test_tmp/window-legacy-tokens.stderr"
+window_legacy_prose="$test_tmp/window-legacy-prose.stdout"
 
 : >"$empty_stderr"
 printf '%s\n' 'unexpected upstream failure xyz123' >"$unknown_stderr"
@@ -146,8 +151,17 @@ printf '%s\n' 'API Error: Prompt is too long for this model' >"$window_stderr"
 printf '%s\n' 'ERROR: input length and max_tokens exceed context limit' >"$window_stdout"
 printf '%s\n' 'The context window is described in the user guide.' >"$window_prose"
 printf '%s\n' 'The maximum context length is documented as 200k tokens.' >"$maximum_prose"
-printf '%s\n' '401 Unauthorized: maximum context length was mentioned by the request' >"$window_auth"
+printf '%s\n' '401 Unauthorized: prompt is too long' >"$window_auth"
 printf '%s\n' 'invalid input: context_length_exceeded' >"$window_input"
+printf '%s\n' 'context length exceeded' >"$window_legacy_length"
+printf '%s\n' 'context-length-exceeded' >"$window_legacy_hyphen"
+printf '%s\n' 'context overflow' >"$window_legacy_overflow"
+printf '%s\n' 'too many tokens' >"$window_legacy_tokens"
+printf '%s\n' \
+  'context length exceeded' \
+  'context-length-exceeded' \
+  'context overflow' \
+  'too many tokens' >"$window_legacy_prose"
 
 check_files stdout-structural-429 1 "$empty_stderr" "$structural_429" transient
 check_files unknown-stderr-stdout-login 1 "$unknown_stderr" "$FIXTURES/cli-not-logged-in.txt" deterministic-auth
@@ -165,6 +179,11 @@ check_files context-window-prose-is-not-window-error 1 "$empty_stderr" "$window_
 check_files maximum-context-prose-is-not-window-error 1 "$empty_stderr" "$maximum_prose" transient
 check_files deterministic-auth-precedes-window-error 1 "$window_auth" "$empty_stderr" deterministic-auth
 check_files deterministic-input-precedes-window-error 1 "$window_input" "$empty_stderr" deterministic-input
+check_files legacy-context-length-exceeded-stderr 1 "$window_legacy_length" "$empty_stderr" window-error
+check_files legacy-context-length-hyphen-stderr 1 "$window_legacy_hyphen" "$empty_stderr" window-error
+check_files legacy-context-overflow-stderr 1 "$window_legacy_overflow" "$empty_stderr" window-error
+check_files legacy-too-many-tokens-stderr 1 "$window_legacy_tokens" "$empty_stderr" window-error
+check_files legacy-window-signatures-stay-excluded-from-stdout 1 "$empty_stderr" "$window_legacy_prose" transient
 
 large_size=225280
 login_banner='Not logged in'

--- a/tests/lib-classify.test.sh
+++ b/tests/lib-classify.test.sh
@@ -74,8 +74,8 @@ check oauth-invalid-grant 1 oauth-invalid-grant.json deterministic-auth
 check invalid-request 1 invalid-request.json deterministic-input
 check rate-limit 1 rate-limit.json transient
 check timeout-408 1 timeout-408.json transient
-check context-4xx 1 context-4xx.json context-overflow
-check context-500 1 context-500.json context-overflow
+check context-4xx-deterministic-input-precedence 1 context-4xx.json deterministic-input
+check context-500-window-error 1 context-500.json window-error
 check degenerate-empty 1 degenerate-empty.txt degenerate
 check unknown-is-transient 1 unknown.json transient
 check short-transient 1 short-transient.txt transient
@@ -125,6 +125,12 @@ unauthorized_prose="$test_tmp/unauthorized-prose.stdout"
 unknown_stdout="$test_tmp/unknown.stdout"
 whitespace_stdout="$test_tmp/whitespace.stdout"
 binary_stdout="$test_tmp/binary.stdout"
+window_stderr="$test_tmp/window.stderr"
+window_stdout="$test_tmp/window.stdout"
+window_prose="$test_tmp/window-prose.stdout"
+maximum_prose="$test_tmp/maximum-prose.stdout"
+window_auth="$test_tmp/window-auth.stderr"
+window_input="$test_tmp/window-input.stderr"
 
 : >"$empty_stderr"
 printf '%s\n' 'unexpected upstream failure xyz123' >"$unknown_stderr"
@@ -136,6 +142,12 @@ printf '%s\n' 'the user was unauthorized to enter' >"$unauthorized_prose"
 printf '%s\n' 'unrecognized non-whitespace stdout evidence' >"$unknown_stdout"
 printf ' \t\n' >"$whitespace_stdout"
 printf '\xff' >"$binary_stdout"
+printf '%s\n' 'API Error: Prompt is too long for this model' >"$window_stderr"
+printf '%s\n' 'ERROR: input length and max_tokens exceed context limit' >"$window_stdout"
+printf '%s\n' 'The context window is described in the user guide.' >"$window_prose"
+printf '%s\n' 'The maximum context length is documented as 200k tokens.' >"$maximum_prose"
+printf '%s\n' '401 Unauthorized: maximum context length was mentioned by the request' >"$window_auth"
+printf '%s\n' 'invalid input: context_length_exceeded' >"$window_input"
 
 check_files stdout-structural-429 1 "$empty_stderr" "$structural_429" transient
 check_files unknown-stderr-stdout-login 1 "$unknown_stderr" "$FIXTURES/cli-not-logged-in.txt" deterministic-auth
@@ -147,6 +159,12 @@ check_files stdout-whitespace-only 1 "$empty_stderr" "$whitespace_stdout" degene
 check_files missing-stderr-stdout-login 1 "$test_tmp/missing.stderr" "$FIXTURES/cli-not-logged-in.txt" deterministic-auth
 check_files stderr-auth-wins-over-stdout-429 1 "$FIXTURES/auth-401.json" "$structural_429" deterministic-auth
 check_files invalid-utf8-stdout-is-nondegenerate 1 "$empty_stderr" "$binary_stdout" transient
+check_files window-error-stderr-case-insensitive 1 "$window_stderr" "$empty_stderr" window-error
+check_files window-error-stdout-signature 1 "$empty_stderr" "$window_stdout" window-error
+check_files context-window-prose-is-not-window-error 1 "$empty_stderr" "$window_prose" transient
+check_files maximum-context-prose-is-not-window-error 1 "$empty_stderr" "$maximum_prose" transient
+check_files deterministic-auth-precedes-window-error 1 "$window_auth" "$empty_stderr" deterministic-auth
+check_files deterministic-input-precedes-window-error 1 "$window_input" "$empty_stderr" deterministic-input
 
 large_size=225280
 login_banner='Not logged in'

--- a/tests/task-runner.test.sh
+++ b/tests/task-runner.test.sh
@@ -135,6 +135,81 @@ run_tick_with_step() {
   env TR_SPAWN_STEP="$step_cmd" "$@" bash "$RUNNER" "$ws"
 }
 
+ledger_event_count() {
+  local ledger=$1
+  local event=$2
+  python3 - "$ledger" "$event" <<'PY'
+import json, sys
+count = 0
+try:
+    source = open(sys.argv[1], encoding="utf-8")
+except OSError:
+    print(0)
+    raise SystemExit
+with source:
+    for line in source:
+        try:
+            record = json.loads(line)
+        except ValueError:
+            continue
+        count += record.get("event") == sys.argv[2]
+print(count)
+PY
+}
+
+receipt_value() {
+  local receipt_file=$1
+  local key=$2
+  python3 - "$receipt_file" "$key" <<'PY'
+import json, sys
+value = json.load(open(sys.argv[1], encoding="utf-8"))
+for part in sys.argv[2].split("."):
+    value = value.get(part)
+print("" if value is None else str(value).lower() if isinstance(value, bool) else value)
+PY
+}
+
+write_terminal_ledger_fixture() {
+  local ws=$1
+  local id=$2
+  local terminal_status=${3:-delivered}
+  local reason=${4:-}
+  local classified=${5:-}
+  local artifact="$ws/loop/artifacts/$id"
+  mkdir -p "$artifact/attempts/001"
+  python3 - "$artifact/state.json" "$terminal_status" "$reason" <<'PY'
+import json, sys
+json.dump({
+    "status": sys.argv[2], "current_step": 1, "attempts_used": 1,
+    "active_seconds_used": 1, "infra_retries": 0, "consec_noncomplete": 0,
+    "last_error_class": None, "last_gap_fingerprint": None,
+    "last_gap_step": None, "lease": None,
+    "terminal_reason": sys.argv[3] or None,
+}, open(sys.argv[1], "w", encoding="utf-8"))
+PY
+  python3 - "$artifact/attempts/001/driver.json" "$classified" <<'PY'
+import json, sys
+value = {"started":"2026-08-27T00:00:00Z", "ended":"2026-08-27T00:00:01Z", "dur_s":1, "outcome":"ok", "exit_code":0}
+if sys.argv[2]: value["classified"] = sys.argv[2]
+json.dump(value, open(sys.argv[1], "w", encoding="utf-8"))
+PY
+  printf '{"event":"init","ledger_schema":1,"task_id":"%s"}\n' "$id" >"$artifact/ledger.jsonl"
+}
+
+set_terminal_lease() {
+  local state_file=$1
+  local pid=${2:-}
+  python3 - "$state_file" "$pid" <<'PY'
+import json, sys
+path, pid = sys.argv[1:3]
+value = json.load(open(path, encoding="utf-8"))
+value["lease"] = ({"pid": int(pid), "pgid": int(pid), "started": "2026-08-27T00:00:00Z"} if pid else None)
+with open(path, "w", encoding="utf-8") as target:
+    json.dump(value, target)
+    target.write("\n")
+PY
+}
+
 write_paused_step() {
   local path=$1
   cat >"$path" <<'SH'
@@ -2938,6 +3013,412 @@ case_crash_verifying_terminal_rederive() {
   fi
 }
 
+case_ledger_terminal_pre_projection_reconcile() {
+  local name=ledger-terminal-pre-projection-reconcile ws artifact rc
+  ws=$(make_ws)
+  write_runner_task "$ws" ledger-crash out/delivery-receipt.json true
+  set +e
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success TR_CRASH_AFTER=terminal-pre-ledger >/dev/null 2>&1
+  rc=$?
+  set -e
+  artifact="$ws/loop/artifacts/ledger-crash"
+  run_tick "$ws" >/dev/null
+  run_tick "$ws" >/dev/null
+  if [[ "$rc" -eq 137 && -f "$artifact/task-end.json" ]] \
+    && [[ "$(ledger_event_count "$artifact/ledger.jsonl" task_end)" -eq 1 ]]; then
+    pass "$name"
+  else
+    fail "$name" "terminal-pre-ledger recovery did not emit one task_end"
+  fi
+}
+
+case_ledger_fired_delivered_is_completed() {
+  local name=ledger-fired-delivered-is-completed ws artifact
+  ws=$(make_ws)
+  write_terminal_ledger_fixture "$ws" fired-delivered delivered
+  artifact="$ws/loop/artifacts/fired-delivered"
+  printf '%s\n' \
+    '{"event":"fire","task_id":"fired-delivered","attempt":"001","turn_idx":2}' \
+    '{"event":"attempt_end","task_id":"fired-delivered","attempt":"001","started_at":"2026-08-27T00:00:00Z","window_error":true,"runtime_compaction":false,"compaction_suspected":false,"total_tokens":9,"injected_summary":{"max":9,"last3_mean":9},"fired_turns":[2],"alert_turns":[],"nudge_disposition_final":"shown","tap_status":"ok","run_meta":{}}' \
+    >"$artifact/attempts/001/sentinel-events.jsonl"
+  run_tick "$ws" >/dev/null
+  if [[ "$(receipt_value "$artifact/task-end.json" outcome)" = completed ]] \
+    && [[ "$(receipt_value "$artifact/task-end.json" window_error)" = true ]]; then
+    pass "$name"
+  else
+    fail "$name" "monitor evidence changed delivered outcome"
+  fi
+}
+
+case_ledger_direct_dlq_reap_folds_once() {
+  local name=ledger-direct-dlq-reap-folds-once ws artifact
+  ws=$(make_ws)
+  write_runner_task "$ws" reap-window out/delivery-receipt.json true
+  run_tick "$ws" TR_MOCK_BEHAVIOR=auth-error TR_CRASH_AFTER=stamp >/dev/null 2>&1 || true
+  artifact="$ws/loop/artifacts/reap-window"
+  printf '%s\n' '{"event":"turn","task_id":"wrong","attempt":"999","turn_idx":1,"input_tokens":1,"cache_read_tokens":0,"cache_creation_tokens":0}' 'not-json' \
+    >"$artifact/attempts/001/sentinel-events.jsonl"
+  run_tick "$ws" >/dev/null
+  if [[ "$(state_value "$ws" reap-window status)" = dlq ]] \
+    && [[ "$(ledger_event_count "$artifact/ledger.jsonl" turn)" -eq 1 ]] \
+    && [[ "$(ledger_event_count "$artifact/ledger.jsonl" task_end)" -eq 1 ]] \
+    && python3 - "$artifact/ledger.jsonl" <<'PY'
+import json, sys
+rows=[json.loads(line) for line in open(sys.argv[1],encoding="utf-8")]
+turn=next(row for row in rows if row.get("event")=="turn")
+raw=next(row for row in rows if row.get("parse_error"))
+assert turn["task_id"]=="reap-window" and turn["attempt"]=="001"
+assert turn["source_task_id"]=="wrong" and turn["source_attempt"]=="999"
+assert raw["schema"]=="raw" and raw["task_id"]=="reap-window"
+PY
+  then
+    pass "$name"
+  else
+    fail "$name" "direct reap DLQ did not fold and emit once"
+  fi
+}
+
+case_ledger_torn_tail_repair() {
+  local name=ledger-torn-tail-repair ws artifact
+  ws=$(make_ws)
+  write_terminal_ledger_fixture "$ws" torn delivered
+  artifact="$ws/loop/artifacts/torn"
+  printf '%s' '{"partial":' >>"$artifact/ledger.jsonl"
+  run_tick "$ws" >/dev/null
+  if [[ "$(ledger_event_count "$artifact/ledger.jsonl" task_end)" -eq 1 ]] \
+    && [[ "$(tail -c 1 "$artifact/ledger.jsonl")" = '' ]]; then
+    pass "$name"
+  else
+    fail "$name" "torn tail was not isolated before task_end append"
+  fi
+}
+
+case_ledger_zero_attempt_dlq() {
+  local name=ledger-zero-attempt-dlq ws artifact
+  ws=$(make_ws)
+  write_runner_task "$ws" zero-attempt __missing__ true
+  run_tick "$ws" >/dev/null
+  artifact="$ws/loop/artifacts/zero-attempt"
+  if [[ "$(state_value "$ws" zero-attempt status)" = dlq ]] \
+    && [[ "$(ledger_event_count "$artifact/ledger.jsonl" init)" -eq 1 ]] \
+    && [[ "$(ledger_event_count "$artifact/ledger.jsonl" task_end)" -eq 1 ]] \
+    && python3 - "$artifact/task-end.json" <<'PY'
+import json, sys
+r=json.load(open(sys.argv[1],encoding="utf-8"))
+assert r["total_tokens"] is None and r["window_error"] is None
+assert r["runtime_compaction"] is None and r["compaction_suspected"] is None
+assert r["fired_turns"] is None and r["alert_turns"] is None
+assert r["tap_status"] == "never-ran"
+PY
+  then
+    pass "$name"
+  else
+    fail "$name" "zero-attempt terminal lacked init/task_end"
+  fi
+}
+
+case_ledger_driver_outcome_mapping() {
+  local name=ledger-driver-outcome-mapping ws root
+  ws=$(make_ws); root="$ws/loop/artifacts"
+  write_terminal_ledger_fixture "$ws" driver-window dlq attempts-budget window-error
+  write_terminal_ledger_fixture "$ws" monitor-only dlq time-budget transient
+  printf '%s\n' '{"event":"attempt_end","started_at":"2026-08-27T00:00:00Z","window_error":true,"runtime_compaction":false,"compaction_suspected":false,"total_tokens":1,"injected_summary":{"max":1,"last3_mean":1},"fired_turns":[],"alert_turns":[],"nudge_disposition_final":"none","tap_status":"ok","run_meta":null}' \
+    >"$root/monitor-only/attempts/001/sentinel-events.jsonl"
+  run_tick "$ws" >/dev/null
+  if [[ "$(receipt_value "$root/driver-window/task-end.json" outcome)" = overflowed ]] \
+    && [[ "$(receipt_value "$root/driver-window/task-end.json" terminal_reason)" = attempts-budget ]] \
+    && [[ "$(receipt_value "$root/monitor-only/task-end.json" outcome)" = aborted ]] \
+    && [[ "$(receipt_value "$root/monitor-only/task-end.json" window_error)" = true ]]; then
+    pass "$name"
+  else fail "$name" "driver/monitor outcome ownership was violated"; fi
+}
+
+case_ledger_window_error_class_is_terminal() {
+  local name=ledger-window-error-class-is-terminal ws step artifact
+  ws=$(make_ws); write_runner_task "$ws" window-terminal out/delivery-receipt.json true
+  step="$ws/window-error-step.sh"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'printf "%s\n" "API Error: Prompt is too long for this model" >&2' \
+    'exit 1' >"$step"
+  chmod +x "$step"
+  run_tick_with_step "$ws" "$step" >/dev/null 2>&1
+  artifact="$ws/loop/artifacts/window-terminal"
+  if [[ "$(state_value "$ws" window-terminal status)" = dlq ]] \
+    && [[ "$(state_value "$ws" window-terminal terminal_reason)" = window-error ]] \
+    && [[ "$(driver_value "$ws" window-terminal classified)" = window-error ]] \
+    && [[ "$(receipt_value "$artifact/task-end.json" outcome)" = overflowed ]]; then
+    pass "$name"
+  else fail "$name" "classified window-error was not routed terminally"; fi
+}
+
+case_ledger_io_failure_is_fail_open() {
+  local name=ledger-io-failure-is-fail-open ws artifact bin real_python marker output warning
+  ws=$(make_ws); write_runner_task "$ws" io-fail out/delivery-receipt.json true
+  artifact="$ws/loop/artifacts/io-fail"; bin="$ws/python-bin"; marker="$ws/python-failed-once"
+  mkdir -p "$bin"; real_python=$(command -v python3)
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'if [[ "${3:-}" = fold && ! -e "$TR_FAIL_ONCE_MARKER" ]]; then' \
+    '  : >"$TR_FAIL_ONCE_MARKER"' \
+    '  printf "%s\n" simulated-EROFS' \
+    '  exit 1' \
+    'fi' \
+    'exec "$TR_REAL_PYTHON" "$@"' >"$bin/python3"
+  chmod +x "$bin/python3"
+  output=$(PATH="$bin:$PATH" TR_REAL_PYTHON="$real_python" TR_FAIL_ONCE_MARKER="$marker" \
+    run_tick "$ws" TR_MOCK_BEHAVIOR=success 2>&1)
+  warning='task-runner.sh: ledger write failed (simulated-EROFS) — telemetry degraded'
+  if [[ "$(state_value "$ws" io-fail status)" = delivered ]] \
+    && [[ -f "$ws/loop/tasks/delivered/io-fail/io-fail.task.md" ]] \
+    && [[ "$(grep -F -x -c "$warning" <<<"$output")" -eq 1 ]] \
+    && [[ "$(ledger_event_count "$artifact/ledger.jsonl" task_end)" -eq 1 ]]; then
+    pass "$name"
+  else fail "$name" "one ledger error stalled delivery or warning contract drifted: $output"; fi
+}
+
+case_ledger_orphan_tail_converges() {
+  local name=ledger-orphan-tail-converges ws artifact version1 source_bytes marker_bytes
+  ws=$(make_ws)
+  write_terminal_ledger_fixture "$ws" orphan delivered
+  artifact="$ws/loop/artifacts/orphan"
+  printf '%s\n' '{"event":"turn","turn_idx":1,"input_tokens":1,"cache_read_tokens":0,"cache_creation_tokens":0}' \
+    >"$artifact/attempts/001/sentinel-events.jsonl"
+  run_tick "$ws" >/dev/null
+  version1=$(receipt_value "$artifact/task-end.json" receipt_version)
+  printf '%s\n' '{"event":"turn","turn_idx":2,"input_tokens":2,"cache_read_tokens":0,"cache_creation_tokens":0}' \
+    >>"$artifact/attempts/001/sentinel-events.jsonl"
+  run_tick "$ws" >/dev/null
+  source_bytes=$(wc -c <"$artifact/attempts/001/sentinel-events.jsonl" | tr -d ' ')
+  marker_bytes=$(python3 - "$artifact/ledger.jsonl" <<'PY'
+import json, sys
+values=[]
+for line in open(sys.argv[1], encoding="utf-8"):
+    try: row=json.loads(line)
+    except ValueError: continue
+    if row.get("event")=="fold_done": values.append(row["source_bytes_at_fold"])
+print(values[-1])
+PY
+)
+  if [[ "$(ledger_event_count "$artifact/ledger.jsonl" turn)" -eq 2 ]] \
+    && [[ "$(receipt_value "$artifact/task-end.json" receipt_version)" -gt "$version1" ]] \
+    && [[ "$marker_bytes" -eq "$source_bytes" ]]; then
+    pass "$name"
+  else
+    fail "$name" "supplementary tail did not converge"
+  fi
+}
+
+case_ledger_receipt_tmp_crash_recovery() {
+  local name=ledger-receipt-tmp-crash-recovery ws artifact
+  ws=$(make_ws)
+  write_terminal_ledger_fixture "$ws" receipt-tmp delivered
+  artifact="$ws/loop/artifacts/receipt-tmp"
+  printf '%s\n' '{"receipt_version":1' >"$artifact/task-end.json.tmp.99999"
+  run_tick "$ws" >/dev/null
+  if [[ -f "$artifact/task-end.json" ]] \
+    && [[ "$(ledger_event_count "$artifact/ledger.jsonl" task_end)" -eq 1 ]]; then
+    pass "$name"
+  else
+    fail "$name" "orphan tmp prevented receipt recovery"
+  fi
+}
+
+case_ledger_fingerprint_repair_after_emit_failure() {
+  local name=ledger-fingerprint-repair-after-emit-failure ws artifact old_version
+  ws=$(make_ws)
+  write_terminal_ledger_fixture "$ws" fingerprint delivered
+  artifact="$ws/loop/artifacts/fingerprint"
+  run_tick "$ws" >/dev/null
+  old_version=$(receipt_value "$artifact/task-end.json" receipt_version)
+  mv "$artifact/task-end.json" "$artifact/task-end.saved"
+  mkdir "$artifact/task-end.json"
+  printf '%s\n' '{"event":"turn","turn_idx":1,"input_tokens":3,"cache_read_tokens":0,"cache_creation_tokens":0}' \
+    >"$artifact/attempts/001/sentinel-events.jsonl"
+  run_tick "$ws" >/dev/null 2>&1 || true
+  rmdir "$artifact/task-end.json"
+  mv "$artifact/task-end.saved" "$artifact/task-end.json"
+  run_tick "$ws" >/dev/null
+  if [[ "$(receipt_value "$artifact/task-end.json" receipt_version)" -gt "$old_version" ]] \
+    && [[ "$(ledger_event_count "$artifact/ledger.jsonl" turn)" -eq 1 ]]; then
+    pass "$name"
+  else
+    fail "$name" "fingerprint mismatch did not repair receipt"
+  fi
+}
+
+case_ledger_quiescence_only_repairs_receipt() {
+  local name=ledger-quiescence-only-repairs-receipt ws artifact old_version
+  ws=$(make_ws)
+  write_terminal_ledger_fixture "$ws" quiescence delivered
+  artifact="$ws/loop/artifacts/quiescence"
+  printf '%s\n' '{"event":"turn","turn_idx":1,"input_tokens":1,"cache_read_tokens":0,"cache_creation_tokens":0}' \
+    >"$artifact/attempts/001/sentinel-events.jsonl"
+  set_terminal_lease "$artifact/state.json" "$$"
+  run_tick "$ws" >/dev/null
+  old_version=$(receipt_value "$artifact/task-end.json" receipt_version)
+  if [[ "$(receipt_value "$artifact/task-end.json" fold_complete)" != false ]]; then
+    fail "$name" "live lease was treated as quiescent"
+    return
+  fi
+  set_terminal_lease "$artifact/state.json"
+  run_tick "$ws" >/dev/null
+  if [[ "$(receipt_value "$artifact/task-end.json" fold_complete)" = true ]] \
+    && [[ "$(receipt_value "$artifact/task-end.json" receipt_version)" -gt "$old_version" ]]; then
+    pass "$name"
+  else
+    fail "$name" "quiescence-only fingerprint change was not repaired"
+  fi
+}
+
+case_ledger_receipt_projection_independent() {
+  local name=ledger-receipt-projection-independent ws artifact version
+  ws=$(make_ws)
+  write_terminal_ledger_fixture "$ws" projection delivered
+  artifact="$ws/loop/artifacts/projection"
+  run_tick "$ws" >/dev/null
+  python3 - "$artifact/task-end.json" <<'PY'
+import json, os, sys
+path=sys.argv[1]
+value=json.load(open(path, encoding="utf-8")); value["receipt_version"] += 1
+tmp=path+".tmp-test"
+with open(tmp,"w",encoding="utf-8") as f: json.dump(value,f); f.write("\n")
+os.replace(tmp,path)
+PY
+  version=$(receipt_value "$artifact/task-end.json" receipt_version)
+  run_tick "$ws" >/dev/null
+  if python3 - "$artifact/ledger.jsonl" "$version" <<'PY'
+import json, sys
+rows=[]
+for line in open(sys.argv[1],encoding="utf-8"):
+    try: row=json.loads(line)
+    except ValueError: continue
+    if row.get("event")=="task_end" and row.get("receipt_version")==int(sys.argv[2]): rows.append(row)
+raise SystemExit(0 if len(rows)==1 else 1)
+PY
+  then pass "$name"; else fail "$name" "stale receipt version was not independently projected"; fi
+}
+
+write_exact_json_lines() {
+  local path=$1 line_bytes=$2 count=$3 partial=${4:-0}
+  python3 - "$path" "$line_bytes" "$count" "$partial" <<'PY'
+import sys
+path, width, count, partial = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
+line = b"{}" + b" " * (width - 3) + b"\n"
+data = line * count
+if partial: data = b'{"event":"turn"'
+open(path,"wb").write(data)
+PY
+}
+
+case_ledger_fold_worked_cases() {
+  local name=ledger-fold-worked-cases ws id artifact
+  ws=$(make_ws)
+  for id in fold64 fold20 fold8; do write_terminal_ledger_fixture "$ws" "$id" delivered; done
+  write_exact_json_lines "$ws/loop/artifacts/fold64/attempts/001/sentinel-events.jsonl" 8 8
+  write_exact_json_lines "$ws/loop/artifacts/fold20/attempts/001/sentinel-events.jsonl" 5 4
+  write_exact_json_lines "$ws/loop/artifacts/fold8/attempts/001/sentinel-events.jsonl" 8 1
+  run_tick "$ws" TR_LEDGER_FOLD_TOTAL_MAX_BYTES=16 TR_LEDGER_FOLD_MAX_BYTES=8 >/dev/null
+  if python3 - "$ws/loop/artifacts" <<'PY'
+import json, os, sys
+root=sys.argv[1]
+states={name:json.load(open(os.path.join(root,name,"attempts/001/.ledger-fold.json"),encoding="utf-8")) for name in ("fold64","fold20","fold8")}
+assert (states["fold64"]["folded_bytes"],states["fold64"]["dropped_bytes"],states["fold64"]["source_bytes_at_fold"],states["fold64"]["budget_remaining"],states["fold64"]["exhausted"]) == (16,48,64,0,True)
+assert (states["fold20"]["folded_bytes"],states["fold20"]["dropped_bytes"],states["fold20"]["source_bytes_at_fold"],states["fold20"]["budget_remaining"],states["fold20"]["exhausted"]) == (15,5,20,0,True)
+assert (states["fold8"]["folded_bytes"],states["fold8"]["dropped_bytes"],states["fold8"]["source_bytes_at_fold"],states["fold8"]["budget_remaining"],states["fold8"]["exhausted"]) == (8,0,8,8,False)
+for name in ("fold64","fold20"): assert sum(1 for row in map(json.loads,open(os.path.join(root,name,"ledger.jsonl"),encoding="utf-8")) if row.get("event")=="fold_exhausted") == 1
+PY
+  then pass "$name"; else fail "$name" "64/16, 20/16, or 8/16 accounting mismatch"; fi
+}
+
+case_ledger_post_exhaustion_is_quiescent() {
+  local name=ledger-post-exhaustion-is-quiescent ws artifact bytes version i
+  ws=$(make_ws); write_terminal_ledger_fixture "$ws" exhausted delivered
+  artifact="$ws/loop/artifacts/exhausted"
+  write_exact_json_lines "$artifact/attempts/001/sentinel-events.jsonl" 8 8
+  run_tick "$ws" TR_LEDGER_FOLD_TOTAL_MAX_BYTES=16 TR_LEDGER_FOLD_MAX_BYTES=8 >/dev/null
+  bytes=$(wc -c <"$artifact/ledger.jsonl" | tr -d ' '); version=$(receipt_value "$artifact/task-end.json" receipt_version)
+  for i in 1 2 3; do
+    printf '{}\n' >>"$artifact/attempts/001/sentinel-events.jsonl"
+    run_tick "$ws" TR_LEDGER_FOLD_TOTAL_MAX_BYTES=16 TR_LEDGER_FOLD_MAX_BYTES=8 >/dev/null
+  done
+  if [[ "$(wc -c <"$artifact/ledger.jsonl" | tr -d ' ')" -eq "$bytes" ]] \
+    && [[ "$(receipt_value "$artifact/task-end.json" receipt_version)" -eq "$version" ]] \
+    && [[ "$(receipt_value "$artifact/task-end.json" fold_complete)" = false ]]; then
+    pass "$name"
+  else fail "$name" "exhausted attempt emitted after adversarial appends"; fi
+}
+
+case_ledger_oversize_lines_are_accounted() {
+  local name=ledger-oversize-lines-are-accounted ws root
+  ws=$(make_ws); root="$ws/loop/artifacts"
+  write_terminal_ledger_fixture "$ws" storm delivered; write_terminal_ledger_fixture "$ws" single delivered
+  write_exact_json_lines "$root/storm/attempts/001/sentinel-events.jsonl" 8 3
+  write_exact_json_lines "$root/single/attempts/001/sentinel-events.jsonl" 8 1
+  run_tick "$ws" TR_LEDGER_FOLD_TOTAL_MAX_BYTES=16 TR_LEDGER_FOLD_MAX_BYTES=4 >/dev/null
+  if python3 - "$root" <<'PY'
+import json, os, sys
+root=sys.argv[1]
+storm=json.load(open(os.path.join(root,"storm/attempts/001/.ledger-fold.json"),encoding="utf-8"))
+single=json.load(open(os.path.join(root,"single/attempts/001/.ledger-fold.json"),encoding="utf-8"))
+assert storm["exhausted"] and storm["truncated"] and storm["dropped_bytes"] == 24
+assert not single["exhausted"] and single["truncated"] and single["dropped_bytes"] == 8
+assert not json.load(open(os.path.join(root,"single/task-end.json"),encoding="utf-8"))["fold_complete"]
+assert sum(1 for row in map(json.loads,open(os.path.join(root,"single/ledger.jsonl"),encoding="utf-8")) if row.get("event")=="fold_oversize_line") == 1
+PY
+  then pass "$name"; else fail "$name" "oversize line truncation totals mismatch"; fi
+}
+
+case_ledger_partial_line_completed_once() {
+  local name=ledger-partial-line-completed-once ws artifact
+  ws=$(make_ws); write_terminal_ledger_fixture "$ws" partial-line delivered
+  artifact="$ws/loop/artifacts/partial-line"
+  printf '%s' '{"event":"turn","turn_idx":1' >"$artifact/attempts/001/sentinel-events.jsonl"
+  run_tick "$ws" >/dev/null
+  printf '%s\n' '}' >>"$artifact/attempts/001/sentinel-events.jsonl"
+  run_tick "$ws" >/dev/null
+  if [[ "$(ledger_event_count "$artifact/ledger.jsonl" turn)" -eq 1 ]] \
+    && [[ "$(python3 - "$artifact/ledger.jsonl" <<'PY'
+import json,sys
+print([r["seq"] for r in map(json.loads,open(sys.argv[1],encoding="utf-8")) if r.get("event")=="turn"][-1])
+PY
+)" -eq 1 ]]; then
+    pass "$name"
+  else fail "$name" "newline-anchored cursor duplicated or lost completed record"; fi
+}
+
+case_ledger_pre_feature_terminal_gate() {
+  local name=ledger-pre-feature-terminal-gate ws artifact
+  ws=$(make_ws); write_terminal_ledger_fixture "$ws" legacy delivered
+  artifact="$ws/loop/artifacts/legacy"; rm "$artifact/ledger.jsonl"
+  run_tick "$ws" >/dev/null
+  if [[ ! -e "$artifact/task-end.json" && ! -e "$artifact/ledger.jsonl" ]]; then
+    pass "$name"
+  else fail "$name" "reconcile fabricated telemetry for pre-feature artifact"; fi
+}
+
+if [[ "${TR_LEDGER_FOCUSED:-0}" = 1 ]]; then
+  case_ledger_terminal_pre_projection_reconcile
+  case_ledger_fired_delivered_is_completed
+  case_ledger_direct_dlq_reap_folds_once
+  case_ledger_torn_tail_repair
+  case_ledger_zero_attempt_dlq
+  case_ledger_driver_outcome_mapping
+  case_ledger_window_error_class_is_terminal
+  case_ledger_io_failure_is_fail_open
+  case_ledger_orphan_tail_converges
+  case_ledger_receipt_tmp_crash_recovery
+  case_ledger_fingerprint_repair_after_emit_failure
+  case_ledger_quiescence_only_repairs_receipt
+  case_ledger_receipt_projection_independent
+  case_ledger_fold_worked_cases
+  case_ledger_post_exhaustion_is_quiescent
+  case_ledger_oversize_lines_are_accounted
+  case_ledger_partial_line_completed_once
+  case_ledger_pre_feature_terminal_gate
+  log "TOTAL pass=$pass_count fail=$fail_count"
+  (( fail_count == 0 ))
+  exit
+fi
+
 case_env_integer_validation
 case_corrupt_state_quarantine_continues
 case_quoted_id_intake_runner_agree
@@ -3035,6 +3516,24 @@ case_stdout_cli_login_deterministic_auth_dlq
 case_non111_unknown_error_uses_infra_retries
 case_empty_stderr_is_degenerate_and_retries
 case_metrics_idempotent
+case_ledger_terminal_pre_projection_reconcile
+case_ledger_fired_delivered_is_completed
+case_ledger_direct_dlq_reap_folds_once
+case_ledger_torn_tail_repair
+case_ledger_zero_attempt_dlq
+case_ledger_driver_outcome_mapping
+case_ledger_window_error_class_is_terminal
+case_ledger_io_failure_is_fail_open
+case_ledger_orphan_tail_converges
+case_ledger_receipt_tmp_crash_recovery
+case_ledger_fingerprint_repair_after_emit_failure
+case_ledger_quiescence_only_repairs_receipt
+case_ledger_receipt_projection_independent
+case_ledger_fold_worked_cases
+case_ledger_post_exhaustion_is_quiescent
+case_ledger_oversize_lines_are_accounted
+case_ledger_partial_line_completed_once
+case_ledger_pre_feature_terminal_gate
 
 log "TOTAL pass=$pass_count fail=$fail_count"
 if (( fail_count > 0 )); then

--- a/tests/task-runner.test.sh
+++ b/tests/task-runner.test.sh
@@ -3133,22 +3133,51 @@ case_ledger_driver_outcome_mapping() {
   else fail "$name" "driver/monitor outcome ownership was violated"; fi
 }
 
-case_ledger_window_error_class_is_terminal() {
-  local name=ledger-window-error-class-is-terminal ws step artifact
-  ws=$(make_ws); write_runner_task "$ws" window-terminal out/delivery-receipt.json true
+case_ledger_window_error_retries_then_overflows() {
+  local name=ledger-window-error-retries-then-overflows ws step artifact i
+  ws=$(make_ws); write_runner_task "$ws" window-overflow out/delivery-receipt.json true
+  step="$ws/window-error-step.sh"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'printf "%s\n" "API Error 400: maximum context length exceeded for this request" >&2' \
+    'exit 1' >"$step"
+  chmod +x "$step"
+  for i in 1 2 3 4; do
+    run_tick_with_step "$ws" "$step" >/dev/null 2>&1
+  done
+  artifact="$ws/loop/artifacts/window-overflow"
+  if [[ "$(state_value "$ws" window-overflow status)" = dlq ]] \
+    && [[ "$(state_value "$ws" window-overflow terminal_reason)" = infra ]] \
+    && [[ "$(state_value "$ws" window-overflow infra_retries)" -eq 4 ]] \
+    && [[ "$(state_value "$ws" window-overflow attempts_used)" -eq 0 ]] \
+    && [[ "$(driver_value "$ws" window-overflow classified)" = window-error ]] \
+    && [[ "$(infra_driver_value "$ws" window-overflow 1 classified)" = window-error ]] \
+    && [[ "$(receipt_value "$artifact/task-end.json" outcome)" = overflowed ]]; then
+    pass "$name"
+  else fail "$name" "window-error did not exhaust infra retries with an overflowed receipt"; fi
+}
+
+case_ledger_window_error_recovers_completed() {
+  local name=ledger-window-error-recovers-completed ws step artifact rc
+  ws=$(make_ws); write_runner_task "$ws" window-recovery out/delivery-receipt.json true
   step="$ws/window-error-step.sh"
   printf '%s\n' '#!/usr/bin/env bash' \
     'printf "%s\n" "API Error: Prompt is too long for this model" >&2' \
     'exit 1' >"$step"
   chmod +x "$step"
-  run_tick_with_step "$ws" "$step" >/dev/null 2>&1
-  artifact="$ws/loop/artifacts/window-terminal"
-  if [[ "$(state_value "$ws" window-terminal status)" = dlq ]] \
-    && [[ "$(state_value "$ws" window-terminal terminal_reason)" = window-error ]] \
-    && [[ "$(driver_value "$ws" window-terminal classified)" = window-error ]] \
-    && [[ "$(receipt_value "$artifact/task-end.json" outcome)" = overflowed ]]; then
+  set +e
+  run_tick_with_step "$ws" "$step" TR_CRASH_AFTER=stamp >/dev/null 2>&1
+  rc=$?
+  set -e
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success >/dev/null
+  artifact="$ws/loop/artifacts/window-recovery"
+  if [[ "$rc" -eq 137 ]] \
+    && [[ "$(state_value "$ws" window-recovery status)" = delivered ]] \
+    && [[ "$(state_value "$ws" window-recovery infra_retries)" -eq 1 ]] \
+    && [[ "$(state_value "$ws" window-recovery attempts_used)" -eq 1 ]] \
+    && [[ "$(infra_driver_value "$ws" window-recovery 1 classified)" = window-error ]] \
+    && [[ "$(receipt_value "$artifact/task-end.json" outcome)" = completed ]]; then
     pass "$name"
-  else fail "$name" "classified window-error was not routed terminally"; fi
+  else fail "$name" "window-error stamp crash/reap recovery did not complete: first_rc=$rc"; fi
 }
 
 case_ledger_io_failure_is_fail_open() {
@@ -3395,29 +3424,50 @@ case_ledger_pre_feature_terminal_gate() {
   else fail "$name" "reconcile fabricated telemetry for pre-feature artifact"; fi
 }
 
-if [[ "${TR_LEDGER_FOCUSED:-0}" = 1 ]]; then
-  case_ledger_terminal_pre_projection_reconcile
-  case_ledger_fired_delivered_is_completed
-  case_ledger_direct_dlq_reap_folds_once
-  case_ledger_torn_tail_repair
-  case_ledger_zero_attempt_dlq
-  case_ledger_driver_outcome_mapping
-  case_ledger_window_error_class_is_terminal
-  case_ledger_io_failure_is_fail_open
-  case_ledger_orphan_tail_converges
-  case_ledger_receipt_tmp_crash_recovery
-  case_ledger_fingerprint_repair_after_emit_failure
-  case_ledger_quiescence_only_repairs_receipt
-  case_ledger_receipt_projection_independent
-  case_ledger_fold_worked_cases
-  case_ledger_post_exhaustion_is_quiescent
-  case_ledger_oversize_lines_are_accounted
-  case_ledger_partial_line_completed_once
-  case_ledger_pre_feature_terminal_gate
-  log "TOTAL pass=$pass_count fail=$fail_count"
-  (( fail_count == 0 ))
-  exit
-fi
+case_ledger_reconcile_steady_state_is_stat_only() {
+  local name=ledger-reconcile-steady-state-is-stat-only ws root trace ops bin real_python before after i
+  ws=$(make_ws); root="$ws/loop/artifacts"
+  i=1
+  while (( i <= 20 )); do
+    write_terminal_ledger_fixture "$ws" "steady-$(printf '%02d' "$i")" delivered
+    i=$(( i + 1 ))
+  done
+  trace="$ws/full-parse.trace"
+  run_tick "$ws" TR_LEDGER_TEST_FULL_PARSE_MARKER="$trace" >/dev/null
+  rm -f "$trace"
+  before=$(python3 - "$root" <<'PY'
+import glob, os, sys
+root=sys.argv[1]
+for artifact in sorted(glob.glob(os.path.join(root, "steady-*"))):
+    for name in ("ledger.jsonl", "task-end.json", ".ledger-reconcile.json"):
+        stat=os.stat(os.path.join(artifact,name))
+        print("%s/%s:%s:%s" % (os.path.basename(artifact), name, stat.st_size, stat.st_mtime_ns))
+PY
+)
+  ops="$ws/ledger-ops.trace"; bin="$ws/python-bin"; real_python=$(command -v python3)
+  mkdir -p "$bin"
+  printf '%s\n' '#!/usr/bin/env bash' \
+    'case "${3:-}" in init|fold|catchup|receipt|project|reconcile) printf "%s\n" "$3" >>"$TR_LEDGER_OP_TRACE" ;; esac' \
+    'exec "$TR_REAL_PYTHON" "$@"' >"$bin/python3"
+  chmod +x "$bin/python3"
+  PATH="$bin:$PATH" TR_REAL_PYTHON="$real_python" TR_LEDGER_OP_TRACE="$ops" \
+    run_tick "$ws" TR_LEDGER_TEST_FULL_PARSE_MARKER="$trace" >/dev/null
+  after=$(python3 - "$root" <<'PY'
+import glob, os, sys
+root=sys.argv[1]
+for artifact in sorted(glob.glob(os.path.join(root, "steady-*"))):
+    for name in ("ledger.jsonl", "task-end.json", ".ledger-reconcile.json"):
+        stat=os.stat(os.path.join(artifact,name))
+        print("%s/%s:%s:%s" % (os.path.basename(artifact), name, stat.st_size, stat.st_mtime_ns))
+PY
+)
+  if [[ "$before" = "$after" ]] \
+    && [[ ! -e "$trace" ]] \
+    && [[ "$(grep -c '^reconcile$' "$ops")" -eq 20 ]] \
+    && ! grep -Eq '^(init|fold|catchup|receipt|project)$' "$ops"; then
+    pass "$name"
+  else fail "$name" "steady reconcile parsed/wrote telemetry or used split Python operations"; fi
+}
 
 case_env_integer_validation
 case_corrupt_state_quarantine_continues
@@ -3522,7 +3572,8 @@ case_ledger_direct_dlq_reap_folds_once
 case_ledger_torn_tail_repair
 case_ledger_zero_attempt_dlq
 case_ledger_driver_outcome_mapping
-case_ledger_window_error_class_is_terminal
+case_ledger_window_error_retries_then_overflows
+case_ledger_window_error_recovers_completed
 case_ledger_io_failure_is_fail_open
 case_ledger_orphan_tail_converges
 case_ledger_receipt_tmp_crash_recovery
@@ -3534,6 +3585,7 @@ case_ledger_post_exhaustion_is_quiescent
 case_ledger_oversize_lines_are_accounted
 case_ledger_partial_line_completed_once
 case_ledger_pre_feature_terminal_gate
+case_ledger_reconcile_steady_state_is_stat_only
 
 log "TOTAL pass=$pass_count fail=$fail_count"
 if (( fail_count > 0 )); then

--- a/tests/task-runner.test.sh
+++ b/tests/task-runner.test.sh
@@ -3236,6 +3236,64 @@ PY
   fi
 }
 
+case_ledger_reconcile_post_race_cache_self_heals() {
+  local name=ledger-reconcile-post-race-cache-self-heals ws artifact source fold cache first final i
+  ws=$(make_ws)
+  write_terminal_ledger_fixture "$ws" post-race delivered
+  artifact="$ws/loop/artifacts/post-race"
+  source="$artifact/attempts/001/sentinel-events.jsonl"
+  fold="$artifact/attempts/001/.ledger-fold.json"
+  cache="$artifact/.ledger-reconcile.json"
+  printf '%s\n' '{"event":"turn","turn_idx":1,"input_tokens":1,"cache_read_tokens":0,"cache_creation_tokens":0}' >"$source"
+  run_tick "$ws" >/dev/null
+  printf '%s\n' '{"event":"turn","turn_idx":2,"input_tokens":2,"cache_read_tokens":0,"cache_creation_tokens":0}' >>"$source"
+  python3 - "$source" "$fold" "$cache" <<'PY'
+import json, os, sys
+source_path, fold_path, cache_path = sys.argv[1:]
+source_stat = os.stat(source_path)
+fold = json.load(open(fold_path, encoding="utf-8"))
+cache = json.load(open(cache_path, encoding="utf-8"))
+assert fold["source_bytes_at_fold"] < source_stat.st_size
+attempt = cache["signature"]["attempts"][0]
+attempt["source_size"] = source_stat.st_size
+attempt["source_mtime_ns"] = source_stat.st_mtime_ns
+tmp = cache_path + ".tmp-test"
+with open(tmp, "w", encoding="utf-8") as handle:
+    json.dump(cache, handle, sort_keys=True, separators=(",", ":"))
+    handle.write("\n")
+os.replace(tmp, cache_path)
+PY
+  run_tick "$ws" >/dev/null
+  first=$(python3 - "$source" "$fold" "$artifact/task-end.json" "$artifact/ledger.jsonl" <<'PY'
+import json, os, sys
+source_path, fold_path, receipt_path, ledger_path = sys.argv[1:]
+source_size = os.path.getsize(source_path)
+folded_size = json.load(open(fold_path, encoding="utf-8"))["source_bytes_at_fold"]
+complete = json.load(open(receipt_path, encoding="utf-8"))["fold_complete"]
+turns = sum(1 for row in map(json.loads, open(ledger_path, encoding="utf-8")) if row.get("event") == "turn")
+print("%s:%s:%s:%s" % (source_size, folded_size, str(complete).lower(), turns))
+PY
+)
+  for i in 2 3 4 5; do run_tick "$ws" >/dev/null; done
+  final=$(python3 - "$source" "$fold" "$artifact/task-end.json" "$artifact/ledger.jsonl" <<'PY'
+import json, os, sys
+source_path, fold_path, receipt_path, ledger_path = sys.argv[1:]
+source_size = os.path.getsize(source_path)
+folded_size = json.load(open(fold_path, encoding="utf-8"))["source_bytes_at_fold"]
+complete = json.load(open(receipt_path, encoding="utf-8"))["fold_complete"]
+turns = sum(1 for row in map(json.loads, open(ledger_path, encoding="utf-8")) if row.get("event") == "turn")
+print("%s:%s:%s:%s" % (source_size, folded_size, str(complete).lower(), turns))
+PY
+)
+  if [[ "$first" = "$final" ]] \
+    && [[ "${first%%:*}" = "$(cut -d: -f2 <<<"$first")" ]] \
+    && [[ "$(cut -d: -f3-4 <<<"$first")" = "true:2" ]]; then
+    pass "$name"
+  else
+    fail "$name" "poisoned reconcile cache did not heal on the next tick: first=$first after_5=$final"
+  fi
+}
+
 case_ledger_receipt_tmp_crash_recovery() {
   local name=ledger-receipt-tmp-crash-recovery ws artifact
   ws=$(make_ws)
@@ -3576,6 +3634,7 @@ case_ledger_window_error_retries_then_overflows
 case_ledger_window_error_recovers_completed
 case_ledger_io_failure_is_fail_open
 case_ledger_orphan_tail_converges
+case_ledger_reconcile_post_race_cache_self_heals
 case_ledger_receipt_tmp_crash_recovery
 case_ledger_fingerprint_repair_after_emit_failure
 case_ledger_quiescence_only_repairs_receipt


### PR DESCRIPTION
Closes #187.

Sentinel events now join a per-task, append-only `ledger.jsonl` (driver as sole writer), and the driver emits a task-level `task_end` exactly once at its terminal transitions as an atomic `task-end.json` receipt — distinct from the monitor's per-run `attempt_end`, with `outcome` derived solely from the driver's own persisted classification (new retryable `window-error` class in classify_failure; monitor evidence never drives outcome). All ledger I/O is fail-open behind a single choke point, strictly after the authoritative terminal layout; fold uses an entry-frozen allowance with a saturating cumulative budget; reconcile telemetry is one python invocation per terminal artifact with a self-healing change-detection cache.

Design was frozen BEFORE implementation via a 12-round upstream L1-9 review (IMPL-PLAN-187 v1+v2..v2.10; codex/grok/glm 3-seat GO; records: `~/claude-workspace/experiments/ev006/reviews-187/` LEDGER.md, linked from #187).

## Files touched (WIP declaration ↔ diff)

Declared (#187 WIP, 2026-08-27): scripts/task-runner.sh / scripts/lib-classify.sh / tests/task-runner.test.sh / tests/lib-classify.test.sh / tests/overflow-sentinel.test.sh (if needed — NOT touched) / docs/design/159-overflow-sentinel/DESIGN.md / docs/reference.md / docs/reference.ja.md. lib_overflow_sentinel.py goal-zero (achieved: untouched) / overflow_sentinel_monitor.py must-not-touch (achieved: untouched).
Actual `git diff --stat origin/main...f3a6b46`: exactly the 7 declared-and-touched files (+1650/-66 across 3 commits). New runtime artifacts: `<artifact_dir>/ledger.jsonl`, `task-end.json`, `.ledger-fold.json`, `.ledger-reconcile.json`.

## Completion record (L1-7)

Candidate SHA: `f3a6b46` (rebase of bbd5cff onto main a1bdd77-era head; `git range-diff` = 3 commits all `=`, content-neutral; post-rebase full re-verification below).

| Done when | verdict | evidence (inline, 2026-08-27) |
|---|---|---|
| sentinel events join the task-runner ledger keyed by task_id (DESIGN §6 first-choice placement) | PASS | Driver-owned envelope (task_id always overwritten from artifact basename, source values preserved as diagnostics) at every attempt-finalize/reap/pre-quarantine/direct-DLQ fold site; catch-up to quiescence on terminal+reconcile passes. Pinned by `ledger-direct-dlq-reap-folds-once`, `ledger-orphan-tail-converges`, worked-case goldens (64/16, 20/16, 8/16), post-exhaustion quiescence. Suite: task-runner **118 PASS / 0 FAIL** (orchestrator re-runs at faeedb8/31efab4/bbd5cff and post-rebase). |
| task-level task_end emitted once at the driver's terminal transition, distinct from per-run attempt_end | PASS | Atomic `task-end.json` receipt (tmp+rename = emission-once; fingerprint-driven version repair; independent stale-projection step; torn-tail repair; `TR_CRASH_AFTER=terminal-pre-ledger` + crash goldens 1/6/9/10/11/12). Zero-attempt terminals covered via idempotent `ensure_ledger_init` (golden 7). |
| outcome derives from the driver's actual terminal state, not step_complete∧exit0 | PASS | `outcome=overflowed` iff the FINAL burned attempt's persisted driver.json classification is `window-error` (adjudicated ownership rule, now recorded in DESIGN v0.5.4); delivered⇒completed; monitor `window_error` is evidence-only (adversarial test `ledger-driver-outcome-mapping`: monitor-only window_error ⇒ aborted). classify_failure gains retryable `window-error` (stderr legacy signatures restored at original strength; precedence after deterministic-auth/input, pinned by 3 tests that all die under the reorder mutant). |

- **Review (blind r1 → measured fix rounds → deltas), writer = Codex GPT-5.6 Sol (sol-xhigh):**
  - GLM 5.3: r1 GO @faeedb8 (16/16 goldens verified, mutants 3/3) → delta GO @31efab4 (M3 re-run: both precedence tests now fail; legacy signatures verified stderr-only at original strength).
  - Kimi K3: r1 GO @faeedb8 (formal delivery) → cumulative delta GO @f3a6b46 (nothing invalidated; r1 MINORs fixed & test-pinned).
  - Opus 5: r1 **NO-GO** @faeedb8 with 3 measured MAJORs (window-error made non-retryable — A/B with retry-budget deletion; context-overflow signatures silently dropped; reconcile O(N) no-op cost) → fix 31efab4 → r2: 5/6 RESOLVED + **NEW-1 MAJOR** (reconcile cache TOCTOU: post-work stat orphans in-window appends forever + false fold_complete, reproduced) → fix bbd5cff (entry-time source stats + self-heal coverage guard + seeded post-race pin test) → r3 **GO** (reproduction flips fail→pass; ADV5-11 controls green; NEW-2/NEW-3 documented in DESIGN; remaining: 1 MINOR comment suggestion, 1 LOW cosmetic).
  - All seats pairwise-distinct and distinct from the writer (L1-10); requested=actual; records: `~/claude-workspace/experiments/ev006/impl-187/out-*/`.
- Tests (T-3): +658 test lines net; 17+ ledger driver-path cases incl. crash goldens, fold worked-cases, steady-state stat-only pin, post-race self-heal pin; suites at head: task-runner 118/0, lib-classify 58/0, pause-contract ok, overflow-sentinel 14/0; full `make test` **38 suites PASS, 0 FAIL** (run at bbd5cff and re-run post-rebase).
- Boundaries: monitor and lib_overflow_sentinel.py untouched; sentinel-disabled tasks change only by the new ledger/receipt records themselves (Opus A/B verified retry-budget parity with main after the fix).
- CI: pending at record time (runs start with this PR) — merge blocked until green (T-4); will be updated before merge. pr-size: diff exceeds 400 lines → size-exempt will be requested (owner action) after CI reports.
- release: next MINOR over the release list as re-measured immediately before tagging (currently v0.19.1 → expected **v0.20.0**; new user-visible ledger/receipt artifacts + new classify class = 出荷相当). Number is re-measured at tag time per the v0.17.3 lesson; any drift is noted per T-5 without an extra L1-8 round.
- previous release: v0.19.1 — fulfilled (https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.19.1).

Follow-ups recorded, not filed (owner interest pending): budget-charge/coalesce fold_done markers (GLM r1 MINOR-2, 386× amplification measured); `maximum context length` guard narrowing is a recorded deliberate decision (DESIGN v0.5.4); DLQ REPORT.md label (`infra`) vs receipt outcome (`overflowed`) surface split (Opus open question — matches pre-#187 shape).

Merge, tag, and release execution wait for owner (翔さん) decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
