### PR TITLE
fix(#222): idempotent eviction-archive append — refused publish retry adopts the existing record

### DIFF
--- a/adapters/claude-code/INSTALL.md
+++ b/adapters/claude-code/INSTALL.md
@@ -182,7 +182,12 @@ Each parsed bullet is limited to `INTAKE_MAX_BULLET_BYTES` bytes (default `512` 
 control-character stripping); an oversized bullet is dropped whole and counted as
 `dropped_oversize` in the run receipt. Lessons displaced by the STATE cap are appended
 to `loop/archive/intake-evictions-<UTC-date>.md`, while `evicted_by_cap` and the archive
-path remain visible in the receipt.
+path remain visible in the receipt. When the previous receipt records a refused STATE
+publish (`error=state-publish`), a retry whose displaced-lesson payload byte-matches the
+archive's last record adopts that record instead of appending a duplicate; the
+comparison is payload-only, so the adopted record keeps its original adapter header. A
+failed archive append aborts the run before the STATE publish with
+`error=eviction-archive` in the receipt.
 
 On every intake under the shared STATE lock, including scans with zero flush files,
 the host folds `## Last session` into a newest-first index capped at 20 entries. Entry

--- a/scripts/flush-intake.sh
+++ b/scripts/flush-intake.sh
@@ -469,9 +469,38 @@ if [[ -s "$accepted_lessons" || -s "$accepted_failures" ]]; then
   if [[ -s "$evicted_lessons_file" ]]; then
     eviction_archive="loop/archive/intake-evictions-$today.md"
     eviction_archive_path="$workspace/$eviction_archive"
-    printf '<!-- intake eviction adapter=%s ts=%s -->\n' \
-      "$adapter_identity" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >>"$eviction_archive_path"
-    cat "$evicted_lessons_file" >>"$eviction_archive_path"
+    eviction_block="$work_dir/eviction-block.md"
+    if ! {
+      printf '<!-- intake eviction adapter=%s ts=%s -->\n' \
+        "$adapter_identity" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+      cat "$evicted_lessons_file"
+    } >"$eviction_block"; then
+      folded=0
+      receipt_error=eviction-archive
+      write_receipt acquired untouched
+      exit 1
+    fi
+    append_eviction=1
+    last_header=
+    if [[ -f "$eviction_archive_path" ]]; then
+      last_header=$(grep -n '^<!-- intake eviction adapter=' "$eviction_archive_path" \
+        | tail -n 1 | cut -d: -f1) || last_header=
+      if [[ "$last_header" =~ ^[0-9]+$ ]]; then
+        dedup_rc=0
+        tail -n "+$((last_header + 1))" "$eviction_archive_path" \
+          | cmp -s - "$evicted_lessons_file" || dedup_rc=$?
+        if [[ "$dedup_rc" -eq 0 ]]; then
+          append_eviction=0
+        fi
+      fi
+    fi
+    if [[ "$append_eviction" -eq 1 ]] \
+      && ! state_fold_atomic_archive_append "$eviction_block" "$eviction_archive_path"; then
+      folded=0
+      receipt_error=eviction-archive
+      write_receipt acquired untouched
+      exit 1
+    fi
   fi
   if ! atomic_write_file "$state_tmp" "$state_file"; then
     folded=0

--- a/scripts/flush-intake.sh
+++ b/scripts/flush-intake.sh
@@ -490,7 +490,7 @@ if [[ -s "$accepted_lessons" || -s "$accepted_failures" ]]; then
     fi
     last_header=
     if [[ -f "$eviction_archive_path" ]]; then
-      last_header=$(grep -n '^<!-- intake eviction adapter=' "$eviction_archive_path" \
+      last_header=$(grep -a -n '^<!-- intake eviction adapter=' "$eviction_archive_path" \
         | tail -n 1 | cut -d: -f1) || last_header=
       if [[ "$last_header" =~ ^[0-9]+$ ]]; then
         dedup_rc=0

--- a/scripts/flush-intake.sh
+++ b/scripts/flush-intake.sh
@@ -481,6 +481,13 @@ if [[ -s "$accepted_lessons" || -s "$accepted_failures" ]]; then
       exit 1
     fi
     append_eviction=1
+    dedup_allowed=0
+    if [[ -f "$pending_dir/intake-runs.log" ]]; then
+      last_receipt=$(tail -n 1 "$pending_dir/intake-runs.log") || last_receipt=
+      case "$last_receipt" in
+        *' error=state-publish'*) dedup_allowed=1 ;;
+      esac
+    fi
     last_header=
     if [[ -f "$eviction_archive_path" ]]; then
       last_header=$(grep -n '^<!-- intake eviction adapter=' "$eviction_archive_path" \
@@ -489,7 +496,7 @@ if [[ -s "$accepted_lessons" || -s "$accepted_failures" ]]; then
         dedup_rc=0
         tail -n "+$((last_header + 1))" "$eviction_archive_path" \
           | cmp -s - "$evicted_lessons_file" || dedup_rc=$?
-        if [[ "$dedup_rc" -eq 0 ]]; then
+        if [[ "$dedup_allowed" -eq 1 && "$dedup_rc" -eq 0 ]]; then
           append_eviction=0
         fi
       fi

--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -831,5 +831,88 @@ else
     'raw archive did not preserve the accepted and rejected bullet bodies exactly'
 fi
 
+ws=$(new_ws case-36-eviction-retry-dedup)
+{
+  printf '%s\n' '## Verified facts' '## General rules' '## Open failures' '## Lessons learned'
+  i=1
+  while [ "$i" -le 60 ]; do
+    printf -- '- 2026-06-01 capped lesson %02d (source: distill-audit)\n' "$i"
+    i=$((i + 1))
+  done
+  printf '%s\n' '## Last session'
+} >"$ws/STATE.md"
+cp "$ws/STATE.md" "$TMP_ROOT/state-before-eviction-retry"
+write_block "$ws/loop/pending/flush-2026-07-23.md" 2026-07-23 \
+  'A refused cap eviction is adopted by its retry.'
+eviction_publish_shim=$TMP_ROOT/eviction-publish-shim
+mkdir -p "$eviction_publish_shim"
+cat >"$eviction_publish_shim/cp" <<'SH'
+#!/usr/bin/env bash
+case ${1##*/} in
+  .STATE.md.rebuild.*)
+    printf 'partial STATE copy\n' >"$2"
+    exit 1
+    ;;
+esac
+exec "$REAL_CP" "$@"
+SH
+chmod +x "$eviction_publish_shim/cp"
+real_cp=$(command -v cp)
+set +e
+run_intake "$ws" PATH="$eviction_publish_shim:$PATH" REAL_CP="$real_cp"
+eviction_publish_rc=$?
+set -e
+eviction_archive_path="$ws/loop/archive/intake-evictions-$TODAY.md"
+if [ "$eviction_publish_rc" -eq 1 ] \
+  && cmp -s "$TMP_ROOT/state-before-eviction-retry" "$ws/STATE.md" \
+  && [ "$(receipt_value "$ws" error)" = state-publish ] \
+  && [ "$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 1 ] \
+  && [ "$(grep -Fc 'capped lesson 01' "$eviction_archive_path")" -eq 1 ]; then
+  eviction_refusal_ok=1
+else
+  eviction_refusal_ok=0
+fi
+set +e
+run_intake "$ws"
+eviction_retry_rc=$?
+set -e
+if [ "$eviction_refusal_ok" -eq 1 ] \
+  && [ "$eviction_retry_rc" -eq 0 ] \
+  && grep -Fq 'A refused cap eviction is adopted by its retry.' "$ws/STATE.md" \
+  && ! grep -Fq 'capped lesson 01' "$ws/STATE.md" \
+  && [ "$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 1 ] \
+  && [ "$(grep -Fc 'capped lesson 01' "$eviction_archive_path")" -eq 1 ]; then
+  pass '[36] refused STATE publish retry adopts the existing eviction record without duplication'
+else
+  fail_case '[36] refused STATE publish retry adopts the existing eviction record without duplication' \
+    "refusal_ok=$eviction_refusal_ok refusal_rc=$eviction_publish_rc retry_rc=$eviction_retry_rc receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+ws=$(new_ws case-37-distinct-evictions)
+{
+  printf '%s\n' '## Verified facts' '## General rules' '## Open failures' '## Lessons learned'
+  i=1
+  while [ "$i" -le 60 ]; do
+    printf -- '- 2026-06-01 capped lesson %02d (source: distill-audit)\n' "$i"
+    i=$((i + 1))
+  done
+  printf '%s\n' '## Last session'
+} >"$ws/STATE.md"
+write_block "$ws/loop/pending/flush-2026-07-24.md" 2026-07-24 \
+  'The first distinct eviction succeeds.'
+run_intake "$ws"
+write_block "$ws/loop/pending/flush-2026-07-25.md" 2026-07-25 \
+  'The second distinct eviction succeeds.'
+run_intake "$ws"
+eviction_archive_path="$ws/loop/archive/intake-evictions-$TODAY.md"
+if [ "$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 2 ] \
+  && [ "$(grep -Fc 'capped lesson 01' "$eviction_archive_path")" -eq 1 ] \
+  && [ "$(grep -Fc 'capped lesson 02' "$eviction_archive_path")" -eq 1 ]; then
+  pass '[37] distinct same-day eviction payloads append separate archive records'
+else
+  fail_case '[37] distinct same-day eviction payloads append separate archive records' \
+    "headers=$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path") archive=$(tr '\n' ' ' <"$eviction_archive_path")"
+fi
+
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
 [ "$FAIL_COUNT" -eq 0 ]

--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -914,5 +914,45 @@ else
     "headers=$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path") archive=$(tr '\n' ' ' <"$eviction_archive_path")"
 fi
 
+ws=$(new_ws case-38-external-rewind)
+{
+  printf '%s\n' '## Verified facts' '## General rules' '## Open failures' '## Lessons learned'
+  i=1
+  while [ "$i" -le 60 ]; do
+    printf -- '- 2026-06-01 capped lesson %02d (source: distill-audit)\n' "$i"
+    i=$((i + 1))
+  done
+  printf '%s\n' '## Last session'
+} >"$ws/STATE.md"
+cp "$ws/STATE.md" "$TMP_ROOT/state-before-external-rewind"
+write_block "$ws/loop/pending/flush-2026-07-26.md" 2026-07-26 \
+  'The first rewind-sensitive eviction succeeds.'
+run_intake "$ws"
+first_rewind_rc=$?
+eviction_archive_path="$ws/loop/archive/intake-evictions-$TODAY.md"
+if [ "$first_rewind_rc" -eq 0 ] \
+  && [ "$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 1 ]; then
+  first_rewind_archive_ok=1
+else
+  first_rewind_archive_ok=0
+fi
+cp "$TMP_ROOT/state-before-external-rewind" "$ws/STATE.md"
+write_block "$ws/loop/pending/flush-2026-07-27.md" 2026-07-27 \
+  'The second rewind-sensitive eviction is distinct.'
+run_intake "$ws"
+second_rewind_rc=$?
+if [ "$first_rewind_archive_ok" -eq 1 ] \
+  && [ "$second_rewind_rc" -eq 0 ] \
+  && [ "$(receipt_value "$ws" evicted_by_cap)" -eq 1 ] \
+  && [ "$(receipt_value "$ws" eviction_archive)" = "loop/archive/intake-evictions-$TODAY.md" ] \
+  && [ "$(receipt_value "$ws" error)" = none ] \
+  && [ "$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 2 ] \
+  && [ "$(grep -Fc 'capped lesson 01' "$eviction_archive_path")" -eq 2 ]; then
+  pass '[38] external STATE rewind appends an identical eviction payload as a distinct record'
+else
+  fail_case '[38] external STATE rewind appends an identical eviction payload as a distinct record' \
+    "first_ok=$first_rewind_archive_ok first_rc=$first_rewind_rc second_rc=$second_rewind_rc receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log") archive=$(tr '\n' ' ' <"$eviction_archive_path")"
+fi
+
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
 [ "$FAIL_COUNT" -eq 0 ]

--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -954,5 +954,108 @@ else
     "first_ok=$first_rewind_archive_ok first_rc=$first_rewind_rc second_rc=$second_rewind_rc receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log") archive=$(tr '\n' ' ' <"$eviction_archive_path")"
 fi
 
+ws=$(new_ws case-39-last-header-dedup)
+{
+  printf '%s\n' '## Verified facts' '## General rules' '## Open failures' '## Lessons learned'
+  i=1
+  while [ "$i" -le 60 ]; do
+    printf -- '- 2026-06-01 capped lesson %02d (source: distill-audit)\n' "$i"
+    i=$((i + 1))
+  done
+  printf '%s\n' '## Last session'
+} >"$ws/STATE.md"
+write_block "$ws/loop/pending/flush-2026-07-28.md" 2026-07-28 \
+  'The first same-day eviction succeeds.'
+run_intake "$ws"
+first_same_day_rc=$?
+eviction_archive_path="$ws/loop/archive/intake-evictions-$TODAY.md"
+if [ "$first_same_day_rc" -eq 0 ] \
+  && [ "$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 1 ] \
+  && [ "$(grep -Fc 'capped lesson 01' "$eviction_archive_path")" -eq 1 ] \
+  && [ "$(grep -Fc 'capped lesson 02' "$eviction_archive_path")" -eq 0 ]; then
+  first_same_day_ok=1
+else
+  first_same_day_ok=0
+fi
+eviction_retry_shim=$TMP_ROOT/eviction-retry-shim
+mkdir -p "$eviction_retry_shim"
+cat >"$eviction_retry_shim/cp" <<'SH'
+#!/usr/bin/env bash
+case ${1##*/} in
+  .STATE.md.rebuild.*)
+    printf 'partial STATE copy\n' >"$2"
+    exit 1
+    ;;
+esac
+exec "$REAL_CP" "$@"
+SH
+chmod +x "$eviction_retry_shim/cp"
+real_cp=$(command -v cp)
+write_block "$ws/loop/pending/flush-2026-07-29.md" 2026-07-29 \
+  'A refused retry must adopt the latest same-day eviction.'
+set +e
+run_intake "$ws" PATH="$eviction_retry_shim:$PATH" REAL_CP="$real_cp"
+same_day_refusal_rc=$?
+set -e
+if [ "$first_same_day_ok" -eq 1 ] \
+  && [ "$same_day_refusal_rc" -eq 1 ] \
+  && [ "$(receipt_value "$ws" error)" = state-publish ] \
+  && [ "$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 2 ] \
+  && [ "$(grep -Fc 'capped lesson 01' "$eviction_archive_path")" -eq 1 ] \
+  && [ "$(grep -Fc 'capped lesson 02' "$eviction_archive_path")" -eq 1 ]; then
+  same_day_refusal_ok=1
+else
+  same_day_refusal_ok=0
+fi
+run_intake "$ws"
+same_day_retry_rc=$?
+if [ "$same_day_refusal_ok" -eq 1 ] \
+  && [ "$same_day_retry_rc" -eq 0 ] \
+  && [ "$(receipt_value "$ws" error)" = none ] \
+  && [ "$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 2 ] \
+  && [ "$(grep -Fc 'capped lesson 01' "$eviction_archive_path")" -eq 1 ] \
+  && [ "$(grep -Fc 'capped lesson 02' "$eviction_archive_path")" -eq 1 ]; then
+  pass '[39] refused same-day retry adopts the latest archived eviction record without duplication'
+else
+  fail_case '[39] refused same-day retry adopts the latest archived eviction record without duplication' \
+    "first_ok=$first_same_day_ok refusal_ok=$same_day_refusal_ok refusal_rc=$same_day_refusal_rc retry_rc=$same_day_retry_rc receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log") archive=$(tr '\n' ' ' <"$eviction_archive_path")"
+fi
+
+ws=$(new_ws case-40-headerless-equal-archive)
+{
+  printf '%s\n' '## Verified facts' '## General rules' '## Open failures' '## Lessons learned'
+  i=1
+  while [ "$i" -le 60 ]; do
+    printf -- '- 2026-06-01 capped lesson %02d (source: distill-audit)\n' "$i"
+    i=$((i + 1))
+  done
+  printf '%s\n' '## Last session'
+} >"$ws/STATE.md"
+write_block "$ws/loop/pending/flush-2026-07-30.md" 2026-07-30 \
+  'A headerless equal archive must still append.'
+case_40_payload=$TMP_ROOT/case-40-payload
+printf '%s\n' '- 2026-06-01 capped lesson 01 (source: distill-audit)' >"$case_40_payload"
+eviction_archive_path="$ws/loop/archive/intake-evictions-$TODAY.md"
+cp "$case_40_payload" "$eviction_archive_path"
+printf '%s\n' 'scan=prior error=state-publish' >"$ws/loop/pending/intake-runs.log"
+if cmp -s "$case_40_payload" "$eviction_archive_path" \
+  && [ "$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 0 ]; then
+  headerless_seed_ok=1
+else
+  headerless_seed_ok=0
+fi
+run_intake "$ws"
+headerless_retry_rc=$?
+if [ "$headerless_seed_ok" -eq 1 ] \
+  && [ "$headerless_retry_rc" -eq 0 ] \
+  && [ "$(receipt_value "$ws" error)" = none ] \
+  && [ "$(grep -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 1 ] \
+  && [ "$(grep -Fc 'capped lesson 01' "$eviction_archive_path")" -eq 2 ]; then
+  pass '[40] a headerless archive equal to the eviction payload still appends a recorded eviction'
+else
+  fail_case '[40] a headerless archive equal to the eviction payload still appends a recorded eviction' \
+    "seed_ok=$headerless_seed_ok rc=$headerless_retry_rc receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log") archive=$(tr '\n' ' ' <"$eviction_archive_path")"
+fi
+
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
 [ "$FAIL_COUNT" -eq 0 ]

--- a/tests/hermes-flush-intake.test.sh
+++ b/tests/hermes-flush-intake.test.sh
@@ -195,7 +195,7 @@ INTAKE_UNDER_TEST="$HERMES_INTAKE" \
 full_suite_rc=$?
 set -e
 if [ "$full_suite_rc" -eq 0 ] \
-  && grep -Fqx 'Summary: 38 PASS, 0 FAIL' "$full_suite_log"; then
+  && grep -Fqx 'Summary: 40 PASS, 0 FAIL' "$full_suite_log"; then
   pass '[10] the full flush-intake behavioural suite passes through the Hermes entry'
 else
   fail_case '[10] the full flush-intake behavioural suite passes through the Hermes entry' \

--- a/tests/hermes-flush-intake.test.sh
+++ b/tests/hermes-flush-intake.test.sh
@@ -195,7 +195,7 @@ INTAKE_UNDER_TEST="$HERMES_INTAKE" \
 full_suite_rc=$?
 set -e
 if [ "$full_suite_rc" -eq 0 ] \
-  && grep -Fqx 'Summary: 37 PASS, 0 FAIL' "$full_suite_log"; then
+  && grep -Fqx 'Summary: 38 PASS, 0 FAIL' "$full_suite_log"; then
   pass '[10] the full flush-intake behavioural suite passes through the Hermes entry'
 else
   fail_case '[10] the full flush-intake behavioural suite passes through the Hermes entry' \

--- a/tests/hermes-flush-intake.test.sh
+++ b/tests/hermes-flush-intake.test.sh
@@ -195,7 +195,7 @@ INTAKE_UNDER_TEST="$HERMES_INTAKE" \
 full_suite_rc=$?
 set -e
 if [ "$full_suite_rc" -eq 0 ] \
-  && grep -Fqx 'Summary: 35 PASS, 0 FAIL' "$full_suite_log"; then
+  && grep -Fqx 'Summary: 37 PASS, 0 FAIL' "$full_suite_log"; then
   pass '[10] the full flush-intake behavioural suite passes through the Hermes entry'
 else
   fail_case '[10] the full flush-intake behavioural suite passes through the Hermes entry' \


### PR DESCRIPTION
Fixes #222.

## What

Make the eviction-archive append idempotent so a refused STATE publish followed by a clean retry leaves exactly one record per evicted lesson. The append-before-publish ordering is deliberately preserved (design decision recorded on #222: an append-only audit store prefers duplication over loss; reordering would create a crash window that permanently drops the record).

- Dedup: before appending, the payload is compared against everything after the archive's last `<!-- intake eviction adapter=` header; byte-identical → the refused run's block is adopted and the retry skips the duplicate.
- The skip is **gated on evidence of a refused publish** (previous `intake-runs.log` line contains `error=state-publish`) — an externally rewound STATE.md between two successful flushes appends its own record instead of being silently dropped (Kimi seat MAJOR, adopted).
- The append goes through `state_fold_atomic_archive_append` and fails closed (`receipt_error=eviction-archive`, exit 1, before the publish). Header search uses `grep -a` so a NUL byte cannot silently disable dedup (GLM seat MINOR, adopted).
- No new receipt fields, no header format change, no sidecar files — success-path bytes of STATE.md, receipts, and the archive are unchanged (byte-compared vs origin/main by two seats independently).
- INSTALL.md documents the retry-adoption rule, its payload-only (adapter-blind) comparison, and `receipt_error=eviction-archive`.

Commits: `13f5397` (dedup + cases 36/37) → `41abc9f` (hermes count 35→37) → `9d20d33` (receipt gate + case 38) → `ea8543d` (grep -a + cases 39/40 + docs). Implementation writer: Codex GPT-5.6 Sol (docs sentences: Alpha). Candidate SHA: **ea8543d**.

## Files touched (matches the WIP declaration + 2 visible re-declarations on #222)

- scripts/flush-intake.sh
- tests/flush-intake.test.sh
- tests/hermes-flush-intake.test.sh
- adapters/claude-code/INSTALL.md

`git diff --stat origin/main...ea8543d` = exactly these 4 files (+275/−7). No undeclared files in the diff.

## Completion record (L1-7)

**Candidate SHA**: `ea8543d` (= PR head at review time; all four review verdict rounds reference it or its reviewed ancestor `41abc9f` with delta re-review on `ea8543d`).

**Done when mapping** (all evidence dated 2026-08-29, commands run in the PR worktree unless noted):

1. *"A refused STATE publish followed by a clean retry leaves the eviction archive with exactly one record per evicted lesson (no duplicates, no false-positive record …)"* — **PASS**. `bash tests/flush-intake.test.sh` → `PASS [36] refused STATE publish retry adopts the existing eviction record without duplication` … `Summary: 40 PASS, 0 FAIL`. Independently replicated by all 3 seats with their own harnesses (GLM B1a/B1b probe: refusal ends 1 header/1 payload with STATE byte-unchanged, retry stays 1/1; Kimi probe E; Grok replica probes 15/15).
2. *"The chosen ordering/idempotence behavior is pinned by a test (refusal + retry scenario)"* — **PASS**. Cases [36]–[40] pin refusal-retry adoption, distinct-payload append, rewind append, LAST-header comparison, and headerless-equal append. Mutation authenticity (orchestrator runs, each restored to a clean tree afterwards): dedup-off → [36] red; always-skip → [10]/[36]/[37] red; first-header comparator → exactly [39] red; numeric-guard bypass → exactly [40] red. Seats reproduced with independent mutants (GLM M4p/M5p; Kimi ungated-dedup → exactly [38] red; Grok both r1 mutants).
3. *"Success-path bytes of STATE.md, receipts, and the eviction archive unchanged for the no-refusal case"* — **PASS**. Two independent seat A/B byte-comparisons vs an `origin/main` worktree (Kimi: STATE.md / intake-runs.log / archive / stdout+stderr identical after normalizing `ts=`; GLM s1/s2/s3: single/double/no-eviction all byte-identical, no new workspace file classes; Grok: same, receipt field set unchanged).

**Full verification at `ea8543d`** (orchestrator, 2026-08-29): flush-intake 40/40 · hermes-flush-intake 10/10 · state-fold-archive-append 9/9 · atomic-write-file 4/4 · last-session-fold 21/21 · state-caps-fold 11/11 · pending-dedup 13/13 · distill-audit 53/53 (SWEEP_OVERALL=0) · shellcheck clean.

**Review** (heterogeneous 3-seat, size M, loom-seats decision; full record: #222 review-record comment):
- Writer: Codex GPT-5.6 Sol (OpenAI) — heterogeneous vs all seats; orchestrator Alpha (Claude Fable 5) holds no seat vote.
- r1 on `41abc9f`: GLM 5.3 GO-WITH-MINOR · Kimi K3 NO-GO (MAJOR) · Grok 4.6 GO. Adjudication: Kimi MAJOR adopted (receipt gate, `9d20d33`); GLM MINORs adopted (`ea8543d`); Grok INFO deferred → #226.
- delta on `ea8543d`: **GLM GO · Kimi GO · Grok GO** (cumulative; requested/actual models recorded in the review record).

**CI**: all checks green on `ea8543d` (`gh pr checks 224` — test-lint / test, test-macos, lint, gitleaks, history-check, pr-size w/ size-exempt + rationale comment, repo-state, risk-review-gate all pass). pr-size exemption: production diff +46 lines; remainder is panel-demanded test cases + 8 doc lines (precedent PR #220/#223).

**release**: v0.22.5 — ship-relevant (user-visible behavior of the flush-intake consumer changes: dedup on retry, new `error=eviction-archive` receipt value). Annotated tag + GitHub Release to follow merge per T-5; MERGED declaration on #222 will carry the tag URL.

**previous release**: v0.22.4 — fulfilled: https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.22.4 (verified existing, #213 lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
