### PR TITLE
fix(lib-state-fold): verify-then-rename guard in atomic_write_file (#182)

### DIFF
--- a/scripts/lib-state-fold.sh
+++ b/scripts/lib-state-fold.sh
@@ -409,8 +409,12 @@ atomic_write_file() {
   destination_dir=$(cd "$(dirname "$destination")" && pwd)
   destination_name=${destination##*/}
   tmp_file="$destination_dir/.$destination_name.tmp.$$"
-  cp "$source_file" "$tmp_file"
-  mv -f "$tmp_file" "$destination"
+  cp "$source_file" "$tmp_file" || { rm -f "$tmp_file"; return 1; }
+  # Verify before rename: catches ENOSPC mid-copy and short reads.
+  if ! cmp -s "$source_file" "$tmp_file"; then rm -f "$tmp_file"; return 1; fi
+  # The destination must be a regular file or absent, never a directory.
+  if [ -e "$destination" ] && [ ! -f "$destination" ]; then rm -f "$tmp_file"; return 1; fi
+  mv -f "$tmp_file" "$destination" || { rm -f "$tmp_file"; return 1; }
 }
 
 last_session_parse_snapshot() {

--- a/tests/atomic-write-file.test.sh
+++ b/tests/atomic-write-file.test.sh
@@ -95,5 +95,33 @@ else
     "rc=$directory_rc entries=$(ls -A "$directory_destination" 2>/dev/null | tr '\n' ',') parent_temp_removed=$([ ! -e "$directory_tmp" ] && printf yes || printf no) nested_temp_removed=$([ ! -e "$directory_nested_tmp" ] && printf yes || printf no)"
 fi
 
+symlink_dir=$TMP_ROOT/symlink-dir-trap
+mkdir -p "$symlink_dir"
+symlink_source=$symlink_dir/source
+symlink_real=$symlink_dir/realdir
+symlink_destination=$symlink_dir/destination
+symlink_tmp=$symlink_dir/.destination.tmp.$$
+symlink_nested_tmp=$symlink_real/.destination.tmp.$$
+printf 'replacement content\n' >"$symlink_source"
+mkdir -p "$symlink_real"
+printf 'sentinel content\n' >"$symlink_real/sentinel"
+ln -s "$symlink_real" "$symlink_destination"
+if atomic_write_file "$symlink_source" "$symlink_destination"; then
+  symlink_rc=0
+else
+  symlink_rc=$?
+fi
+if [ "$symlink_rc" -ne 0 ] \
+  && [ -L "$symlink_destination" ] \
+  && [ "$(cat "$symlink_real/sentinel" 2>/dev/null)" = "sentinel content" ] \
+  && [ "$(ls -A "$symlink_real")" = "sentinel" ] \
+  && [ ! -e "$symlink_tmp" ] \
+  && [ ! -e "$symlink_nested_tmp" ]; then
+  pass "symlink-to-directory destination is refused with the symlink untouched"
+else
+  fail_case "symlink-to-directory destination is refused with the symlink untouched" \
+    "rc=$symlink_rc still_symlink=$([ -L "$symlink_destination" ] && printf yes || printf no) entries=$(ls -A "$symlink_real" 2>/dev/null | tr '\n' ',') parent_temp_removed=$([ ! -e "$symlink_tmp" ] && printf yes || printf no) nested_temp_removed=$([ ! -e "$symlink_nested_tmp" ] && printf yes || printf no)"
+fi
+
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
 [ "$FAIL_COUNT" -eq 0 ]

--- a/tests/atomic-write-file.test.sh
+++ b/tests/atomic-write-file.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TMP_ROOT=${TMPDIR:-/tmp}/atomic-write-file-test.$$
+PASS_COUNT=0
+FAIL_COUNT=0
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+mkdir -p "$TMP_ROOT"
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+fail_case() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL %s: %s\n' "$1" "$2"
+}
+
+source "$ROOT/scripts/lib-state-fold.sh"
+
+failure_dir=$TMP_ROOT/copy-failure
+mkdir -p "$failure_dir"
+failure_source=$failure_dir/source
+failure_destination=$failure_dir/destination
+failure_before=$failure_dir/destination.before
+failure_tmp=$failure_dir/.destination.tmp.$$
+dd if=/dev/zero of="$failure_source" bs=1024 count=8 2>/dev/null
+printf 'original destination content\n' >"$failure_destination"
+cp "$failure_destination" "$failure_before"
+if (ulimit -f 1; atomic_write_file "$failure_source" "$failure_destination") \
+  >"$failure_dir/output" 2>&1; then
+  failure_rc=0
+else
+  failure_rc=$?
+fi
+if [ "$failure_rc" -ne 0 ] \
+  && cmp -s "$failure_before" "$failure_destination" \
+  && [ ! -e "$failure_tmp" ]; then
+  pass "copy failure preserves destination and removes temporary file"
+else
+  fail_case "copy failure preserves destination and removes temporary file" \
+    "rc=$failure_rc destination_preserved=$(cmp -s "$failure_before" "$failure_destination" && printf yes || printf no) temp_removed=$([ ! -e "$failure_tmp" ] && printf yes || printf no)"
+fi
+
+success_dir=$TMP_ROOT/success
+mkdir -p "$success_dir"
+success_source=$success_dir/source
+success_destination=$success_dir/destination
+success_tmp=$success_dir/.destination.tmp.$$
+dd if=/dev/zero of="$success_source" bs=1024 count=8 2>/dev/null
+printf 'old destination content\n' >"$success_destination"
+if atomic_write_file "$success_source" "$success_destination"; then
+  success_rc=0
+else
+  success_rc=$?
+fi
+if [ "$success_rc" -eq 0 ] \
+  && cmp -s "$success_source" "$success_destination" \
+  && [ ! -e "$success_tmp" ]; then
+  pass "successful copy replaces destination byte-for-byte"
+else
+  fail_case "successful copy replaces destination byte-for-byte" \
+    "rc=$success_rc destination_matches=$(cmp -s "$success_source" "$success_destination" && printf yes || printf no) temp_removed=$([ ! -e "$success_tmp" ] && printf yes || printf no)"
+fi
+
+directory_dir=$TMP_ROOT/directory-trap
+mkdir -p "$directory_dir"
+directory_source=$directory_dir/source
+directory_destination=$directory_dir/destination
+directory_tmp=$directory_dir/.destination.tmp.$$
+directory_nested_tmp=$directory_destination/.destination.tmp.$$
+printf 'replacement content\n' >"$directory_source"
+mkdir -p "$directory_destination"
+printf 'sentinel content\n' >"$directory_destination/sentinel"
+if atomic_write_file "$directory_source" "$directory_destination"; then
+  directory_rc=0
+else
+  directory_rc=$?
+fi
+if [ "$directory_rc" -ne 0 ] \
+  && [ -d "$directory_destination" ] \
+  && [ "$(cat "$directory_destination/sentinel" 2>/dev/null)" = "sentinel content" ] \
+  && [ "$(ls -A "$directory_destination")" = "sentinel" ] \
+  && [ ! -e "$directory_tmp" ] \
+  && [ ! -e "$directory_nested_tmp" ]; then
+  pass "existing directory destination is refused without changes"
+else
+  fail_case "existing directory destination is refused without changes" \
+    "rc=$directory_rc entries=$(ls -A "$directory_destination" 2>/dev/null | tr '\n' ',') parent_temp_removed=$([ ! -e "$directory_tmp" ] && printf yes || printf no) nested_temp_removed=$([ ! -e "$directory_nested_tmp" ] && printf yes || printf no)"
+fi
+
+printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
Closes #182. Adopts the externally proposed guard pattern (@pm25coder, comment 5430526039→5430577638): `atomic_write_file` now does cp-with-cleanup → `cmp -s` verify → destination-type check → guarded `mv -f`, with the PID-named temp removed on every failure path. New regression suite drives the copy failure deterministically (subshell-scoped `ulimit -f`) and pins the directory and symlink-to-directory rename traps.

## 完了記録（L1-7）

**候補 SHA: `ea74e923ff8d5de0156300c2ec8a548bec77f1f2`**（= PR head。r1 レビューは `7c0a711`、delta `ea74e92` は test-only — `git diff 7c0a711 ea74e92 -- scripts/lib-state-fold.sh` が空であることを Grok 席が機械確認済み）

### Done when 対応表

1. **cp / mv 両ガード＋非ゼロ伝播＋temp 掃除 — PASS**
   `bash tests/atomic-write-file.test.sh`（2026-08-29, worktree）→ `Summary: 4 PASS, 0 FAIL`。ケース1= `(ulimit -f 1; atomic_write_file …)` が `rc≠0`・destination byte-identical・`.destination.tmp.$$` 不在を assert し PASS。mv 失敗時も `|| { rm -f "$tmp_file"; return 1; }`（scripts/lib-state-fold.sh:416）。
2. **mv 先の型検査をヘルパー側に — PASS**
   `[ -e "$destination" ] && [ ! -f "$destination" ] → refuse`（lib-state-fold.sh:415）。実ディレクトリ・symlink→ディレクトリの両方をテストで釘留め（ケース3/4・2026-08-29 実測 PASS）。Grok 席の型検査マトリクス実測: symlink-to-dir `-e=yes -f=no → refuse`、ガード無し `mv -f` は `rc=0` で実ディレクトリ内に payload 落下（罠の実在確認）。
3. **再現テスト（fix 前赤・fix 後緑）— PASS**
   Alpha 実測（2026-08-29）: `git stash push -q -- scripts/lib-state-fold.sh` で旧コードに対し新テスト → `Summary: 1 PASS, 2 FAIL`（copy-failure が `rc=0 destination_preserved=no`・directory-trap が rc=0 = #182 の欠陥そのもの）→ stash pop 後 `4 PASS, 0 FAIL`。GLM 席も独立に `7c0a711~1` スクラッチ複製で `1 PASS, 2 FAIL` を再現。Grok 席は delta ケースの変異プローブ（ガード無し複製で symlink ケース赤化）を実測。
4. **異種3席レビュー — PASS**
   S 席割= loom-seats 決定論出力（panel: glm-5.3 / kimi-k3 / grok-4.6・writer=codex-sol 前提・quorum GO）。blind r1（候補 `7c0a711`・2026-08-29）: **Kimi K3 = GO / GLM 5.3 = GO-WITH-MINOR / Grok 4.6 = GO-WITH-MINOR・blocking 0**。採用= Grok MINOR-1＋Kimi NIT-2 収束（symlink→dir 未釘留め）→ test-only delta `ea74e92` → **Grok delta = RESOLVED + CUMULATIVE GO**（変異プローブ付き）。GLM/Kimi の票はライブラリ変更なし（上記 diff 空）につき候補に有効。スコープ外 finding（残存 publisher・archive append・呼び出し元 rc）は **#213** に分離起票（宣言ファイル集合を広げないため）。レビュー成果物= セッション記録（seat out ファイル保存済み）。
5. **T-5: release / previous release 欄 — PASS**（下記）

### 宣言ファイル集合 ↔ diff 照合（L0-6）

WIP 宣言（#182 comment 5457489439）= `scripts/lib-state-fold.sh` + `tests/`（新規回帰テスト）。
`git diff --stat origin/main...ea74e92` = `scripts/lib-state-fold.sh | 8 ±` + `tests/atomic-write-file.test.sh | 127 +`（2 files）— **一致・宣言外ゼロ**。

### 身元（L1-3 / L1-10）

- 実装 writer: **Codex GPT-5.6 Sol**（sitter-run 発注・編集納品後にコミット無しで終了→ Alpha 検品の上コミット）
- delta writer（test-only）: **Alpha（Claude Fable 5）**
- レビュー席: **GLM 5.3（Zhipu）/ Kimi K3（Moonshot）/ Grok 4.6（xAI）** — 相互異種・両 writer とも異種。同系統席なし。
- 外部提案者: **@pm25coder**（両コミットに `Suggested-by:` 明記）

### CI

PR checks を green 確認の上で merge する（赤のまま merge しない・既知無関係赤の例外は T-4 のみ）。

### release

- **release: v0.22.2**（出荷相当: 出荷済みライブラリの失敗時挙動が変わる — 切り詰め STATE.md の無音 rename → 正直な非ゼロ拒否）
- **previous release: v0.22.1 — 履行済み**（`gh release view v0.22.1` → tag 実在・draft:false・2026-08-29 検算）
