### PR TITLE
fix(#213): extend verify-then-rename guarantees beyond atomic_write_file

### DIFF
--- a/adapters/openclaw/distill-audit.sh
+++ b/adapters/openclaw/distill-audit.sh
@@ -445,7 +445,7 @@ distiller_cmd=${DISTILLER_CMD:-}
 distiller_id=${DISTILLER_ID:-$distiller_cmd}
 state_file="$workspace/STATE.md"
 state_dir=$(cd "$(dirname "$state_file")" && pwd)
-state_tmp_file="$state_dir/.STATE.md.tmp.$$"
+state_tmp_file="$state_dir/.STATE.md.rebuild.$$"
 marker_file="$workspace/loop/.distill-last-run"
 pending_dir="$workspace/loop/pending"
 staging_dir=${STAGING_DIR:-$workspace/skills/_staging}
@@ -702,7 +702,7 @@ if [[ "$lessons_added" -gt 0 || "$failures_added" -gt 0 ]]; then
   elif [[ "$append_rc" -ne 0 ]]; then
     infra_fail "STATE.md fold failed (append rc=$append_rc)"
   fi
-  mv -f "$state_tmp_file" "$state_file"
+  atomic_write_file "$state_tmp_file" "$state_file" || infra_fail 'STATE.md publish failed'
   evicted_by_cap=$(cat "$work_dir/evicted-count.txt")
 fi
 

--- a/scripts/flush-intake.sh
+++ b/scripts/flush-intake.sh
@@ -293,7 +293,7 @@ fi
 
 tmp_root=${TMPDIR:-/tmp}
 work_dir=$(mktemp -d "$tmp_root/flush-intake.XXXXXX")
-state_tmp="$workspace/.STATE.md.tmp.$$"
+state_tmp="$workspace/.STATE.md.rebuild.$$"
 marker_tmp="$deadman_dir/.distill.marker.tmp.$$"
 # shellcheck disable=SC2329
 cleanup() {
@@ -473,7 +473,12 @@ if [[ -s "$accepted_lessons" || -s "$accepted_failures" ]]; then
       "$adapter_identity" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >>"$eviction_archive_path"
     cat "$evicted_lessons_file" >>"$eviction_archive_path"
   fi
-  mv -f "$state_tmp" "$state_file"
+  if ! atomic_write_file "$state_tmp" "$state_file"; then
+    folded=0
+    receipt_error=state-publish
+    write_receipt acquired untouched
+    exit 1
+  fi
   if [[ ${INTAKE_TEST_CRASH_AFTER_STATE:-0} == 1 ]]; then
     exit 75
   fi
@@ -490,7 +495,11 @@ if [[ -s "$accepted_keys" ]]; then
   while IFS= read -r composite_key || [[ -n "$composite_key" ]]; do
     printf '<!-- carried dedup_key: %s -->\n' "$composite_key" >>"$ledger_source"
   done <"$accepted_keys"
-  atomic_write_file "$ledger_source" "$ledger_file"
+  if ! atomic_write_file "$ledger_source" "$ledger_file"; then
+    receipt_error=ledger-write
+    write_receipt acquired untouched
+    exit 1
+  fi
 fi
 
 while IFS=$'\034' read -r action source_path relative_path || [[ -n "$action" ]]; do

--- a/scripts/lib-state-fold.sh
+++ b/scripts/lib-state-fold.sh
@@ -599,23 +599,47 @@ state_fold_atomic_archive_append() {
   archive_name=${archive_file##*/}
   tmp_file="$archive_dir/.$archive_name.tmp.$$"
   if [[ -f "$archive_file" ]]; then
-    cp "$archive_file" "$tmp_file" || return 1
-    before_bytes=$(wc -c <"$archive_file" | tr -d '[:space:]')
+    cp "$archive_file" "$tmp_file" || { rm -f "$tmp_file"; return 1; }
+    if ! before_bytes=$(wc -c <"$archive_file" | tr -d '[:space:]'); then
+      rm -f "$tmp_file"
+      return 1
+    fi
   else
-    : >"$tmp_file" || return 1
+    : >"$tmp_file" || { rm -f "$tmp_file"; return 1; }
   fi
-  source_bytes=$(wc -c <"$source_file" | tr -d '[:space:]')
+  if ! source_bytes=$(wc -c <"$source_file" | tr -d '[:space:]'); then
+    rm -f "$tmp_file"
+    return 1
+  fi
   cat "$source_file" >>"$tmp_file" || {
     rm -f "$tmp_file"
     return 1
   }
   expected_bytes=$((before_bytes + source_bytes))
-  actual_bytes=$(wc -c <"$tmp_file" | tr -d '[:space:]')
+  if ! actual_bytes=$(wc -c <"$tmp_file" | tr -d '[:space:]'); then
+    rm -f "$tmp_file"
+    return 1
+  fi
   if [[ "$actual_bytes" -ne "$expected_bytes" ]]; then
     rm -f "$tmp_file"
     return 1
   fi
-  mv -f "$tmp_file" "$archive_file"
+  if [[ "$source_bytes" -gt 0 ]] \
+    && ! tail -c "$source_bytes" "$tmp_file" | cmp -s - "$source_file"; then
+    rm -f "$tmp_file"
+    return 1
+  fi
+  if [[ "$before_bytes" -gt 0 ]] \
+    && ! head -c "$before_bytes" "$tmp_file" | cmp -s - "$archive_file"; then
+    rm -f "$tmp_file"
+    return 1
+  fi
+  # The destination must be a regular file or absent, never a directory.
+  if [ -e "$archive_file" ] && [ ! -f "$archive_file" ]; then
+    rm -f "$tmp_file"
+    return 1
+  fi
+  mv -f "$tmp_file" "$archive_file" || { rm -f "$tmp_file"; return 1; }
 }
 
 fold_declared_state_caps() {

--- a/scripts/lib-state-fold.sh
+++ b/scripts/lib-state-fold.sh
@@ -600,26 +600,29 @@ state_fold_atomic_archive_append() {
   tmp_file="$archive_dir/.$archive_name.tmp.$$"
   if [[ -f "$archive_file" ]]; then
     cp "$archive_file" "$tmp_file" || { rm -f "$tmp_file"; return 1; }
-    if ! before_bytes=$(wc -c <"$archive_file" | tr -d '[:space:]'); then
+    if ! before_bytes=$(wc -c <"$archive_file"); then
       rm -f "$tmp_file"
       return 1
     fi
+    before_bytes=${before_bytes//[[:space:]]/}
   else
     : >"$tmp_file" || { rm -f "$tmp_file"; return 1; }
   fi
-  if ! source_bytes=$(wc -c <"$source_file" | tr -d '[:space:]'); then
+  if ! source_bytes=$(wc -c <"$source_file"); then
     rm -f "$tmp_file"
     return 1
   fi
+  source_bytes=${source_bytes//[[:space:]]/}
   cat "$source_file" >>"$tmp_file" || {
     rm -f "$tmp_file"
     return 1
   }
   expected_bytes=$((before_bytes + source_bytes))
-  if ! actual_bytes=$(wc -c <"$tmp_file" | tr -d '[:space:]'); then
+  if ! actual_bytes=$(wc -c <"$tmp_file"); then
     rm -f "$tmp_file"
     return 1
   fi
+  actual_bytes=${actual_bytes//[[:space:]]/}
   if [[ "$actual_bytes" -ne "$expected_bytes" ]]; then
     rm -f "$tmp_file"
     return 1

--- a/tests/distill-audit.test.sh
+++ b/tests/distill-audit.test.sh
@@ -380,7 +380,7 @@ if [ "$rc" -eq 0 ] \
   && ! grep -Fq -- '- 2026-07-05 old lesson 001 (source: distill-audit)' "$ws/STATE.md" \
   && ! grep -Fq -- '- 2026-07-05 old failure 001 (source: distill-audit)' "$ws/STATE.md" \
   && grep -Fq 'evicted_by_cap=2' "$ws/loop/pending/distill-runs.log" \
-  && [ ! -e "$ws/.STATE.md.tmp.$$" ] \
+  && ! find "$ws" -maxdepth 1 \( -name '.STATE.md.tmp.*' -o -name '.STATE.md.rebuild.*' \) -print | grep -q . \
   && [ ! -d "$ws/loop/.distill-state.lock" ]; then
   pass "state rewrite is capped, eviction reported, atomic temp cleaned, and lock released"
 else

--- a/tests/distill-audit.test.sh
+++ b/tests/distill-audit.test.sh
@@ -408,6 +408,73 @@ else
     "rc=$rc output=$output pending=$(find "$ws/loop/pending" -maxdepth 1 -type f -print)"
 fi
 
+ws=$(make_ws state-publish-refusal)
+cp "$ws/STATE.md" "$TMP_ROOT/state-before-publish-refusal"
+state_publish_shim=$TMP_ROOT/state-publish-shim
+mkdir -p "$state_publish_shim"
+cat >"$state_publish_shim/cp" <<'SH'
+#!/usr/bin/env bash
+case ${1##*/} in
+  .STATE.md.rebuild.*)
+    printf 'partial STATE copy\n' >"$2"
+    exit 1
+    ;;
+esac
+exec "$REAL_CP" "$@"
+SH
+chmod +x "$state_publish_shim/cp"
+real_cp=$(command -v cp)
+set +e
+output=$(PATH="$state_publish_shim:$PATH" REAL_CP="$real_cp" \
+  DISTILLER_CMD="$distiller" bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 3 ] \
+  && printf '%s\n' "$output" | grep -Fq 'distill-audit infra error: STATE.md publish failed' \
+  && cmp -s "$TMP_ROOT/state-before-publish-refusal" "$ws/STATE.md" \
+  && [ ! -e "$ws/loop/.distill-last-run" ] \
+  && [ ! -d "$ws/loop/.distill-state.lock" ] \
+  && ! find "$ws" \( -name '.STATE.md.tmp.*' -o -name '.STATE.md.rebuild.*' \
+    -o -name '.distill-*.md.tmp.*' -o -path '*/loop/archive/.*.tmp.*' \) -print | grep -q .; then
+  pass "refused STATE publish exits infra error and cleans lock and temporary files"
+else
+  fail_case "refused STATE publish exits infra error and cleans lock and temporary files" \
+    "rc=$rc output=$output temps=$(find "$ws" -name '.*.tmp.*' -print) lock=$([ -d "$ws/loop/.distill-state.lock" ] && printf held || printf released)"
+fi
+
+ws=$(make_ws reply-publish-refusal)
+reply_publish_shim=$TMP_ROOT/reply-publish-shim
+mkdir -p "$reply_publish_shim"
+cat >"$reply_publish_shim/cmp" <<'SH'
+#!/usr/bin/env bash
+case ${2##*/} in
+  reply.annotated.md)
+    mkdir "$REPLY_DESTINATION"
+    ;;
+esac
+exec "$REAL_CMP" "$@"
+SH
+chmod +x "$reply_publish_shim/cmp"
+real_cmp=$(command -v cmp)
+reply_destination=$ws/loop/pending/distill-$(date -u '+%Y-%m-%d').md
+set +e
+output=$(PATH="$reply_publish_shim:$PATH" REAL_CMP="$real_cmp" \
+  REPLY_DESTINATION="$reply_destination" DISTILLER_CMD="$distiller" \
+  bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 0 ] \
+  && [ -d "$reply_destination" ] \
+  && [ ! -e "$ws/loop/.distill-last-run" ] \
+  && [ ! -d "$ws/loop/.distill-state.lock" ] \
+  && ! find "$ws" \( -name '.STATE.md.tmp.*' -o -name '.STATE.md.rebuild.*' \
+    -o -name '.distill-*.md.tmp.*' -o -path '*/loop/archive/.*.tmp.*' \) -print | grep -q .; then
+  pass "reply publish guard refusal releases the lock and cleans all temporary files"
+else
+  fail_case "reply publish guard refusal releases the lock and cleans all temporary files" \
+    "rc=$rc output=$output temps=$(find "$ws" -name '.*.tmp.*' -print) lock=$([ -d "$ws/loop/.distill-state.lock" ] && printf held || printf released)"
+fi
+
 ws=$(make_ws bad-cmd)
 set +e
 output=$(DISTILLER_CMD="$TMP_ROOT/missing-distiller.sh" bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)

--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -82,12 +82,38 @@ file_mtime() {
 
 ws=$(new_ws case-01-fold)
 cp "$ROOT/tests/fixtures/flush/basic.md" "$ws/loop/pending/flush-2026-07-01.md"
+case_01_lessons=$TMP_ROOT/case-01-lessons
+case_01_failures=$TMP_ROOT/case-01-failures
+case_01_expected_state=$TMP_ROOT/case-01-STATE.md
+case_01_evictions=$TMP_ROOT/case-01-evictions
+printf '%s\n' \
+  '- 2026-07-01 Keep the fold receipt beside the pending ledgers. (source: flush-intake)' \
+  '- 2026-07-01 Preserve the original flush record in the archive. (source: flush-intake)' \
+  >"$case_01_lessons"
+: >"$case_01_failures"
+bash -c '
+  source "$1"
+  append_state_sections "$2" "$3" "$4" "$5" \
+    "$STATE_FOLD_LESSONS_CAP_DEFAULT" "$STATE_FOLD_FAILURES_CAP_DEFAULT" "$6"
+' _ "$ROOT/scripts/lib-state-fold.sh" "$ws/STATE.md" "$case_01_lessons" \
+  "$case_01_failures" "$case_01_expected_state" "$case_01_evictions"
 run_intake "$ws"
 if grep -Fqx -- '- 2026-07-01 Keep the fold receipt beside the pending ledgers. (source: flush-intake)' "$ws/STATE.md" \
-  && [ "$(receipt_value "$ws" folded)" -eq 2 ]; then
-  pass '[1] ok blocks fold deterministically into Lessons learned'
+  && cmp -s "$case_01_expected_state" "$ws/STATE.md" \
+  && [ "$(receipt_value "$ws" files_scanned)" -eq 1 ] \
+  && [ "$(receipt_value "$ws" blocks)" -eq 1 ] \
+  && [ "$(receipt_value "$ws" candidates)" -eq 2 ] \
+  && [ "$(receipt_value "$ws" folded)" -eq 2 ] \
+  && [ "$(receipt_value "$ws" deduped)" -eq 0 ] \
+  && [ "$(receipt_value "$ws" rejected)" -eq 0 ] \
+  && [ "$(receipt_value "$ws" evicted_by_cap)" -eq 0 ] \
+  && [ "$(receipt_value "$ws" lock)" = acquired ] \
+  && [ "$(receipt_value "$ws" marker)" = touched ] \
+  && [ "$(receipt_value "$ws" error)" = none ]; then
+  pass '[1] ok blocks publish rebuilt STATE bytes and exact receipt fields deterministically'
 else
-  fail_case '[1] ok blocks fold deterministically into Lessons learned' "receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+  fail_case '[1] ok blocks publish rebuilt STATE bytes and exact receipt fields deterministically' \
+    "state_matches=$(cmp -s "$case_01_expected_state" "$ws/STATE.md" && printf yes || printf no) receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
 fi
 
 ws=$(new_ws case-02-skip)
@@ -481,9 +507,44 @@ run_intake "$ws"
 if [ "$crash_rc" -eq 75 ] && [ -z "$ledger_after_crash" ] && [ "$marker_after_crash" -eq 0 ] \
   && [ "$(state_count "$ws" '- 2026-07-13 STATE moves before the ledger. (source: flush-intake)')" -eq 1 ] \
   && [ "$(receipt_value "$ws" folded)" -eq 0 ] && [ "$(receipt_value "$ws" deduped)" -eq 1 ]; then
-  pass '[25] crash after STATE move is stopped by normalized STATE backstop on retry'
+  crash_order_ok=1
 else
-  fail_case '[25] crash after STATE move is stopped by normalized STATE backstop on retry' "rc=$crash_rc ledger=$ledger_after_crash"
+  crash_order_ok=0
+fi
+crash_order_receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log" 2>/dev/null)
+
+ws=$(new_ws case-25-ledger-write-failure)
+write_block "$ws/loop/pending/flush-2026-07-23.md" 2026-07-23 \
+  'A refused ledger write stays visible.'
+ledger_directory=$ws/loop/pending/intake-$TODAY.md
+mkdir -p "$ledger_directory"
+printf 'sentinel\n' >"$ledger_directory/sentinel"
+set +e
+run_intake "$ws"
+ledger_write_rc=$?
+set -e
+if [ "$ledger_write_rc" -eq 1 ] \
+  && grep -Fq 'A refused ledger write stays visible.' "$ws/STATE.md" \
+  && [ "$(receipt_value "$ws" folded)" -eq 1 ] \
+  && [ "$(receipt_value "$ws" error)" = ledger-write ] \
+  && [ "$(receipt_value "$ws" marker)" = untouched ] \
+  && [ -f "$ws/loop/pending/flush-2026-07-23.md" ] \
+  && [ "$(cat "$ledger_directory/sentinel" 2>/dev/null)" = sentinel ] \
+  && ! find "$ledger_directory" -mindepth 1 -maxdepth 1 ! -name sentinel -print | grep -q . \
+  && [ ! -e "$ws/loop/.deadman/distill.marker" ] \
+  && [ ! -d "$ws/loop/.distill-state.lock" ] \
+  && ! find "$ws" -name '.STATE.md.tmp.*' -print | grep -q . \
+  && ! find "$ws/loop/pending" -maxdepth 1 -name '.intake-*.tmp.*' -print | grep -q .; then
+  ledger_write_failed_closed=1
+else
+  ledger_write_failed_closed=0
+fi
+ledger_write_receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log" 2>/dev/null)
+if [ "$crash_order_ok" -eq 1 ] && [ "$ledger_write_failed_closed" -eq 1 ]; then
+  pass '[25] STATE-before-ledger ordering preserves dedup safety and exposes refused ledger writes'
+else
+  fail_case '[25] STATE-before-ledger ordering preserves dedup safety and exposes refused ledger writes' \
+    "crash_ok=$crash_order_ok crash_rc=$crash_rc crash_ledger=$ledger_after_crash crash_receipt=$crash_order_receipt ledger_ok=$ledger_write_failed_closed ledger_rc=$ledger_write_rc ledger_receipt=$ledger_write_receipt"
 fi
 
 ws=$(new_ws case-26-anchor)
@@ -627,15 +688,59 @@ set +e
 run_intake "$ws"
 annotated_section_rc=$?
 set -e
-if [ "$missing_section_failed_closed" -eq 1 ] \
-  && [ "$annotated_section_rc" -eq 0 ] \
+if [ "$annotated_section_rc" -eq 0 ] \
   && grep -Fqx '## Lessons learned - house annotation' "$ws/STATE.md" \
   && grep -Fq 'Missing sections fail closed.' "$ws/STATE.md" \
   && [ -f "$ws/loop/archive/flush-2026-07-16.md" ] \
   && [ -e "$ws/loop/.deadman/distill.marker" ]; then
-  pass '[31] missing requested STATE section fails atomically and a prefix-matched annotated header folds after repair'
+  annotated_section_repaired=1
 else
-  fail_case '[31] missing requested STATE section fails atomically and a prefix-matched annotated header folds after repair' "failed_closed=$missing_section_failed_closed repair_rc=$annotated_section_rc receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+  annotated_section_repaired=0
+fi
+
+ws=$(new_ws case-31-state-publish-failure)
+cp "$ws/STATE.md" "$TMP_ROOT/state-before-publish-failure"
+write_block "$ws/loop/pending/flush-2026-07-22.md" 2026-07-22 \
+  'A refused STATE publish stays visible.'
+state_publish_shim=$TMP_ROOT/state-publish-shim
+mkdir -p "$state_publish_shim"
+cat >"$state_publish_shim/cp" <<'SH'
+#!/usr/bin/env bash
+case ${1##*/} in
+  .STATE.md.rebuild.*)
+    printf 'partial STATE copy\n' >"$2"
+    exit 1
+    ;;
+esac
+exec "$REAL_CP" "$@"
+SH
+chmod +x "$state_publish_shim/cp"
+real_cp=$(command -v cp)
+set +e
+run_intake "$ws" PATH="$state_publish_shim:$PATH" REAL_CP="$real_cp"
+state_publish_rc=$?
+set -e
+if [ "$state_publish_rc" -eq 1 ] \
+  && cmp -s "$TMP_ROOT/state-before-publish-failure" "$ws/STATE.md" \
+  && [ "$(receipt_value "$ws" folded)" -eq 0 ] \
+  && [ "$(receipt_value "$ws" error)" = state-publish ] \
+  && [ "$(receipt_value "$ws" marker)" = untouched ] \
+  && [ -f "$ws/loop/pending/flush-2026-07-22.md" ] \
+  && [ ! -e "$ws/loop/.deadman/distill.marker" ] \
+  && [ ! -d "$ws/loop/.distill-state.lock" ] \
+  && ! find "$ws" -maxdepth 1 \( -name '.STATE.md.tmp.*' -o -name '.STATE.md.rebuild.*' \) -print | grep -q .; then
+  state_publish_failed_closed=1
+else
+  state_publish_failed_closed=0
+fi
+state_publish_receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log" 2>/dev/null)
+if [ "$missing_section_failed_closed" -eq 1 ] \
+  && [ "$annotated_section_repaired" -eq 1 ] \
+  && [ "$state_publish_failed_closed" -eq 1 ]; then
+  pass '[31] missing sections and refused STATE publish fail atomically before repaired headers fold'
+else
+  fail_case '[31] missing sections and refused STATE publish fail atomically before repaired headers fold' \
+    "missing_section_ok=$missing_section_failed_closed repair_ok=$annotated_section_repaired repair_rc=$annotated_section_rc state_publish_ok=$state_publish_failed_closed state_publish_rc=$state_publish_rc state_publish_receipt=$state_publish_receipt"
 fi
 
 set +e

--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -511,7 +511,7 @@ if [ "$crash_rc" -eq 75 ] && [ -z "$ledger_after_crash" ] && [ "$marker_after_cr
 else
   crash_order_ok=0
 fi
-crash_order_receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log" 2>/dev/null)
+crash_order_receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log" 2>/dev/null) || true
 
 ws=$(new_ws case-25-ledger-write-failure)
 write_block "$ws/loop/pending/flush-2026-07-23.md" 2026-07-23 \
@@ -539,7 +539,7 @@ if [ "$ledger_write_rc" -eq 1 ] \
 else
   ledger_write_failed_closed=0
 fi
-ledger_write_receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log" 2>/dev/null)
+ledger_write_receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log" 2>/dev/null) || true
 if [ "$crash_order_ok" -eq 1 ] && [ "$ledger_write_failed_closed" -eq 1 ]; then
   pass '[25] STATE-before-ledger ordering preserves dedup safety and exposes refused ledger writes'
 else
@@ -733,7 +733,7 @@ if [ "$state_publish_rc" -eq 1 ] \
 else
   state_publish_failed_closed=0
 fi
-state_publish_receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log" 2>/dev/null)
+state_publish_receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log" 2>/dev/null) || true
 if [ "$missing_section_failed_closed" -eq 1 ] \
   && [ "$annotated_section_repaired" -eq 1 ] \
   && [ "$state_publish_failed_closed" -eq 1 ]; then

--- a/tests/state-fold-archive-append.test.sh
+++ b/tests/state-fold-archive-append.test.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+TMP_ROOT=${TMPDIR:-/tmp}/state-fold-archive-append-test.$$
+PASS_COUNT=0
+FAIL_COUNT=0
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+mkdir -p "$TMP_ROOT"
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS %s\n' "$1"
+}
+
+fail_case() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'FAIL %s: %s\n' "$1" "$2"
+}
+
+# shellcheck disable=SC1091
+source "$ROOT/scripts/lib-state-fold.sh"
+
+existing_dir=$TMP_ROOT/existing
+mkdir -p "$existing_dir"
+existing_archive=$existing_dir/archive.md
+existing_source=$existing_dir/source.md
+existing_expected=$existing_dir/expected.md
+existing_tmp=$existing_dir/.archive.md.tmp.$$
+printf 'existing archive\nwith a second line\n' >"$existing_archive"
+printf 'appended payload\nwith a final line\n' >"$existing_source"
+cp "$existing_archive" "$existing_expected"
+cat "$existing_source" >>"$existing_expected"
+if state_fold_atomic_archive_append "$existing_source" "$existing_archive"; then
+  existing_rc=0
+else
+  existing_rc=$?
+fi
+if [ "$existing_rc" -eq 0 ] \
+  && cmp -s "$existing_expected" "$existing_archive" \
+  && [ ! -e "$existing_tmp" ]; then
+  pass "existing archive append is byte-exact"
+else
+  fail_case "existing archive append is byte-exact" \
+    "rc=$existing_rc matches=$(cmp -s "$existing_expected" "$existing_archive" && printf yes || printf no) temp_removed=$([ ! -e "$existing_tmp" ] && printf yes || printf no)"
+fi
+
+absent_dir=$TMP_ROOT/absent
+mkdir -p "$absent_dir"
+absent_archive=$absent_dir/archive.md
+absent_source=$absent_dir/source.md
+absent_tmp=$absent_dir/.archive.md.tmp.$$
+printf 'new archive payload\n' >"$absent_source"
+if state_fold_atomic_archive_append "$absent_source" "$absent_archive"; then
+  absent_rc=0
+else
+  absent_rc=$?
+fi
+if [ "$absent_rc" -eq 0 ] \
+  && cmp -s "$absent_source" "$absent_archive" \
+  && [ ! -e "$absent_tmp" ]; then
+  pass "absent archive is created byte-for-byte"
+else
+  fail_case "absent archive is created byte-for-byte" \
+    "rc=$absent_rc matches=$(cmp -s "$absent_source" "$absent_archive" && printf yes || printf no) temp_removed=$([ ! -e "$absent_tmp" ] && printf yes || printf no)"
+fi
+
+directory_dir=$TMP_ROOT/directory
+mkdir -p "$directory_dir"
+directory_archive=$directory_dir/archive.md
+directory_source=$directory_dir/source.md
+directory_tmp=$directory_dir/.archive.md.tmp.$$
+mkdir -p "$directory_archive"
+printf 'sentinel\n' >"$directory_archive/sentinel"
+printf 'refused payload\n' >"$directory_source"
+if state_fold_atomic_archive_append "$directory_source" "$directory_archive"; then
+  directory_rc=0
+else
+  directory_rc=$?
+fi
+if [ "$directory_rc" -ne 0 ] \
+  && [ -d "$directory_archive" ] \
+  && [ "$(cat "$directory_archive/sentinel" 2>/dev/null)" = sentinel ] \
+  && [ "$(ls -A "$directory_archive")" = sentinel ] \
+  && [ ! -e "$directory_tmp" ]; then
+  pass "directory destination is refused without a temporary file"
+else
+  fail_case "directory destination is refused without a temporary file" \
+    "rc=$directory_rc entries=$(find "$directory_archive" -mindepth 1 -maxdepth 1 -print 2>/dev/null | tr '\n' ',') temp_removed=$([ ! -e "$directory_tmp" ] && printf yes || printf no)"
+fi
+
+copy_dir=$TMP_ROOT/copy-failure
+mkdir -p "$copy_dir"
+copy_archive=$copy_dir/archive.md
+copy_source=$copy_dir/source.md
+copy_before=$copy_dir/archive.before
+copy_tmp=$copy_dir/.archive.md.tmp.$$
+printf 'original archive\n' >"$copy_archive"
+printf 'new payload\n' >"$copy_source"
+cp "$copy_archive" "$copy_before"
+if (
+  # shellcheck disable=SC2329
+  cp() {
+    printf 'partial copy\n' >"$2"
+    return 1
+  }
+  state_fold_atomic_archive_append "$copy_source" "$copy_archive"
+); then
+  copy_rc=0
+else
+  copy_rc=$?
+fi
+if [ "$copy_rc" -ne 0 ] \
+  && cmp -s "$copy_before" "$copy_archive" \
+  && [ ! -e "$copy_tmp" ]; then
+  pass "copy failure preserves the archive and removes its partial temporary file"
+else
+  fail_case "copy failure preserves the archive and removes its partial temporary file" \
+    "rc=$copy_rc preserved=$(cmp -s "$copy_before" "$copy_archive" && printf yes || printf no) temp_removed=$([ ! -e "$copy_tmp" ] && printf yes || printf no)"
+fi
+
+move_dir=$TMP_ROOT/move-failure
+mkdir -p "$move_dir"
+move_archive=$move_dir/archive.md
+move_source=$move_dir/source.md
+move_before=$move_dir/archive.before
+move_tmp=$move_dir/.archive.md.tmp.$$
+printf 'original archive\n' >"$move_archive"
+printf 'new payload\n' >"$move_source"
+cp "$move_archive" "$move_before"
+if (
+  # shellcheck disable=SC2329
+  mv() {
+    return 1
+  }
+  state_fold_atomic_archive_append "$move_source" "$move_archive"
+); then
+  move_rc=0
+else
+  move_rc=$?
+fi
+if [ "$move_rc" -ne 0 ] \
+  && cmp -s "$move_before" "$move_archive" \
+  && [ ! -e "$move_tmp" ]; then
+  pass "move failure preserves the archive and removes the verified temporary file"
+else
+  fail_case "move failure preserves the archive and removes the verified temporary file" \
+    "rc=$move_rc preserved=$(cmp -s "$move_before" "$move_archive" && printf yes || printf no) temp_removed=$([ ! -e "$move_tmp" ] && printf yes || printf no)"
+fi
+
+tail_dir=$TMP_ROOT/tail-corruption
+mkdir -p "$tail_dir"
+tail_archive=$tail_dir/archive.md
+tail_source=$tail_dir/source.md
+tail_before=$tail_dir/archive.before
+tail_tmp=$tail_dir/.archive.md.tmp.$$
+printf 'original archive\n' >"$tail_archive"
+printf 'expected appended payload\n' >"$tail_source"
+cp "$tail_archive" "$tail_before"
+tail_source_bytes=$(wc -c <"$tail_source" | tr -d '[:space:]')
+if (
+  # shellcheck disable=SC2329
+  cat() {
+    head -c "$tail_source_bytes" /dev/zero | tr '\0' x
+  }
+  state_fold_atomic_archive_append "$tail_source" "$tail_archive"
+); then
+  tail_rc=0
+else
+  tail_rc=$?
+fi
+if [ "$tail_rc" -ne 0 ] \
+  && cmp -s "$tail_before" "$tail_archive" \
+  && [ ! -e "$tail_tmp" ]; then
+  pass "same-length appended-tail corruption is refused"
+else
+  fail_case "same-length appended-tail corruption is refused" \
+    "rc=$tail_rc preserved=$(cmp -s "$tail_before" "$tail_archive" && printf yes || printf no) temp_removed=$([ ! -e "$tail_tmp" ] && printf yes || printf no)"
+fi
+
+prefix_dir=$TMP_ROOT/prefix-corruption
+mkdir -p "$prefix_dir"
+prefix_archive=$prefix_dir/archive.md
+prefix_source=$prefix_dir/source.md
+prefix_before=$prefix_dir/archive.before
+prefix_tmp=$prefix_dir/.archive.md.tmp.$$
+printf 'original archive prefix\n' >"$prefix_archive"
+printf 'valid appended payload\n' >"$prefix_source"
+cp "$prefix_archive" "$prefix_before"
+prefix_bytes=$(wc -c <"$prefix_archive" | tr -d '[:space:]')
+if (
+  # shellcheck disable=SC2329
+  cp() {
+    head -c "$prefix_bytes" /dev/zero | tr '\0' x >"$2"
+  }
+  state_fold_atomic_archive_append "$prefix_source" "$prefix_archive"
+); then
+  prefix_rc=0
+else
+  prefix_rc=$?
+fi
+if [ "$prefix_rc" -ne 0 ] \
+  && cmp -s "$prefix_before" "$prefix_archive" \
+  && [ ! -e "$prefix_tmp" ]; then
+  pass "same-length archive-prefix corruption is refused"
+else
+  fail_case "same-length archive-prefix corruption is refused" \
+    "rc=$prefix_rc preserved=$(cmp -s "$prefix_before" "$prefix_archive" && printf yes || printf no) temp_removed=$([ ! -e "$prefix_tmp" ] && printf yes || printf no)"
+fi
+
+empty_dir=$TMP_ROOT/empty-source
+mkdir -p "$empty_dir"
+empty_archive=$empty_dir/archive.md
+empty_source=$empty_dir/source.md
+empty_before=$empty_dir/archive.before
+empty_probe=$empty_dir/tail-zero.out
+empty_tmp=$empty_dir/.archive.md.tmp.$$
+printf 'archive unchanged by empty append\n' >"$empty_archive"
+: >"$empty_source"
+cp "$empty_archive" "$empty_before"
+tail -c 0 "$empty_archive" >"$empty_probe"
+if state_fold_atomic_archive_append "$empty_source" "$empty_archive"; then
+  empty_rc=0
+else
+  empty_rc=$?
+fi
+if [ "$empty_rc" -eq 0 ] \
+  && cmp -s "$empty_before" "$empty_archive" \
+  && cmp -s "$empty_source" "$empty_probe" \
+  && [ ! -e "$empty_tmp" ]; then
+  pass "zero-byte append succeeds unchanged and tail -c 0 is empty"
+else
+  fail_case "zero-byte append succeeds unchanged and tail -c 0 is empty" \
+    "rc=$empty_rc unchanged=$(cmp -s "$empty_before" "$empty_archive" && printf yes || printf no) tail_zero_empty=$(cmp -s "$empty_source" "$empty_probe" && printf yes || printf no) temp_removed=$([ ! -e "$empty_tmp" ] && printf yes || printf no)"
+fi
+
+printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]

--- a/tests/state-fold-archive-append.test.sh
+++ b/tests/state-fold-archive-append.test.sh
@@ -238,5 +238,41 @@ else
     "rc=$empty_rc unchanged=$(cmp -s "$empty_before" "$empty_archive" && printf yes || printf no) tail_zero_empty=$(cmp -s "$empty_source" "$empty_probe" && printf yes || printf no) temp_removed=$([ ! -e "$empty_tmp" ] && printf yes || printf no)"
 fi
 
+unreadable_dir=$TMP_ROOT/unreadable-source
+mkdir -p "$unreadable_dir"
+unreadable_archive=$unreadable_dir/archive.md
+unreadable_source=$unreadable_dir/source.md
+unreadable_before=$unreadable_dir/archive.before
+printf 'archive preserved when source size is unreadable\n' >"$unreadable_archive"
+printf 'payload that must not be appended\n' >"$unreadable_source"
+cp "$unreadable_archive" "$unreadable_before"
+chmod 000 "$unreadable_source"
+if (
+  set +o pipefail
+  # If a broken wc pipeline reaches cat, make that bypass observable instead of
+  # letting cat independently refuse the same unreadable source.
+  # shellcheck disable=SC2329
+  cat() {
+    if [ "$1" = "$unreadable_source" ]; then
+      return 0
+    fi
+    command cat "$@"
+  }
+  state_fold_atomic_archive_append "$unreadable_source" "$unreadable_archive"
+); then
+  unreadable_rc=0
+else
+  unreadable_rc=$?
+fi
+chmod 600 "$unreadable_source"
+if [ "$unreadable_rc" -ne 0 ] \
+  && cmp -s "$unreadable_before" "$unreadable_archive" \
+  && ! find "$unreadable_dir" -maxdepth 1 -name '.archive.md.tmp.*' -print | grep -q .; then
+  pass "unreadable source size is refused without changing the archive"
+else
+  fail_case "unreadable source size is refused without changing the archive" \
+    "rc=$unreadable_rc preserved=$(cmp -s "$unreadable_before" "$unreadable_archive" && printf yes || printf no) temps=$(find "$unreadable_dir" -maxdepth 1 -name '.archive.md.tmp.*' -print | tr '\n' ',')"
+fi
+
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
 [ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
Closes #213.

Extends the #182 verify-then-rename guarantees to the residual STATE.md publishers and callers outside `atomic_write_file`'s file set, per the Issue's 3 finding groups (#182 panel: Grok / Kimi / GLM seats). Success paths are byte-identical; only failure behavior changes.

## What changed

- **flush-intake / distill-audit STATE publish**: both awk-rebuild `mv -f` sites now route through `atomic_write_file` (cp → cmp verify → destination type check → guarded rename). Refusal is loud: flush-intake writes receipt `error=state-publish`, leaves the deadman marker untouched, exits 1; distill-audit exits 3 via `infra_fail`, EXIT trap releases the state lock.
- **flush-intake ledger rc**: `atomic_write_file` refusal now writes receipt `error=ledger-write` + exits 1 (pre-change: receipt-less abort via the `set -e` inherited from sourcing lib-state-fold.sh — measured during review; the Issue premise "no set -e" was imprecise).
- **`state_fold_atomic_archive_append`**: temp cleanup on every failure path, appended-tail + archive-prefix `cmp` verify (catches same-length garbage the byte-count check misses), destination type check, guarded final rename. wc rc guards capture `wc`'s own rc (delta; the `| tr` pipeline form only guarded under pipefail — 3-seat convergent finding).
- **Temp rename** `.STATE.md.tmp.$$` → `.STATE.md.rebuild.$$` in both publishers: hard prerequisite, since `atomic_write_file` stages at `.STATE.md.tmp.$$` — same PID would collide cp source==dest (mutation-verified: reverting the rename fails 10+ tests).
- **distill-audit lock-on-abort**: measured before implementation (Issue comment): the EXIT-trap `cleanup()` has released the state lock since the initial release, so the Issue's claimed hold-until-stale-timeout path does not exist. Per the recorded disposition, this Done-when item is proven by a new regression test; no code change.
- **Tests**: new `tests/state-fold-archive-append.test.sh` (9 cases incl. same-length corruption, unreadable source, temp-leak and directory-destination refusals); flush-intake + distill-audit failure-injection cases (publish refusal, ledger refusal, lock-release-on-abort) plus an exact-bytes + full-receipt success pin for the STATE publish.

## Files touched (WIP declaration ↔ diff)

Declared: scripts/lib-state-fold.sh, scripts/flush-intake.sh, adapters/openclaw/distill-audit.sh, tests/atomic-write-file.test.sh, tests/state-fold-archive-append.test.sh (new), tests/flush-intake.test.sh, tests/distill-audit.test.sh
`git diff --stat origin/main...e735536`: scripts/lib-state-fold.sh | scripts/flush-intake.sh | adapters/openclaw/distill-audit.sh | tests/state-fold-archive-append.test.sh (new) | tests/flush-intake.test.sh | tests/distill-audit.test.sh — 6 files, ⊆ declared set (tests/atomic-write-file.test.sh declared but ultimately untouched; no undeclared files in the diff).

## Completion record (L1-7)

Candidate SHA: **e735536** (= PR head; 64465a4 implementation + e735536 review-delta). Reviewed as e868bb6/9b8e6d3, then rebased onto origin/main 157c13b (repo-state chore + README nav, disjoint from this file set) — `git range-diff` shows `=` for both commits (content-identical); all four suites re-run green post-rebase (evidence below applies unchanged).
Implementer: Codex GPT-5.6 Sol (writer, both rounds; sitter-run). Orchestrator/adjudicator: Alpha (claude-code) — not a counted review seat; no self-approve.
Review seats (heterogeneous 3, per loom-seats deterministic output, size L, writer codex-sol excluded): Kimi K3 / Opus 5 / GLM 5.3 — all pairwise-distinct lineages and ≠ writer. Review record: #213 (comment link added on post).

### Done when → evidence (2026-08-29, all measured on this branch)

1. **Both awk-rebuild publishers verify-then-rename with tests — PASS.**
   `scripts/flush-intake.sh:476` and `adapters/openclaw/distill-audit.sh:705` route through `atomic_write_file`. Evidence: `bash tests/flush-intake.test.sh` → `Summary: 35 PASS, 0 FAIL` (case [31] pins refusal: rc=1, `error=state-publish`, STATE byte-unchanged, marker untouched, lock released, no temps; case [1] pins success bytes + 10 receipt fields); `bash tests/distill-audit.test.sh` → `Summary: 53 PASS, 0 FAIL` (state-publish-refusal: rc=3, `distill-audit infra error: STATE.md publish failed`, lock released, no temps). Mutation: reverting either site to bare `mv -f` → the corresponding test FAILs with the silent-success signature (orchestrator + 3 seats independently; e.g. `FAIL [31] ... state_publish_ok=0 state_publish_rc=0`).
2. **`state_fold_atomic_archive_append` cleanup + verify + type check with tests — PASS.**
   Evidence: `bash tests/state-fold-archive-append.test.sh` → `Summary: 9 PASS, 0 FAIL` (byte-exact success, create-when-absent, directory refusal, cp-failure cleanup, mv-failure cleanup, appended-tail corruption, prefix corruption, zero-byte append, unreadable-source wc-guard). Mutations: each guard individually removed → its test FAILs (5/5 by Opus seat M-B..M-F; tail-verify and publish-revert also by orchestrator and other seats).
3. **flush-intake ledger failure loud; distill-audit releases lock on guard-refusal abort — PASS.**
   Ledger: case [25] pins rc=1 + `error=ledger-write` + `marker=untouched` + lock released + no temps. Lock: reply-publish-refusal test pins rc≠0 + lock dir absent + temps cleaned; seat mutation deleting `release_state_lock` from `cleanup()` → 2 tests FAIL `lock=held` (assertion is live, not vacuous). Measured fact recorded on #213: the EXIT trap has released the lock since initial release — code correctly unchanged.
4. **No behavior change on success paths (byte-identical) — PASS.**
   Evidence: Opus seat ran BASE `f1ed00e` vs CAND on identical workspaces: STATE.md `cmp` silent (8577 B), reply file identical incl. dedup_key hashes, receipt fields identical modulo `ts=`, mode bits 644/644, no temp residue. Forward pin: flush-intake case [1] asserts exact STATE bytes + every receipt field (drift-sensitivity verified with a 1-byte mutant). Full local sweep `for t in tests/*.test.sh` → ALL SUITES GREEN (2026-08-29).

### Review rounds

- r1 (blind, fresh context, read-only) on e868bb6: GLM 5.3 **GO-WITH-MINOR** / Kimi K3 **GO-WITH-MINOR** / Opus 5 **GO-WITH-MINOR** — zero blocking findings; 20+ independent mutation probes all detected; coverage matrix (Opus): zero-coverage items = none, no unjustified unrequested work.
- Convergent findings adjudicated: wc-guard inertness (3/3 seats) → fixed in delta 9b8e6d3 with a pinning test; eviction-archive append-before-publish (3/3 seats, each with an empirical repro) → follow-up **#222** (design tradeoff: reordering trades audit duplication for loss; needs a deliberate choice, not a ride-along).
- Seat fact-conflict adjudicated by measurement: flush-intake inherits `set -euo pipefail` from sourcing lib-state-fold.sh:2 (errexit=ON, pipefail=ON after source) — Kimi's reading confirmed; Issue premise and r1 brief superseded.
- delta (cumulative) on 9b8e6d3: GLM **GO** / Kimi **GO** / Opus **GO** (3/3; each re-ran the suites and its own mutation probe independently; Opus posted a measured self-correction adopting the set-e fact adjudication). Full review record: https://github.com/caty-ai/caty-agent-harness/issues/213#issuecomment-5462298995
- requested/actual models: GLM requested glm-5.3 / actual glm-5.3; Kimi requested kimi-k3 / actual kimi-code CLI (reports "kimi"); Opus requested opus-5 / actual claude-opus-5[1m]. Effort: seat defaults.

### Non-blocking notes carried out of review (recorded, not fixed here)

- Reply-file publish at `distill-audit.sh:722` remains rc-silent under `set -e` (pre-existing, outside #213's declared scope; the new regression test pins rc≠0 + lock release + temp cleanup).
- CI `PASS_FLOOR` (ci-matrix) not ratcheted for the net +10 PASS lines (floor semantics, safe; workflow file outside this lane's declared file set).
- Eviction-archive ordering → #222.

### CI

All checks green at head e735536 (observed 2026-08-29): test-lint / test (ubuntu) pass 20m2s and test-lint / test-macos pass 26m8s — run https://github.com/caty-ai/caty-agent-harness/actions/runs/33251704443; lint pass; gitleaks, history-check, repo-state, risk-review-gate, watch all pass; pr-size pass with the size-exempt label (precedent PR #220; justification: https://github.com/caty-ai/caty-agent-harness/pull/223#issuecomment-5462331855). No red, no missing runs.

### Release

- release: **v0.22.4** (shipping-equivalent: failure-path behavior of user-run harness scripts changes)
- previous release: **v0.22.3 — fulfilled** (https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.22.3, verified 2026-08-29: annotated tag on merge commit, release-sync green, Release exists, draft:false)

Credit: findings surfaced during the #182 panel review of @pm25coder's proposal (Issue #213 body); r1 convergent findings by the GLM 5.3 / Kimi K3 / Opus 5 seats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
