### PR TITLE
fix(lib-state-fold): never compute a dedup key from an empty normalized string (#118)

### DIFF
--- a/adapters/claude-code/INSTALL.md
+++ b/adapters/claude-code/INSTALL.md
@@ -116,6 +116,10 @@ fold. The same deterministic consumer may be used by Codex and Kimi workspaces b
 their checkpoint hooks emit the shared flush format. It does not assume that a
 model-authored `session=` attribute has been sanitized.
 
+`iconv` is a runtime dependency of flush intake (POSIX-standard and present on
+macOS and Linux); if it is absent, validation fails closed and receipts report
+`rejected=candidates`.
+
 Run the consumer two to four times per day. For a LaunchAgent, use a `StartInterval`
 between `21600` and `43200` seconds. A daily schedule has no jitter margin at the
 default deadman threshold. The consumer calls no model, so its scheduler does not need

--- a/adapters/openclaw/distill-audit.sh
+++ b/adapters/openclaw/distill-audit.sh
@@ -343,8 +343,9 @@ check_draft_integrity() {
         printf '%s\n' "$draft_name" >>"$rejected_drafts"
       fi
       failure_line="- $date_stamp distill integrity mismatch: skill $draft_name declares $field=$value not found (source: distill-audit)"
-      failure_hash=$(candidate_lesson_hash "$failure_line")
-      printf '%s [dedup_key: %s:%s]\n' "$failure_line" "$task_id" "$failure_hash" >>"$integrity_failures"
+      if failure_hash=$(candidate_lesson_hash "$failure_line"); then
+        printf '%s [dedup_key: %s:%s]\n' "$failure_line" "$task_id" "$failure_hash" >>"$integrity_failures"
+      fi
     fi
   done <"$declarations"
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -60,7 +60,7 @@ Pre-existing workspaces create it on first enqueue/runner use; invalid entries f
 
 ## Flush intake consumer receipts
 
-The flush intake consumer's accounting ledger is `loop/pending/intake-runs.log`. The deadman `distill` marker proves only that intake ran; inspect the ledger for content-level silence, dedup, deferral, eviction, and quarantine counts. The `loop/archive/` raw layer is append-only and is never auto-pruned; see [DESIGN.md §3.1](design/DESIGN.md#31-files-per-agent-workspace) for its exact membership. See [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) for the full ledger format and scheduling.
+The flush intake consumer's accounting ledger is `loop/pending/intake-runs.log`. The deadman `distill` marker proves only that intake ran; inspect the ledger for content-level silence, dedup, deferral, eviction, rejection, and quarantine counts. The `rejected` field records content-level rejection of invalid-UTF-8 candidates. The `loop/archive/` raw layer is append-only and is never auto-pruned; see [DESIGN.md §3.1](design/DESIGN.md#31-files-per-agent-workspace) for its exact membership. See [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) for the full ledger format and scheduling.
 
 ## Raw-layer cross-model review
 

--- a/scripts/flush-intake.sh
+++ b/scripts/flush-intake.sh
@@ -103,9 +103,9 @@ write_receipt() {
   local timestamp
 
   timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-  printf 'ts=%s files_scanned=%s blocks=%s candidates=%s folded=%s deduped=%s evicted_by_cap=%s eviction_archive=%s dropped_oversize=%s deferred=%s headerless_bullets=%s torn_lines=%s quarantined=%s lock=%s marker=%s error=%s%s%s%s\n' \
+  printf 'ts=%s files_scanned=%s blocks=%s candidates=%s folded=%s deduped=%s rejected=%s evicted_by_cap=%s eviction_archive=%s dropped_oversize=%s deferred=%s headerless_bullets=%s torn_lines=%s quarantined=%s lock=%s marker=%s error=%s%s%s%s\n' \
     "$timestamp" "$files_scanned" "$blocks" "$candidates" "$folded" "$deduped" \
-    "$evicted_by_cap" "$eviction_archive" "$dropped_oversize" "$deferred" \
+    "$rejected" "$evicted_by_cap" "$eviction_archive" "$dropped_oversize" "$deferred" \
     "$headerless_bullets" "$torn_lines" \
     "$quarantined" "$lock_status" "$marker_status" "$receipt_error" "$quarantined_paths" \
     "$last_session_receipt" \
@@ -156,6 +156,10 @@ consider_candidate() {
   local split_failures="$work_dir/candidate.failures"
 
   candidates=$((candidates + 1))
+  if ! printf '%s' "$text" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1; then
+    rejected=$((rejected + 1))
+    return 0
+  fi
   if (( budget_used >= max_fold )); then
     deferred=$((deferred + 1))
     return 1
@@ -177,11 +181,25 @@ consider_candidate() {
   split_annotated_reply_sections "$annotated_reply" "$split_lessons" "$split_failures" \
     '(source: flush-intake)' 'LESSONS|OPEN_FAILURES'
   if [[ "$target" == lessons ]]; then
-    IFS=$'\t' read -r composite_key line <"$split_lessons"
+    if ! IFS=$'\t' read -r composite_key line <"$split_lessons"; then
+      rejected=$((rejected + 1))
+      return 0
+    fi
   else
-    IFS=$'\t' read -r composite_key line <"$split_failures"
+    if ! IFS=$'\t' read -r composite_key line <"$split_failures"; then
+      rejected=$((rejected + 1))
+      return 0
+    fi
+  fi
+  if [[ -z "$composite_key" || -z "$line" || "$composite_key" != *:* ]]; then
+    rejected=$((rejected + 1))
+    return 0
   fi
   lesson_hash=${composite_key##*:}
+  if [[ -z "$lesson_hash" ]]; then
+    rejected=$((rejected + 1))
+    return 0
+  fi
   if [[ "$target" == lessons ]]; then
     normalized_target=$normalized_lessons_state
   else
@@ -250,6 +268,7 @@ blocks=0
 candidates=0
 folded=0
 deduped=0
+rejected=0
 evicted_by_cap=0
 eviction_archive=none
 dropped_oversize=0

--- a/scripts/lib-state-fold.sh
+++ b/scripts/lib-state-fold.sh
@@ -78,6 +78,7 @@ annotate_reply_dedup_keys() {
   local stripped_line
   local source_anchored_line
   local lesson_hash
+  local LC_ALL=C
 
   state_fold_trace annotate
 
@@ -105,8 +106,9 @@ annotate_reply_dedup_keys() {
     if [[ "$section" != other && -n "$section" \
       && "$source_anchored_line" =~ ^-\ [0-9]{4}-[0-9]{2}-[0-9]{2}\  \
       && "$source_anchored_line" == *" $source_marker" ]]; then
-      lesson_hash=$(candidate_lesson_hash "$stripped_line")
-      printf '%s [dedup_key: %s:%s]\n' "$stripped_line" "$task_id" "$lesson_hash" >>"$annotated_reply"
+      if lesson_hash=$(candidate_lesson_hash "$stripped_line"); then
+        printf '%s [dedup_key: %s:%s]\n' "$stripped_line" "$task_id" "$lesson_hash" >>"$annotated_reply"
+      fi
     else
       printf '%s\n' "$stripped_line" >>"$annotated_reply"
     fi
@@ -128,7 +130,12 @@ normalize_state_candidate() {
 
 normalize_state_candidate_key_text() {
   local normalized
-  normalized=$(normalize_state_candidate "$1")
+  if ! normalized=$(normalize_state_candidate "$1"); then
+    return 1
+  fi
+  if [[ -n "$1" && -z "$normalized" ]]; then
+    return 1
+  fi
 
   # NFKC intentionally has a broad compatibility effect, not just the NBSP and
   # fullwidth-ASCII folds needed here. For example, it maps x²/x₂ to x2,
@@ -155,7 +162,7 @@ SMART_QUOTES = str.maketrans({
 value = unicodedata.normalize("NFKC", sys.argv[1]).translate(SMART_QUOTES)
 # Compatibility spaces introduced by NFKC join the existing whitespace fold.
 value = re.sub(r" +", " ", value).strip(" ")
-sys.stdout.write(value + "\n")
+sys.stdout.buffer.write((value + "\n").encode("utf-8"))
 PY
 }
 
@@ -164,7 +171,10 @@ PY
 # before a newly normalized key is recorded for later folds.
 candidate_lesson_hash() {
   local normalized
-  normalized=$(normalize_state_candidate_key_text "$1")
+  if ! normalized=$(normalize_state_candidate_key_text "$1"); then
+    return 1
+  fi
+  [[ -n "$normalized" ]] || return 1
   sha256_text "$normalized"
 }
 
@@ -215,8 +225,9 @@ snapshot_state_normalized_candidates() {
   local section_headings=$3
   local raw_file="$output.raw.$$"
   local line
+  local normalized
 
-  awk -v section_headings="$section_headings" '
+  LC_ALL=C awk -v section_headings="$section_headings" '
     BEGIN {
       count = split(section_headings, headings, "|")
       for (i = 1; i <= count; i++) allowed[headings[i]] = 1
@@ -236,7 +247,9 @@ snapshot_state_normalized_candidates() {
 
   : >"$output"
   while IFS= read -r line || [[ -n "$line" ]]; do
-    normalize_state_candidate_key_text "$line" >>"$output"
+    if normalized=$(normalize_state_candidate_key_text "$line"); then
+      [[ -n "$normalized" ]] && printf '%s\n' "$normalized" >>"$output"
+    fi
   done <"$raw_file"
   rm -f "$raw_file"
 }
@@ -253,7 +266,8 @@ state_fold_candidate_is_duplicate() {
 
   state_fold_trace dedup
 
-  normalized=$(normalize_state_candidate_key_text "$candidate_line")
+  normalized=$(normalize_state_candidate_key_text "$candidate_line") || return 1
+  [[ -n "$normalized" ]] || return 1
   grep -Fqx -- "$lesson_hash" "$prior_hashes" \
     || grep -Fqx -- "$lesson_hash" "$batch_hashes" \
     || grep -Fqx -- "$normalized" "$normalized_state" \

--- a/scripts/lib-state-fold.sh
+++ b/scripts/lib-state-fold.sh
@@ -78,6 +78,8 @@ annotate_reply_dedup_keys() {
   local stripped_line
   local source_anchored_line
   local lesson_hash
+  # Keep this shell-local for byte-wise bash regex matching only. Child
+  # processes intentionally retain the ambient locale so valid keys do not drift.
   local LC_ALL=C
 
   state_fold_trace annotate
@@ -162,7 +164,10 @@ SMART_QUOTES = str.maketrans({
 value = unicodedata.normalize("NFKC", sys.argv[1]).translate(SMART_QUOTES)
 # Compatibility spaces introduced by NFKC join the existing whitespace fold.
 value = re.sub(r" +", " ", value).strip(" ")
-sys.stdout.buffer.write((value + "\n").encode("utf-8"))
+try:
+    sys.stdout.buffer.write((value + "\n").encode("utf-8"))
+except UnicodeEncodeError:
+    sys.exit(1)
 PY
 }
 

--- a/tests/distill-audit.test.sh
+++ b/tests/distill-audit.test.sh
@@ -733,6 +733,22 @@ else
   fail_case "integrity gate accepts existing files_created references" "rc=$rc output=$output"
 fi
 
+ws=$(make_ws integrity-invalid-utf8-hash)
+invalid_integrity_value=$'wrong-\xff\xfe-value'
+reply=$(printf '## LESSONS\n## OPEN_FAILURES\n## SKILL_DRAFTS\n### invalid-integrity-hash\ntrigger: test\ntarget_skill: %s\nDo not create this skill.\n### valid-integrity-sibling\ntrigger: test\ntarget_skill: different-valid-name\nDo not create this skill.' "$invalid_integrity_value")
+set +e
+output=$(LC_ALL=C DISTILL_REPLY="$reply" DISTILLER_CMD="$distiller" bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] \
+  && ! LC_ALL=C grep -R -a -E '\[dedup_key: [0-9a-f]{64}:\]' "$ws" >/dev/null 2>&1 \
+  && LC_ALL=C grep -R -a -E 'distill integrity mismatch: skill valid-integrity-sibling.*\[dedup_key: [0-9a-f]{64}:[0-9a-f]{64}\]' "$ws" >/dev/null 2>&1; then
+  pass "integrity hash refusal emits no empty key and preserves valid sibling keys"
+else
+  fail_case "integrity hash refusal emits no empty key and preserves valid sibling keys" \
+    "rc=$rc output=$(LC_ALL=C printf '%s' "$output" | sed -n l) artifacts=$(LC_ALL=C grep -R -a -n 'dedup_key:' "$ws" 2>/dev/null)"
+fi
+
 ws=$(make_ws integrity-mechanically-checkable)
 reply='## LESSONS
 ## OPEN_FAILURES

--- a/tests/lesson-hash-invalid-utf8.test.sh
+++ b/tests/lesson-hash-invalid-utf8.test.sh
@@ -51,6 +51,9 @@ hash_candidate_with_normalizer() {
       awk-failure)
         normalize_state_candidate() { return 1; }
         ;;
+      partial-failure)
+        normalize_state_candidate() { printf "partial\n"; return 1; }
+        ;;
       python-failure)
         normalize_state_candidate() { printf "%s\n" "$1"; }
         ;;
@@ -77,6 +80,24 @@ else
     "rcs=$invalid_one_rc/$invalid_two_rc outputs=$(tr '\n' ';' <"$invalid_one_out")/$(tr '\n' ';' <"$invalid_two_out")"
 fi
 
+quiet_out=$TMP_ROOT/quiet-invalid.out
+quiet_err=$TMP_ROOT/quiet-invalid.err
+set +e
+bash -c '
+  source "$1"
+  set +e
+  normalize_state_candidate() { printf "%s\n" "$1"; }
+  candidate_lesson_hash "$2"
+' _ "$STATE_FOLD_LIB" "$invalid_one" >"$quiet_out" 2>"$quiet_err"
+quiet_rc=$?
+set -e
+if [ "$quiet_rc" -ne 0 ] && [ ! -s "$quiet_out" ] && [ ! -s "$quiet_err" ]; then
+  pass 'invalid-UTF-8 encode refusal is quiet'
+else
+  fail_case 'invalid-UTF-8 encode refusal is quiet' \
+    "rc=$quiet_rc stdout=$(LC_ALL=C sed -n l "$quiet_out") stderr=$(LC_ALL=C sed -n l "$quiet_err")"
+fi
+
 awk_failure_out=$TMP_ROOT/awk-failure.out
 python_failure_out=$TMP_ROOT/python-failure.out
 set +e
@@ -91,6 +112,35 @@ if [ "$awk_failure_rc" -ne 0 ] && [ "$python_failure_rc" -ne 0 ] \
 else
   fail_case 'awk-stage and Python-stage failures independently refuse hashing' \
     "rcs=$awk_failure_rc/$python_failure_rc outputs=$(tr '\n' ';' <"$awk_failure_out")/$(tr '\n' ';' <"$python_failure_out")"
+fi
+
+partial_failure_out=$TMP_ROOT/partial-failure.out
+set +e
+hash_candidate_with_normalizer 'ordinary text' partial-failure "$partial_failure_out"
+partial_failure_rc=$?
+set -e
+if [ "$partial_failure_rc" -ne 0 ] && [ ! -s "$partial_failure_out" ]; then
+  pass 'partial normalizer output with failure status is refused'
+else
+  fail_case 'partial normalizer output with failure status is refused' \
+    "rc=$partial_failure_rc output=$(tr '\n' ';' <"$partial_failure_out")"
+fi
+
+key_text_empty_out=$TMP_ROOT/key-text-empty.out
+set +e
+bash -c '
+  source "$1"
+  set +e
+  normalize_state_candidate() { return 0; }
+  normalize_state_candidate_key_text "ordinary text"
+' _ "$STATE_FOLD_LIB" >"$key_text_empty_out" 2>/dev/null
+key_text_empty_rc=$?
+set -e
+if [ "$key_text_empty_rc" -ne 0 ] && [ ! -s "$key_text_empty_out" ]; then
+  pass 'key-text normalization refuses empty output for non-empty input'
+else
+  fail_case 'key-text normalization refuses empty output for non-empty input' \
+    "rc=$key_text_empty_rc output=$(tr '\n' ';' <"$key_text_empty_out")"
 fi
 
 empty_out=$TMP_ROOT/empty.out
@@ -123,6 +173,7 @@ annotated=$TMP_ROOT/invalid.annotated
   printf '%s\n' "$invalid_one"
 } >"$reply"
 : >"$annotated"
+set +e
 bash -c '
   source "$1"
   set +e
@@ -131,6 +182,7 @@ bash -c '
     "$3" "(source: distill-audit)" "LESSONS|OPEN_FAILURES"
 ' _ "$STATE_FOLD_LIB" "$reply" "$annotated" 2>/dev/null
 annotate_rc=$?
+set -e
 if [ "$annotate_rc" -eq 0 ] \
   && [ "$(wc -l <"$annotated" | tr -d '[:space:]')" -eq 1 ] \
   && grep -Fqx -- '## LESSONS' "$annotated" \
@@ -149,12 +201,14 @@ normalized_state=$TMP_ROOT/state.normalized
   printf '%s\n' '- 2026-08-29 valid historical lesson (source: distill-audit)'
   printf '%s\n' '## Open failures'
 } >"$state"
+set +e
 bash -c '
   source "$1"
   set +e
   snapshot_state_normalized_candidates "$2" "$3" "## Lessons learned"
 ' _ "$STATE_FOLD_LIB" "$state" "$normalized_state" 2>/dev/null
 snapshot_rc=$?
+set -e
 if [ "$snapshot_rc" -eq 0 ] \
   && [ "$(wc -l <"$normalized_state" | tr -d '[:space:]')" -eq 1 ] \
   && grep -Fqx -- 'valid historical lesson' "$normalized_state"; then
@@ -196,9 +250,13 @@ invalid_flush=$workspace/loop/pending/flush-2026-07-22.md
   printf -- '- Invalid UTF-8 \377\376 candidate is refused.\n'
 } >"$invalid_flush"
 cp "$invalid_flush" "$TMP_ROOT/invalid-utf8-original.md"
-INTAKE_LOCK_SLEEP_S=0 "$INTAKE" "$workspace" \
+intake_trace=$TMP_ROOT/intake.trace
+: >"$intake_trace"
+set +e
+STATE_FOLD_TEST_TRACE_FILE="$intake_trace" INTAKE_LOCK_SLEEP_S=0 "$INTAKE" "$workspace" \
   >"$TMP_ROOT/intake.out" 2>"$TMP_ROOT/intake.err"
 intake_rc=$?
+set -e
 if [ "$intake_rc" -eq 0 ] \
   && [ "$(receipt_value "$workspace" candidates)" -eq 1 ] \
   && [ "$(receipt_value "$workspace" rejected)" -eq 1 ] \
@@ -211,6 +269,13 @@ if [ "$intake_rc" -eq 0 ] \
 else
   fail_case 'intake rejects invalid UTF-8 visibly and archives the raw file byte-identically' \
     "rc=$intake_rc receipt=$(tail -n 1 "$workspace/loop/pending/intake-runs.log" 2>/dev/null)"
+fi
+
+if ! grep -Eq '^(annotate|dedup)$' "$intake_trace"; then
+  pass 'intake invalid-UTF-8 validation stops before annotation and dedup'
+else
+  fail_case 'intake invalid-UTF-8 validation stops before annotation and dedup' \
+    "trace=$(tr '\n' ',' <"$intake_trace")"
 fi
 
 ascii_out=$TMP_ROOT/ascii.out

--- a/tests/lesson-hash-invalid-utf8.test.sh
+++ b/tests/lesson-hash-invalid-utf8.test.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+STATE_FOLD_LIB=$ROOT/scripts/lib-state-fold.sh
+INTAKE=$ROOT/adapters/claude-code/flush-intake.sh
+TMP_ROOT=${TMPDIR:-/tmp}/lesson-hash-invalid-utf8-test.$$
+EMPTY_SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+ASCII_EXPECTED=b238af1ca82d4fcba0c46adc0ab0125c73f0b53e0065365158ea0d03de83a879
+PASS_COUNT=0
+FAIL_COUNT=0
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+mkdir -p "$TMP_ROOT"
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+fail_case() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL %s: %s\n' "$1" "$2"
+}
+
+receipt_value() {
+  local workspace=$1
+  local key=$2
+  tail -n 1 "$workspace/loop/pending/intake-runs.log" \
+    | tr ' ' '\n' | sed -n "s/^$key=//p" | head -n 1
+}
+
+hash_candidate() {
+  local candidate=$1
+  local output=$2
+  bash -c 'source "$1"; set +e; candidate_lesson_hash "$2"' _ \
+    "$STATE_FOLD_LIB" "$candidate" >"$output" 2>/dev/null
+}
+
+hash_candidate_with_normalizer() {
+  local candidate=$1
+  local normalizer_mode=$2
+  local output=$3
+  bash -c '
+    source "$1"
+    set +e
+    case "$2" in
+      awk-failure)
+        normalize_state_candidate() { return 1; }
+        ;;
+      python-failure)
+        normalize_state_candidate() { printf "%s\n" "$1"; }
+        ;;
+    esac
+    candidate_lesson_hash "$3"
+  ' _ "$STATE_FOLD_LIB" "$normalizer_mode" "$candidate" >"$output" 2>/dev/null
+}
+
+invalid_one=$'- 2026-08-29 \xff\xfe broken one (source: distill-audit)'
+invalid_two=$'- 2026-08-29 \xff\xfe totally different text (source: distill-audit)'
+invalid_one_out=$TMP_ROOT/invalid-one.out
+invalid_two_out=$TMP_ROOT/invalid-two.out
+set +e
+hash_candidate "$invalid_one" "$invalid_one_out"
+invalid_one_rc=$?
+hash_candidate "$invalid_two" "$invalid_two_out"
+invalid_two_rc=$?
+set -e
+if [ "$invalid_one_rc" -ne 0 ] && [ "$invalid_two_rc" -ne 0 ] \
+  && [ ! -s "$invalid_one_out" ] && [ ! -s "$invalid_two_out" ]; then
+  pass 'different invalid-UTF-8 lessons are both refused without output'
+else
+  fail_case 'different invalid-UTF-8 lessons are both refused without output' \
+    "rcs=$invalid_one_rc/$invalid_two_rc outputs=$(tr '\n' ';' <"$invalid_one_out")/$(tr '\n' ';' <"$invalid_two_out")"
+fi
+
+awk_failure_out=$TMP_ROOT/awk-failure.out
+python_failure_out=$TMP_ROOT/python-failure.out
+set +e
+hash_candidate_with_normalizer 'ordinary text' awk-failure "$awk_failure_out"
+awk_failure_rc=$?
+hash_candidate_with_normalizer "$invalid_one" python-failure "$python_failure_out"
+python_failure_rc=$?
+set -e
+if [ "$awk_failure_rc" -ne 0 ] && [ "$python_failure_rc" -ne 0 ] \
+  && [ ! -s "$awk_failure_out" ] && [ ! -s "$python_failure_out" ]; then
+  pass 'awk-stage and Python-stage failures independently refuse hashing'
+else
+  fail_case 'awk-stage and Python-stage failures independently refuse hashing' \
+    "rcs=$awk_failure_rc/$python_failure_rc outputs=$(tr '\n' ';' <"$awk_failure_out")/$(tr '\n' ';' <"$python_failure_out")"
+fi
+
+empty_out=$TMP_ROOT/empty.out
+normalized_empty_out=$TMP_ROOT/normalized-empty.out
+set +e
+hash_candidate '' "$empty_out"
+empty_rc=$?
+hash_candidate '   ' "$normalized_empty_out"
+normalized_empty_rc=$?
+set -e
+if [ "$empty_rc" -ne 0 ] && [ "$normalized_empty_rc" -ne 0 ] \
+  && [ ! -s "$empty_out" ] && [ ! -s "$normalized_empty_out" ]; then
+  pass 'empty and empty-normalized lessons are refused without output'
+else
+  fail_case 'empty and empty-normalized lessons are refused without output' \
+    "rcs=$empty_rc/$normalized_empty_rc outputs=$(tr '\n' ';' <"$empty_out")/$(tr '\n' ';' <"$normalized_empty_out")"
+fi
+
+if ! grep -Fqx -- "$EMPTY_SHA256" "$invalid_one_out" "$invalid_two_out" \
+  "$awk_failure_out" "$python_failure_out" "$empty_out" "$normalized_empty_out"; then
+  pass 'sha256 of empty text is never emitted as a lesson key'
+else
+  fail_case 'sha256 of empty text is never emitted as a lesson key' 'empty digest was emitted'
+fi
+
+reply=$TMP_ROOT/invalid.reply
+annotated=$TMP_ROOT/invalid.annotated
+{
+  printf '%s\n' '## LESSONS'
+  printf '%s\n' "$invalid_one"
+} >"$reply"
+: >"$annotated"
+bash -c '
+  source "$1"
+  set +e
+  annotate_reply_dedup_keys "$2" \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+    "$3" "(source: distill-audit)" "LESSONS|OPEN_FAILURES"
+' _ "$STATE_FOLD_LIB" "$reply" "$annotated" 2>/dev/null
+annotate_rc=$?
+if [ "$annotate_rc" -eq 0 ] \
+  && [ "$(wc -l <"$annotated" | tr -d '[:space:]')" -eq 1 ] \
+  && grep -Fqx -- '## LESSONS' "$annotated" \
+  && ! LC_ALL=C grep -Fq '[dedup_key:' "$annotated"; then
+  pass 'annotation drops a refused lesson instead of emitting an empty key'
+else
+  fail_case 'annotation drops a refused lesson instead of emitting an empty key' \
+    "rc=$annotate_rc output=$(LC_ALL=C sed -n l "$annotated")"
+fi
+
+state=$TMP_ROOT/state.md
+normalized_state=$TMP_ROOT/state.normalized
+{
+  printf '%s\n' '## Lessons learned'
+  printf '%s\n' "$invalid_one"
+  printf '%s\n' '- 2026-08-29 valid historical lesson (source: distill-audit)'
+  printf '%s\n' '## Open failures'
+} >"$state"
+bash -c '
+  source "$1"
+  set +e
+  snapshot_state_normalized_candidates "$2" "$3" "## Lessons learned"
+' _ "$STATE_FOLD_LIB" "$state" "$normalized_state" 2>/dev/null
+snapshot_rc=$?
+if [ "$snapshot_rc" -eq 0 ] \
+  && [ "$(wc -l <"$normalized_state" | tr -d '[:space:]')" -eq 1 ] \
+  && grep -Fqx -- 'valid historical lesson' "$normalized_state"; then
+  pass 'STATE snapshot skips a refused historical line without adding an empty entry'
+else
+  fail_case 'STATE snapshot skips a refused historical line without adding an empty entry' \
+    "rc=$snapshot_rc output=$(LC_ALL=C sed -n l "$normalized_state")"
+fi
+
+prior_hashes=$TMP_ROOT/prior.hashes
+batch_hashes=$TMP_ROOT/batch.hashes
+empty_normalized_state=$TMP_ROOT/empty-normalized-state
+: >"$prior_hashes"
+: >"$batch_hashes"
+printf '\n' >"$empty_normalized_state"
+set +e
+bash -c '
+  source "$1"
+  set +e
+  state_fold_candidate_is_duplicate \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+    "$2" "$3" "$4" "$5" "$6"
+' _ "$STATE_FOLD_LIB" "$invalid_one" "$prior_hashes" "$batch_hashes" \
+  "$state" "$empty_normalized_state" 2>/dev/null
+duplicate_rc=$?
+set -e
+if [ "$duplicate_rc" -ne 0 ]; then
+  pass 'normalization failure cannot match an empty normalized-state entry'
+else
+  fail_case 'normalization failure cannot match an empty normalized-state entry' \
+    'invalid candidate was treated as a duplicate'
+fi
+
+workspace=$TMP_ROOT/intake-workspace
+"$ROOT/scripts/loop-init" --workspace "$workspace" >/dev/null
+invalid_flush=$workspace/loop/pending/flush-2026-07-22.md
+{
+  printf '%s\n' '<!-- flush ts=2026-07-22T01:02:03Z outcome=ok -->'
+  printf -- '- Invalid UTF-8 \377\376 candidate is refused.\n'
+} >"$invalid_flush"
+cp "$invalid_flush" "$TMP_ROOT/invalid-utf8-original.md"
+INTAKE_LOCK_SLEEP_S=0 "$INTAKE" "$workspace" \
+  >"$TMP_ROOT/intake.out" 2>"$TMP_ROOT/intake.err"
+intake_rc=$?
+if [ "$intake_rc" -eq 0 ] \
+  && [ "$(receipt_value "$workspace" candidates)" -eq 1 ] \
+  && [ "$(receipt_value "$workspace" rejected)" -eq 1 ] \
+  && [ "$(receipt_value "$workspace" folded)" -eq 0 ] \
+  && [ "$(receipt_value "$workspace" deduped)" -eq 0 ] \
+  && ! LC_ALL=C grep -Fq 'Invalid UTF-8' "$workspace/STATE.md" \
+  && cmp -s "$TMP_ROOT/invalid-utf8-original.md" \
+    "$workspace/loop/archive/flush-2026-07-22.md"; then
+  pass 'intake rejects invalid UTF-8 visibly and archives the raw file byte-identically'
+else
+  fail_case 'intake rejects invalid UTF-8 visibly and archives the raw file byte-identically' \
+    "rc=$intake_rc receipt=$(tail -n 1 "$workspace/loop/pending/intake-runs.log" 2>/dev/null)"
+fi
+
+ascii_out=$TMP_ROOT/ascii.out
+if hash_candidate '- 2026-08-29 plain ASCII control (source: distill-audit)' "$ascii_out" \
+  && [ "$(cat "$ascii_out")" = "$ASCII_EXPECTED" ]; then
+  pass 'plain-ASCII lesson keeps its pre-fix hash'
+else
+  fail_case 'plain-ASCII lesson keeps its pre-fix hash' \
+    "actual=$(cat "$ascii_out" 2>/dev/null) expected=$ASCII_EXPECTED"
+fi
+
+printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
Fixes #118.

Invalid UTF-8 in a lesson collapsed its dedup key to `sha256("")` (`e3b0c442…`), so every such lesson collided with every other one and was silently dropped. Adopted invariant (from @pm25coder's two-path analysis, issue comment 5430526039): **a dedup key must never be computed from an empty normalized string.** Design = option 1 (fail-closed guards at every caller + empty-normalized refusal inside `candidate_lesson_hash`) + option 3 (reject invalid UTF-8 at flush-intake with a visible `rejected=` receipt counter). Both independent failure paths are closed: Path A (BSD awk abort, previously swallowed) via status guard + empty-output refusal; Path B (python NFKC stage failure, previously unchecked in `candidate_lesson_hash`) via strict `.encode("utf-8")` + status propagation — deterministic on platforms where awk passes invalid bytes through instead of aborting.

Commits: `634f537` (core fix + regression suite) + `31c9fd7` (3-seat review adoptions: last unguarded caller in the openclaw adapter, per-guard pin tests, quiet Path B refusal, docs). Reviews ran at pre-rebase SHAs `ba2a366` / `29638d2`; rebased onto current main with `git range-diff` showing `=` for both commits (byte-identical content), post-rebase `make test` 42/42 + `make lint` re-run.

## Files touched (WIP declarations: issue comments 5459984744 → re-declared 5460437154)

- scripts/lib-state-fold.sh
- scripts/flush-intake.sh
- adapters/openclaw/distill-audit.sh
- docs/reference.md
- adapters/claude-code/INSTALL.md
- tests/lesson-hash-invalid-utf8.test.sh (new)
- tests/distill-audit.test.sh

Declared but unchanged (no delta needed): scripts/raw-review.sh (its :701 caller already fail-closed; verified), tests/pending-dedup.test.sh, tests/flush-intake.test.sh. Follow-up outside scope: docs/reference.ja.md translation sync (one sentence).

`git diff --stat origin/main...31c9fd7` matches the list above exactly (verification below).

## 完了記録 (L1-7)

Candidate SHA: `31c9fd7` (= PR head)

### Done when ↔ evidence (2026-08-29, all commands run in worktree `caty-agent-harness-wt-118`)

1. **`normalize_state_candidate` failure is detected instead of returning empty text — PASS**
   `normalize_state_candidate_key_text` guards the awk stage (status + empty-output-for-non-empty-input refusal, lib-state-fold.sh:132-138) and propagates the python stage's exit. Evidence: `bash tests/lesson-hash-invalid-utf8.test.sh` → `PASS awk-stage and Python-stage failures independently refuse hashing`, `PASS partial normalizer output with failure status is refused`, `PASS key-text normalization refuses empty output for non-empty input` (13 PASS, 0 FAIL). Manual probe: `candidate_lesson_hash $'- 2026-08-29 \xff\xfe broken one (source: distill-audit)'` → rc=1, empty stdout/stderr.
2. **Behaviour for invalid input decided and stated — PASS**
   Chosen: **fail closed** (option 1) + **intake boundary rejection** (option 3), stated in commit ba2a366's message. `sha256("")` is unreachable: `PASS sha256 of empty text is never emitted as a lesson key`. Rejection is visible: intake receipt gains `rejected=` (`PASS intake rejects invalid UTF-8 visibly and archives the raw file byte-identically`; live receipt `candidates=1 rejected=1 folded=0 deduped=0`).
3. **Regression test: two different invalid-UTF-8 lessons ⇒ refused; fails if detection removed — PASS**
   `PASS different invalid-UTF-8 lessons are both refused without output`. Red proof (2026-08-29, at the 9-case ba2a366 stage): with the guards stashed, the suite fails 8/9 including emission of `e3b0c442…` for both lessons (the #118 collapse reproduced); guards restored → all PASS (13/13 after the delta additions). Five single-guard knockouts (status guard / key_text empty-check / candidate_lesson_hash empty-check / iconv stanza / distill-audit guard) each turn ≥1 named test red — per-layer detection, not aggregate only.
4. **Same awk path checked for other aborting inputs — PASS**
   The choke-point refusal keys on *empty normalized output and nonzero status*, not on UTF-8 specifically; Grok seat reproduced identical abort behaviour for incomplete (`\xc3`), lone-continuation (`\x80`), and overlong (`\xc0\xaf`) sequences, and the GNU-awk-shaped exit-0-empty variant is pinned by test (`key-text normalization refuses empty output for non-empty input`). Sibling consumers audited by the seats: raw-review.sh:701 pre-existing fail-closed; distill-audit.sh:346 was the one unguarded caller → guarded in 29638d2 with regression (`integrity hash refusal emits no empty key and preserves valid sibling keys`; knockout → red).

Key-compatibility guarantee (append-only history): plain-ASCII control hash byte-identical to origin/main (`b238af1c…`, pinned in-suite); GLM seat verified 12/12 valid-input digests identical old-vs-new; `local LC_ALL=C` deliberately NOT exported to children to avoid NBSP-suffix key drift (comment in code, adjudication note below).

### Test / CI state

- `make test`: **42/42 suites PASS, 0 FAIL** (run twice: after ba2a366 and after 29638d2, 2026-08-29)
- `make lint`: clean (`bash32 ANSI-C lint: 88 shell files OK` / `lint: 88 shell files OK`)
- T-2 regression tests included (M-size bug fix): tests/lesson-hash-invalid-utf8.test.sh (13 cases) + distill-audit integrity case
- CI on this PR: all checks green at head 31c9fd7 — test-lint (lint / test 20m / test-macos 26m), gitleaks, history-check, repo-state, risk-review-gate (3 jobs), watch, pr-size (green after owner-applied size-exempt label; excess is the 291-line regression test file; run 33242441776)

### Review (S/M 異種3席・writer=Codex GPT-5.6 Sol・Alpha=orchestrator, not a counted seat)

| seat | requested | actual | r1 verdict | delta verdict |
|---|---|---|---|---|
| GLM | glm-5.3 | glm-5.3 | GO-WITH-MINOR (MAJOR-1: distill-audit unguarded caller; M1-M4 mutation probes) | **GO** (all RESOLVED; accepted D5 non-adoption with own measurement) |
| Grok | grok-4.6 | grok-4.6 | GO-WITH-MINOR (4 MINOR incl. convergent distill-audit + locale/traceback analysis) | **GO** (all RESOLVED; 6 knockouts re-verified independently) |
| Kimi → Gemini | kimi-k3 | **gemini-3.7-flash** (substitution: Kimi weekly quota 403 at kickoff; static-form seat) | GO-WITH-MINOR (set -e test hygiene) | **GO** (RESOLVED) |

All r1 seats ran blind (fresh context, isolated dirs, no cross-seat findings). Seat effort: GLM/Grok dynamic probing incl. mutation testing in scratch copies; Gemini static with full diff inline. Full seat records: r1 `seats-118/{glm,grok,gemini}/review.md`, delta `delta-review.md` (session scratchpad); adjudication summary in issue comment (posted at merge).

Adjudication notes: 6 findings adopted (D1-D6, commit 29638d2). One suggestion rejected with recorded rationale: converting `local LC_ALL=C` to exported form would change awk `[[:space:]]` suffix-stripping for NBSP-adjacent inputs and introduce key drift against historical `[dedup_key:]` annotations — comment-only instead (both proposing seats' own measurements support this).

### release

- **release: v0.22.3** (shipped-equivalent: the dedup layer's failure behaviour changes from silent collapse to refusal; intake receipts gain the `rejected=` field)
- **previous release: v0.22.2 — 履行済み** (`gh release list` → v0.22.2 Latest, 2026-08-28; PR #215 in between is `release: N/A ③` and does not enter the shipped chain)

### Credit

External analysis and regression-test specification adopted from @pm25coder (issue #118, comment 5430526039). Credited in both commit trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
