### PR TITLE
startup self-check: ordering asserts for threshold pairs + failure-shape comments (#108)

### DIFF
--- a/adapters/hermes/spawn_step.sh
+++ b/adapters/hermes/spawn_step.sh
@@ -60,6 +60,31 @@ source "$repo_root/scripts/lib-command-argv.sh"
 source "$repo_root/scripts/lib-pause.sh"
 prompt_file="$attempt_dir/prompt.md"
 
+HERMES_HTTP_TIMEOUT_S=$(resolve_timeout_env HERMES_HTTP_TIMEOUT_S 540)
+export HERMES_HTTP_TIMEOUT_S
+HERMES_STEP_TIMEOUT_S=$(resolve_timeout_env HERMES_STEP_TIMEOUT_S 540)
+HERMES_STEP_GRACE_S=$(resolve_timeout_env HERMES_STEP_GRACE_S 10 1)
+TR_STEP_TIMEOUT_S=$(resolve_timeout_env TR_STEP_TIMEOUT_S 600 1)
+
+# An HTTP timeout above the step timeout silently lets the wrapper kill hide the client timeout.
+if (( HERMES_HTTP_TIMEOUT_S > HERMES_STEP_TIMEOUT_S )); then
+  printf 'spawn_step.sh: ordering invariant failed: HERMES_HTTP_TIMEOUT_S(value=%s) <= HERMES_STEP_TIMEOUT_S(value=%s)\n' \
+    "$HERMES_HTTP_TIMEOUT_S" "$HERMES_STEP_TIMEOUT_S" >&2
+  exit 2
+fi
+# A cleanup grace at or above its step timeout silently makes cleanup outlive the operation it cleans up.
+if (( HERMES_STEP_GRACE_S >= HERMES_STEP_TIMEOUT_S )); then
+  printf 'spawn_step.sh: ordering invariant failed: HERMES_STEP_GRACE_S(value=%s) < HERMES_STEP_TIMEOUT_S(value=%s)\n' \
+    "$HERMES_STEP_GRACE_S" "$HERMES_STEP_TIMEOUT_S" >&2
+  exit 2
+fi
+# An adapter timeout plus grace at or above the driver timeout silently lets the driver preempt result quarantine.
+if (( HERMES_STEP_TIMEOUT_S + HERMES_STEP_GRACE_S >= TR_STEP_TIMEOUT_S )); then
+  printf 'spawn_step.sh: ordering invariant failed: HERMES_STEP_TIMEOUT_S(value=%s) + HERMES_STEP_GRACE_S(value=%s) < TR_STEP_TIMEOUT_S(value=%s)\n' \
+    "$HERMES_STEP_TIMEOUT_S" "$HERMES_STEP_GRACE_S" "$TR_STEP_TIMEOUT_S" >&2
+  exit 2
+fi
+
 # Keep the driver-facing arguments visible to strict mode and future audits.
 : "$task_file" "$workspace" "$step_k"
 
@@ -107,16 +132,6 @@ if [[ -n "${HERMES_PROBE_CMD:-}" ]]; then
   if ! "${probe_argv[@]+"${probe_argv[@]}"}"; then
     infra_fail 'HERMES_PROBE_CMD failed'
   fi
-fi
-
-export HERMES_HTTP_TIMEOUT_S="${HERMES_HTTP_TIMEOUT_S:-540}"
-HERMES_STEP_TIMEOUT_S=$(resolve_timeout_env HERMES_STEP_TIMEOUT_S 540)
-HERMES_STEP_GRACE_S=$(resolve_timeout_env HERMES_STEP_GRACE_S 10 1)
-
-if [[ -n "${TR_STEP_TIMEOUT_S:-}" ]] && [[ "$TR_STEP_TIMEOUT_S" =~ ^(0|[1-9][0-9]*)$ ]] \
-  && (( HERMES_STEP_TIMEOUT_S + HERMES_STEP_GRACE_S >= TR_STEP_TIMEOUT_S )); then
-  printf 'WARNING: HERMES_STEP_TIMEOUT_S(%ss)+grace(%ss) >= TR_STEP_TIMEOUT_S(%ss); driver hard-kill may preempt quarantine\n' \
-    "$HERMES_STEP_TIMEOUT_S" "$HERMES_STEP_GRACE_S" "$TR_STEP_TIMEOUT_S" >&2
 fi
 
 # Weak-model sessions lean on env vars they can echo — export the location

--- a/adapters/hermes/verify-job.sh
+++ b/adapters/hermes/verify-job.sh
@@ -626,6 +626,15 @@ source "$repo_root/scripts/lib-classify.sh"
 source "$repo_root/scripts/lib-bounded.sh"
 source "$repo_root/scripts/lib-wrapper-conformance.sh"
 source "$repo_root/scripts/lib-pause.sh"
+VERIFY_TIMEOUT_S=$(resolve_timeout_env VERIFY_TIMEOUT_S 300)
+VERIFY_GRACE_S=$(resolve_timeout_env VERIFY_GRACE_S 10 1)
+
+# A verifier grace at or above its timeout silently makes cleanup outlive the verification window.
+if (( VERIFY_GRACE_S >= VERIFY_TIMEOUT_S )); then
+  printf 'verify-job.sh: ordering invariant failed: VERIFY_GRACE_S(value=%s) < VERIFY_TIMEOUT_S(value=%s)\n' \
+    "$VERIFY_GRACE_S" "$VERIFY_TIMEOUT_S" >&2
+  exit 2
+fi
 bundle_dir=$(caty_pause_canonical_workspace "$1" 2>/dev/null) || {
   usage
   exit 2
@@ -830,8 +839,6 @@ fi
 
 verifier_stderr=$(mktemp "${TMPDIR:-/tmp}/verify-job.stderr.XXXXXX")
 verifier_stdout_file=$(mktemp "${TMPDIR:-/tmp}/verify-job.stdout.XXXXXX")
-VERIFY_TIMEOUT_S=$(resolve_timeout_env VERIFY_TIMEOUT_S 300)
-VERIFY_GRACE_S=$(resolve_timeout_env VERIFY_GRACE_S 10 1)
 
 set +e
 FABLE_CONFORMING_PROVIDER_PATH="$WRAPPER_CONFORMANCE_STAGED_PROVIDER_PATH" \

--- a/docs/ordering-pairs-108.md
+++ b/docs/ordering-pairs-108.md
@@ -1,0 +1,42 @@
+# Startup ordering inventory for issue #108
+
+This inventory covers the configurable thresholds and caps in
+`scripts/task-runner.sh`, `adapters/hermes/spawn_step.sh`,
+`adapters/hermes/verify-job.sh`, `scripts/flush-intake.sh`, and
+`scripts/lib-state-fold.sh`. Phase 1 adds entry guards without changing valid
+defaults. Phase 2 records the intake relationship but deliberately leaves its
+consumer and tests unchanged.
+
+## Ordering and positivity invariants
+
+| Pair or threshold | Where asserted | Silent failure shape prevented | Phase |
+| --- | --- | --- | --- |
+| `TR_GRACE_S < TR_STEP_TIMEOUT_S` | `scripts/task-runner.sh` startup | Recovery can outlive the operation it is meant to clean up. | Phase 1 |
+| `HERMES_HTTP_TIMEOUT_S <= HERMES_STEP_TIMEOUT_S` | `adapters/hermes/spawn_step.sh` pre-flight | The wrapper can kill the step before the HTTP client reports its own timeout, hiding the useful failure boundary. | Phase 1 |
+| `HERMES_STEP_GRACE_S < HERMES_STEP_TIMEOUT_S` | `adapters/hermes/spawn_step.sh` pre-flight | Cleanup can take at least as long as the operation it is cleaning up. | Phase 1 |
+| `HERMES_STEP_TIMEOUT_S + HERMES_STEP_GRACE_S < TR_STEP_TIMEOUT_S` | `adapters/hermes/spawn_step.sh` pre-flight | The driver hard-kill can preempt the adapter's partial-result quarantine. | Phase 1 |
+| `VERIFY_GRACE_S < VERIFY_TIMEOUT_S` | `adapters/hermes/verify-job.sh` entry | Verifier cleanup can outlive the verification window. | Phase 1 |
+| `TR_D21_NO_PROGRESS_THRESHOLD > 0` (hard internal value `2`) | `scripts/task-runner.sh` startup | A zero threshold can make the first noncomplete attempt terminal; the two normal and crash-recovery comparisons can also drift apart when expressed as literals. | Phase 1 |
+| `INTAKE_MAX_FOLD <= STATE_FOLD_LESSONS_CAP_DEFAULT` (the current `STATE_FOLD_LESSONS_CAP`) | Not yet asserted; the values meet in `scripts/flush-intake.sh` after `scripts/lib-state-fold.sh` is sourced. | An intake soft limit above the Lessons hard cap never constrains a run before FIFO eviction. | Phase 2 |
+
+Every Phase 1 ordering guard exits `2`, reports every involved variable and
+value, and runs before the entry point begins work. The D21 value remains an
+internal constant rather than a new environment configuration surface.
+
+## Examined near-misses that are not ordering pairs
+
+- `TR_LEDGER_FOLD_MAX_BYTES` is a per-loop chunk size, while
+  `TR_LEDGER_FOLD_TOTAL_MAX_BYTES` is a cumulative budget. The fold loop already
+  clips each chunk to the remaining total; neither value is a soft threshold
+  that must be less than the other.
+- `TR_DONECHECK_TIMEOUT_S` times a separate verification subprocess after a
+  step. It is not an inner timeout under `TR_STEP_TIMEOUT_S`, so ordering the two
+  would create a new combined-budget contract.
+- `TR_GATE_REPLAY_MAX_BYTES` is independently clamped at use. It has no semantic
+  ordering with the ledger byte budgets.
+- `HERMES_VERIFY_BUNDLE_MAX_BYTES` and `INTAKE_MAX_BULLET_BYTES` have fixed
+  numeric ranges, not relationships with another configurable threshold.
+- `STATE_FOLD_LESSONS_CAP_DEFAULT`, `STATE_FOLD_FAILURES_CAP_DEFAULT`,
+  `STATE_FOLD_VERIFIED_CAP_DEFAULT`, and `STATE_FOLD_RULES_CAP_DEFAULT` bound
+  different `STATE.md` sections. Their relative sizes do not control one
+  another.

--- a/docs/ordering-pairs-108.md
+++ b/docs/ordering-pairs-108.md
@@ -4,8 +4,8 @@ This inventory covers the configurable thresholds and caps in
 `scripts/task-runner.sh`, `adapters/hermes/spawn_step.sh`,
 `adapters/hermes/verify-job.sh`, `scripts/flush-intake.sh`, and
 `scripts/lib-state-fold.sh`. Phase 1 adds entry guards without changing valid
-defaults. Phase 2 records the intake relationship but deliberately leaves its
-consumer and tests unchanged.
+defaults. Phase 2 adds the deferred intake guard without changing its valid
+default or at-cap behavior.
 
 ## Ordering and positivity invariants
 
@@ -16,12 +16,13 @@ consumer and tests unchanged.
 | `HERMES_STEP_GRACE_S < HERMES_STEP_TIMEOUT_S` | `adapters/hermes/spawn_step.sh` pre-flight | Cleanup can take at least as long as the operation it is cleaning up. | Phase 1 |
 | `HERMES_STEP_TIMEOUT_S + HERMES_STEP_GRACE_S < TR_STEP_TIMEOUT_S` | `adapters/hermes/spawn_step.sh` pre-flight | The driver hard-kill can preempt the adapter's partial-result quarantine. | Phase 1 |
 | `VERIFY_GRACE_S < VERIFY_TIMEOUT_S` | `adapters/hermes/verify-job.sh` entry | Verifier cleanup can outlive the verification window. | Phase 1 |
-| `TR_D21_NO_PROGRESS_THRESHOLD > 0` (hard internal value `2`) | `scripts/task-runner.sh` startup | A zero threshold can make the first noncomplete attempt terminal; the two normal and crash-recovery comparisons can also drift apart when expressed as literals. | Phase 1 |
-| `INTAKE_MAX_FOLD <= STATE_FOLD_LESSONS_CAP_DEFAULT` (the current `STATE_FOLD_LESSONS_CAP`) | Not yet asserted; the values meet in `scripts/flush-intake.sh` after `scripts/lib-state-fold.sh` is sourced. | An intake soft limit above the Lessons hard cap never constrains a run before FIFO eviction. | Phase 2 |
+| `TR_PERSISTENT_FAILURE_THRESHOLD > 0` (hard internal value `2`) | `scripts/task-runner.sh` startup | A zero threshold can make the first noncomplete attempt terminal; the normal and crash-recovery persistent-failure comparisons can also drift apart when expressed as literals. | Phase 1 |
+| `INTAKE_MAX_FOLD <= STATE_FOLD_LESSONS_CAP_DEFAULT` | `scripts/flush-intake.sh` entry, after `scripts/lib-state-fold.sh` is sourced | An intake soft limit above the Lessons hard cap never constrains a run before FIFO eviction. | Phase 2 |
 
-Every Phase 1 ordering guard exits `2`, reports every involved variable and
-value, and runs before the entry point begins work. The D21 value remains an
-internal constant rather than a new environment configuration surface.
+Every asserted ordering or positivity guard exits `2`, reports every involved
+variable and value, and runs before the entry point begins work. The
+persistent-failure value remains an internal constant rather than a new
+environment configuration surface.
 
 ## Examined near-misses that are not ordering pairs
 
@@ -36,6 +37,13 @@ internal constant rather than a new environment configuration surface.
   ordering with the ledger byte budgets.
 - `HERMES_VERIFY_BUNDLE_MAX_BYTES` and `INTAKE_MAX_BULLET_BYTES` have fixed
   numeric ranges, not relationships with another configurable threshold.
+- `INTAKE_LOCK_ATTEMPTS` and `INTAKE_LOCK_SLEEP_S` bound the intake consumer's
+  lock retry loop. `STATE_FOLD_LOCK_STALE_S` is the single stale-age TTL used by
+  the shared lock implementation. Retry count, retry delay, and stale age do not
+  form a required ordering pair.
+- `{{ATTEMPTS_BUDGET}}` and `{{TIME_BUDGET_MIN}}` are step-prompt render tokens
+  populated from each task's `attempts_budget` and `time_budget_min` metadata.
+  They are not environment thresholds in these entry points.
 - `STATE_FOLD_LESSONS_CAP_DEFAULT`, `STATE_FOLD_FAILURES_CAP_DEFAULT`,
   `STATE_FOLD_VERIFIED_CAP_DEFAULT`, and `STATE_FOLD_RULES_CAP_DEFAULT` bound
   different `STATE.md` sections. Their relative sizes do not control one

--- a/scripts/flush-intake.sh
+++ b/scripts/flush-intake.sh
@@ -233,19 +233,6 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$repo_root/scripts/lib-state-fold.sh"
 adapter_identity=${adapter_identity:-"${CATY_INTAKE_ADAPTER:?}-flush-intake"}
 
-state_file="$workspace/STATE.md"
-pending_dir="$workspace/loop/pending"
-archive_dir="$workspace/loop/archive"
-artifacts_dir="$workspace/loop/artifacts"
-deadman_dir="$workspace/loop/.deadman"
-receipt_file="$pending_dir/intake-runs.log"
-for required_path in "$state_file" "$pending_dir" "$archive_dir" "$artifacts_dir"; do
-  [[ -e "$required_path" ]] || {
-    usage
-    exit 2
-  }
-done
-
 max_fold=${INTAKE_MAX_FOLD:-$((STATE_FOLD_LESSONS_CAP_DEFAULT / 2))}
 max_bullet_bytes=${INTAKE_MAX_BULLET_BYTES:-512}
 lock_attempts=${INTAKE_LOCK_ATTEMPTS:-30}
@@ -262,6 +249,25 @@ if ((max_bullet_bytes > 1048576)); then
   usage
   exit 2
 fi
+# An intake soft limit above the Lessons hard cap never constrains a run before FIFO eviction.
+if (( max_fold > STATE_FOLD_LESSONS_CAP_DEFAULT )); then
+  printf 'flush-intake.sh: ordering invariant failed: INTAKE_MAX_FOLD(value=%s) <= STATE_FOLD_LESSONS_CAP_DEFAULT(value=%s)\n' \
+    "$max_fold" "$STATE_FOLD_LESSONS_CAP_DEFAULT" >&2
+  exit 2
+fi
+
+state_file="$workspace/STATE.md"
+pending_dir="$workspace/loop/pending"
+archive_dir="$workspace/loop/archive"
+artifacts_dir="$workspace/loop/artifacts"
+deadman_dir="$workspace/loop/.deadman"
+receipt_file="$pending_dir/intake-runs.log"
+for required_path in "$state_file" "$pending_dir" "$archive_dir" "$artifacts_dir"; do
+  [[ -e "$required_path" ]] || {
+    usage
+    exit 2
+  }
+done
 
 files_scanned=0
 blocks=0

--- a/scripts/task-runner.sh
+++ b/scripts/task-runner.sh
@@ -22,8 +22,9 @@ TR_LEDGER_FOLD_TOTAL_MAX_BYTES=${TR_LEDGER_FOLD_TOTAL_MAX_BYTES-16777216}
 TR_LEDGER_FOLD_MAX_BYTES=${TR_LEDGER_FOLD_MAX_BYTES-4194304}
 # Replay payload cap: values are clamped to a 64-byte floor and 1048576-byte ceiling.
 TR_GATE_REPLAY_MAX_BYTES=${TR_GATE_REPLAY_MAX_BYTES-4096}
+TR_D21_NO_PROGRESS_THRESHOLD=2
 
-for integer_var in TR_STEP_TIMEOUT_S TR_GRACE_S TR_DONECHECK_TIMEOUT_S TR_GATE_REPLAY_MAX_BYTES TR_LEDGER_FOLD_TOTAL_MAX_BYTES TR_LEDGER_FOLD_MAX_BYTES; do
+for integer_var in TR_STEP_TIMEOUT_S TR_GRACE_S TR_DONECHECK_TIMEOUT_S TR_GATE_REPLAY_MAX_BYTES TR_LEDGER_FOLD_TOTAL_MAX_BYTES TR_LEDGER_FOLD_MAX_BYTES TR_D21_NO_PROGRESS_THRESHOLD; do
   integer_value=${!integer_var}
   case "$integer_value" in
     ''|*[!0-9]*|0[0-9]*)
@@ -32,8 +33,20 @@ for integer_var in TR_STEP_TIMEOUT_S TR_GRACE_S TR_DONECHECK_TIMEOUT_S TR_GATE_R
       ;;
   esac
 done
+# A zero D21 threshold makes the first noncomplete attempt silently terminal.
+if (( TR_D21_NO_PROGRESS_THRESHOLD == 0 )); then
+  printf 'TR_D21_NO_PROGRESS_THRESHOLD must be greater than zero: value=%s\n' \
+    "$TR_D21_NO_PROGRESS_THRESHOLD" >&2
+  exit 2
+fi
 if (( TR_LEDGER_FOLD_MAX_BYTES == 0 )); then
   printf 'TR_LEDGER_FOLD_MAX_BYTES must be greater than zero\n' >&2
+  exit 2
+fi
+# A grace window at or above the step timeout silently lets recovery outlive the operation it cleans up.
+if (( TR_GRACE_S >= TR_STEP_TIMEOUT_S )); then
+  printf 'ordering invariant failed: TR_GRACE_S(value=%s) < TR_STEP_TIMEOUT_S(value=%s)\n' \
+    "$TR_GRACE_S" "$TR_STEP_TIMEOUT_S" >&2
   exit 2
 fi
 
@@ -2476,7 +2489,7 @@ finalize_attempt() {
       consec_noncomplete=1
     fi
     last_error_class=$error_class
-    if (( consec_noncomplete >= 2 )) && [[ -z "$pending_terminal" ]]; then
+    if (( consec_noncomplete >= TR_D21_NO_PROGRESS_THRESHOLD )) && [[ -z "$pending_terminal" ]]; then
       pending_terminal=persistent-failure
     fi
   fi
@@ -2634,7 +2647,7 @@ recover_verifying() {
       fi
       if [[ -z "$recovery_reason" ]] && (( $(deviation_count "$artifact_dir/attempts") >= 3 )); then
         recovery_reason=plan-mismatch
-      elif [[ -z "$recovery_reason" ]] && (( consec_noncomplete >= 2 )); then
+      elif [[ -z "$recovery_reason" ]] && (( consec_noncomplete >= TR_D21_NO_PROGRESS_THRESHOLD )); then
         recovery_reason=persistent-failure
       elif [[ -z "$recovery_reason" ]] && (( attempts_used >= ${attempts_budget:-0} )); then
         recovery_reason=attempts-budget

--- a/scripts/task-runner.sh
+++ b/scripts/task-runner.sh
@@ -22,9 +22,9 @@ TR_LEDGER_FOLD_TOTAL_MAX_BYTES=${TR_LEDGER_FOLD_TOTAL_MAX_BYTES-16777216}
 TR_LEDGER_FOLD_MAX_BYTES=${TR_LEDGER_FOLD_MAX_BYTES-4194304}
 # Replay payload cap: values are clamped to a 64-byte floor and 1048576-byte ceiling.
 TR_GATE_REPLAY_MAX_BYTES=${TR_GATE_REPLAY_MAX_BYTES-4096}
-TR_D21_NO_PROGRESS_THRESHOLD=2
+TR_PERSISTENT_FAILURE_THRESHOLD=2
 
-for integer_var in TR_STEP_TIMEOUT_S TR_GRACE_S TR_DONECHECK_TIMEOUT_S TR_GATE_REPLAY_MAX_BYTES TR_LEDGER_FOLD_TOTAL_MAX_BYTES TR_LEDGER_FOLD_MAX_BYTES TR_D21_NO_PROGRESS_THRESHOLD; do
+for integer_var in TR_STEP_TIMEOUT_S TR_GRACE_S TR_DONECHECK_TIMEOUT_S TR_GATE_REPLAY_MAX_BYTES TR_LEDGER_FOLD_TOTAL_MAX_BYTES TR_LEDGER_FOLD_MAX_BYTES TR_PERSISTENT_FAILURE_THRESHOLD; do
   integer_value=${!integer_var}
   case "$integer_value" in
     ''|*[!0-9]*|0[0-9]*)
@@ -33,10 +33,10 @@ for integer_var in TR_STEP_TIMEOUT_S TR_GRACE_S TR_DONECHECK_TIMEOUT_S TR_GATE_R
       ;;
   esac
 done
-# A zero D21 threshold makes the first noncomplete attempt silently terminal.
-if (( TR_D21_NO_PROGRESS_THRESHOLD == 0 )); then
-  printf 'TR_D21_NO_PROGRESS_THRESHOLD must be greater than zero: value=%s\n' \
-    "$TR_D21_NO_PROGRESS_THRESHOLD" >&2
+# A zero persistent-failure threshold makes the first noncomplete attempt silently terminal.
+if (( TR_PERSISTENT_FAILURE_THRESHOLD == 0 )); then
+  printf 'task-runner.sh: TR_PERSISTENT_FAILURE_THRESHOLD must be greater than zero: value=%s\n' \
+    "$TR_PERSISTENT_FAILURE_THRESHOLD" >&2
   exit 2
 fi
 if (( TR_LEDGER_FOLD_MAX_BYTES == 0 )); then
@@ -45,7 +45,7 @@ if (( TR_LEDGER_FOLD_MAX_BYTES == 0 )); then
 fi
 # A grace window at or above the step timeout silently lets recovery outlive the operation it cleans up.
 if (( TR_GRACE_S >= TR_STEP_TIMEOUT_S )); then
-  printf 'ordering invariant failed: TR_GRACE_S(value=%s) < TR_STEP_TIMEOUT_S(value=%s)\n' \
+  printf 'task-runner.sh: ordering invariant failed: TR_GRACE_S(value=%s) < TR_STEP_TIMEOUT_S(value=%s)\n' \
     "$TR_GRACE_S" "$TR_STEP_TIMEOUT_S" >&2
   exit 2
 fi
@@ -2489,7 +2489,7 @@ finalize_attempt() {
       consec_noncomplete=1
     fi
     last_error_class=$error_class
-    if (( consec_noncomplete >= TR_D21_NO_PROGRESS_THRESHOLD )) && [[ -z "$pending_terminal" ]]; then
+    if (( consec_noncomplete >= TR_PERSISTENT_FAILURE_THRESHOLD )) && [[ -z "$pending_terminal" ]]; then
       pending_terminal=persistent-failure
     fi
   fi
@@ -2647,7 +2647,7 @@ recover_verifying() {
       fi
       if [[ -z "$recovery_reason" ]] && (( $(deviation_count "$artifact_dir/attempts") >= 3 )); then
         recovery_reason=plan-mismatch
-      elif [[ -z "$recovery_reason" ]] && (( consec_noncomplete >= TR_D21_NO_PROGRESS_THRESHOLD )); then
+      elif [[ -z "$recovery_reason" ]] && (( consec_noncomplete >= TR_PERSISTENT_FAILURE_THRESHOLD )); then
         recovery_reason=persistent-failure
       elif [[ -z "$recovery_reason" ]] && (( attempts_used >= ${attempts_budget:-0} )); then
         recovery_reason=attempts-budget

--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -11,8 +11,9 @@ TMP_ROOT=${TMPDIR:-/tmp}/flush-intake-test.$$
 PASS_COUNT=0
 FAIL_COUNT=0
 TODAY=$(date -u +%F)
-DEFAULT_INTAKE_MAX_FOLD=$(bash -c 'source "$1"; printf "%s\n" "$((STATE_FOLD_LESSONS_CAP_DEFAULT / 2))"' \
+STATE_FOLD_LESSONS_CAP_DEFAULT=$(bash -c 'source "$1"; printf "%s\n" "$STATE_FOLD_LESSONS_CAP_DEFAULT"' \
   _ "$ROOT/scripts/lib-state-fold.sh")
+DEFAULT_INTAKE_MAX_FOLD=$((STATE_FOLD_LESSONS_CAP_DEFAULT / 2))
 DEFAULT_INTAKE_MAX_BULLET_BYTES=512
 
 cleanup() {
@@ -43,6 +44,15 @@ run_intake() {
   local ws=$1
   shift
   env INTAKE_LOCK_SLEEP_S=0 "$@" "$INTAKE" "$ws" >"$TMP_ROOT/intake.out" 2>"$TMP_ROOT/intake.err"
+}
+
+run_intake_unset_max_fold() {
+  local ws=$1
+
+  (
+    unset INTAKE_MAX_FOLD
+    INTAKE_LOCK_SLEEP_S=0 "$INTAKE" "$ws" >"$TMP_ROOT/intake.out" 2>"$TMP_ROOT/intake.err"
+  )
 }
 
 state_count() {
@@ -79,6 +89,31 @@ age_file_seconds() {
 file_mtime() {
   stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1"
 }
+
+ws=$(new_ws case-00-ordering-assert)
+set +e
+run_intake "$ws" INTAKE_MAX_FOLD=$((STATE_FOLD_LESSONS_CAP_DEFAULT + 1))
+ordering_rc=$?
+set -e
+ordering_stderr=$(tr '\n' ' ' <"$TMP_ROOT/intake.err")
+if [ "$ordering_rc" -eq 2 ] \
+  && grep -Fqx "flush-intake.sh: ordering invariant failed: INTAKE_MAX_FOLD(value=$((STATE_FOLD_LESSONS_CAP_DEFAULT + 1))) <= STATE_FOLD_LESSONS_CAP_DEFAULT(value=$STATE_FOLD_LESSONS_CAP_DEFAULT)" "$TMP_ROOT/intake.err" \
+  && [ ! -e "$ws/loop/pending/intake-runs.log" ] \
+  && [ ! -e "$ws/loop/.distill-state.lock" ]; then
+  ordering_red_ok=1
+else
+  ordering_red_ok=0
+fi
+unset_ws=$(new_ws case-00-ordering-unset)
+at_cap_ws=$(new_ws case-00-ordering-at-cap)
+if [ "$ordering_red_ok" -eq 1 ] \
+  && run_intake_unset_max_fold "$unset_ws" \
+  && run_intake "$at_cap_ws" INTAKE_MAX_FOLD="$STATE_FOLD_LESSONS_CAP_DEFAULT"; then
+  pass '[0] intake fold ordering fails closed above the Lessons cap and accepts unset or at-cap values'
+else
+  fail_case '[0] intake fold ordering fails closed above the Lessons cap and accepts unset or at-cap values' \
+    "red_ok=$ordering_red_ok red_rc=$ordering_rc stderr=$ordering_stderr"
+fi
 
 ws=$(new_ws case-01-fold)
 cp "$ROOT/tests/fixtures/flush/basic.md" "$ws/loop/pending/flush-2026-07-01.md"

--- a/tests/hermes-flush-intake.test.sh
+++ b/tests/hermes-flush-intake.test.sh
@@ -195,7 +195,7 @@ INTAKE_UNDER_TEST="$HERMES_INTAKE" \
 full_suite_rc=$?
 set -e
 if [ "$full_suite_rc" -eq 0 ] \
-  && grep -Fqx 'Summary: 40 PASS, 0 FAIL' "$full_suite_log"; then
+  && grep -Fqx 'Summary: 41 PASS, 0 FAIL' "$full_suite_log"; then
   pass '[10] the full flush-intake behavioural suite passes through the Hermes entry'
 else
   fail_case '[10] the full flush-intake behavioural suite passes through the Hermes entry' \

--- a/tests/spawn-step.test.sh
+++ b/tests/spawn-step.test.sh
@@ -108,6 +108,67 @@ case_success() {
   fi
 }
 
+case_ordering_guards() {
+  local name=ordering-guards
+  local dir code output sentinel
+  dir=$(make_case_dir)
+  sentinel="$dir/invoked"
+  cat >"$dir/fake-hermes" <<SH
+#!/usr/bin/env bash
+touch "$sentinel"
+exit 0
+SH
+  chmod +x "$dir/fake-hermes"
+
+  set +e
+  output=$(HERMES_STEP_CMD="$dir/fake-hermes" HERMES_HTTP_TIMEOUT_S=541 \
+    HERMES_STEP_TIMEOUT_S=540 HERMES_STEP_GRACE_S=10 TR_STEP_TIMEOUT_S=600 \
+    run_adapter "$dir" 2>&1)
+  code=$?
+  set -e
+  if [[ "$code" -ne 2 ]] \
+    || ! grep -Fq 'ordering invariant failed: HERMES_HTTP_TIMEOUT_S(value=541) <= HERMES_STEP_TIMEOUT_S(value=540)' <<<"$output" \
+    || [[ -e "$sentinel" ]]; then
+    fail "$name-HERMES_HTTP_TIMEOUT_S-HERMES_STEP_TIMEOUT_S" "rc=$code output=$output"
+    return
+  fi
+
+  set +e
+  output=$(HERMES_STEP_CMD="$dir/fake-hermes" HERMES_HTTP_TIMEOUT_S=10 \
+    HERMES_STEP_TIMEOUT_S=10 HERMES_STEP_GRACE_S=10 TR_STEP_TIMEOUT_S=30 \
+    run_adapter "$dir" 2>&1)
+  code=$?
+  set -e
+  if [[ "$code" -ne 2 ]] \
+    || ! grep -Fq 'ordering invariant failed: HERMES_STEP_GRACE_S(value=10) < HERMES_STEP_TIMEOUT_S(value=10)' <<<"$output" \
+    || [[ -e "$sentinel" ]]; then
+    fail "$name-HERMES_STEP_GRACE_S-HERMES_STEP_TIMEOUT_S" "rc=$code output=$output"
+    return
+  fi
+
+  set +e
+  output=$(HERMES_STEP_CMD="$dir/fake-hermes" HERMES_HTTP_TIMEOUT_S=20 \
+    HERMES_STEP_TIMEOUT_S=20 HERMES_STEP_GRACE_S=1 TR_STEP_TIMEOUT_S=21 \
+    run_adapter "$dir" 2>&1)
+  code=$?
+  set -e
+  if [[ "$code" -ne 2 ]] \
+    || ! grep -Fq 'ordering invariant failed: HERMES_STEP_TIMEOUT_S(value=20) + HERMES_STEP_GRACE_S(value=1) < TR_STEP_TIMEOUT_S(value=21)' <<<"$output" \
+    || [[ -e "$sentinel" ]]; then
+    fail "$name-HERMES_STEP_TIMEOUT_S-HERMES_STEP_GRACE_S-TR_STEP_TIMEOUT_S" "rc=$code output=$output"
+    return
+  fi
+
+  if HERMES_STEP_CMD="$dir/fake-hermes" HERMES_HTTP_TIMEOUT_S=20 \
+    HERMES_STEP_TIMEOUT_S=20 HERMES_STEP_GRACE_S=1 TR_STEP_TIMEOUT_S=22 \
+    run_adapter "$dir" >/dev/null 2>&1 \
+    && [[ -e "$sentinel" ]]; then
+    pass "$name"
+  else
+    fail "$name-happy" 'valid explicit ordering did not invoke the step command'
+  fi
+}
+
 case_step_cmd_unset() {
   local name=step-cmd-unset
   local dir code
@@ -387,7 +448,7 @@ case_timeout_quarantines_partial_output_and_kills_group() {
   dir=$(make_case_dir)
   write_hanging_cli "$dir/fake-hermes"
   set +e
-  HERMES_STEP_CMD="$dir/fake-hermes" HERMES_STEP_TIMEOUT_S=2 HERMES_STEP_GRACE_S=1 run_adapter "$dir" >/dev/null 2>&1
+  HERMES_STEP_CMD="$dir/fake-hermes" HERMES_HTTP_TIMEOUT_S=2 HERMES_STEP_TIMEOUT_S=2 HERMES_STEP_GRACE_S=1 run_adapter "$dir" >/dev/null 2>&1
   code=$?
   set -e
   grandchild_pid=$(cat "$dir/attempt/grandchild.pid" 2>/dev/null || true)
@@ -411,7 +472,7 @@ case_fast_exit_preserves_complete_output_and_reaps_group() {
   dir=$(make_case_dir)
   write_fast_lingering_cli "$dir/fake-hermes"
   set +e
-  HERMES_STEP_CMD="$dir/fake-hermes" HERMES_STEP_TIMEOUT_S=10 HERMES_STEP_GRACE_S=1 run_adapter "$dir" >/dev/null 2>&1
+  HERMES_STEP_CMD="$dir/fake-hermes" HERMES_HTTP_TIMEOUT_S=10 HERMES_STEP_TIMEOUT_S=10 HERMES_STEP_GRACE_S=1 run_adapter "$dir" >/dev/null 2>&1
   code=$?
   set -e
   grandchild_pid=$(cat "$dir/attempt/grandchild.pid" 2>/dev/null || true)
@@ -451,7 +512,7 @@ case_forwarded_term_quarantines_partial_output_and_kills_group() {
   local dir adapter_pid code grandchild_pid tries
   dir=$(make_case_dir)
   write_signal_hanging_cli "$dir/fake-hermes"
-  HERMES_STEP_CMD="$dir/fake-hermes" HERMES_STEP_TIMEOUT_S=30 HERMES_STEP_GRACE_S=1 \
+  HERMES_STEP_CMD="$dir/fake-hermes" HERMES_HTTP_TIMEOUT_S=30 HERMES_STEP_TIMEOUT_S=30 HERMES_STEP_GRACE_S=1 \
     "$ADAPTER" "$dir/task.md" "$dir/ws" "$dir/attempt" 1 >/dev/null 2>&1 &
   adapter_pid=$!
   tries=0
@@ -553,6 +614,7 @@ case_runner_rejects_nonexecutable_spawn_step() {
 }
 
 case_success
+case_ordering_guards
 case_step_cmd_unset
 case_step_cmd_nonexistent
 case_step_runs_in_workspace

--- a/tests/task-runner.test.sh
+++ b/tests/task-runner.test.sh
@@ -347,7 +347,7 @@ case_startup_ordering_validation() {
   code=$?
   set -e
   if [[ "$code" -ne 2 ]] \
-    || ! grep -Fq 'ordering invariant failed: TR_GRACE_S(value=30) < TR_STEP_TIMEOUT_S(value=30)' <<<"$output" \
+    || ! grep -Fq 'task-runner.sh: ordering invariant failed: TR_GRACE_S(value=30) < TR_STEP_TIMEOUT_S(value=30)' <<<"$output" \
     || [[ -e "$ws/loop/tasks/.tick.lock" ]] \
     || [[ -d "$ws/loop/artifacts" ]]; then
     fail "$name-TR_GRACE_S-TR_STEP_TIMEOUT_S" "rc=$code output=$output"
@@ -358,7 +358,7 @@ case_startup_ordering_validation() {
   mutated_root=$(mktemp -d "${TMPDIR:-/tmp}/tr-mutated-root.XXXXXX")
   mkdir -p "$mutated_root/scripts"
   mutated_runner="$mutated_root/scripts/task-runner.sh"
-  sed 's/^TR_D21_NO_PROGRESS_THRESHOLD=2$/TR_D21_NO_PROGRESS_THRESHOLD=0/' \
+  sed 's/^TR_PERSISTENT_FAILURE_THRESHOLD=2$/TR_PERSISTENT_FAILURE_THRESHOLD=0/' \
     "$RUNNER" >"$mutated_runner"
   chmod +x "$mutated_runner"
   set +e
@@ -367,10 +367,10 @@ case_startup_ordering_validation() {
   set -e
   rm -rf "$mutated_root"
   if [[ "$code" -ne 2 ]] \
-    || ! grep -Fq 'TR_D21_NO_PROGRESS_THRESHOLD must be greater than zero: value=0' <<<"$output" \
+    || ! grep -Fq 'task-runner.sh: TR_PERSISTENT_FAILURE_THRESHOLD must be greater than zero: value=0' <<<"$output" \
     || [[ -e "$ws/loop/tasks/.tick.lock" ]] \
     || [[ -d "$ws/loop/artifacts" ]]; then
-    fail "$name-TR_D21_NO_PROGRESS_THRESHOLD" "rc=$code output=$output"
+    fail "$name-TR_PERSISTENT_FAILURE_THRESHOLD" "rc=$code output=$output"
     return
   fi
 

--- a/tests/task-runner.test.sh
+++ b/tests/task-runner.test.sh
@@ -327,7 +327,7 @@ case_env_integer_validation() {
 
   ws=$(make_ws)
   set +e
-  output=$(run_tick "$ws" TR_STEP_TIMEOUT_S=0 TR_GRACE_S=0 TR_DONECHECK_TIMEOUT_S=0 TR_GATE_REPLAY_MAX_BYTES=0 2>&1)
+  output=$(run_tick "$ws" TR_STEP_TIMEOUT_S=1 TR_GRACE_S=0 TR_DONECHECK_TIMEOUT_S=0 TR_GATE_REPLAY_MAX_BYTES=0 2>&1)
   code=$?
   set -e
   if [[ "$code" -ne 0 ]] || grep -F -q 'must be a non-negative integer' <<<"$output"; then
@@ -335,6 +335,53 @@ case_env_integer_validation() {
     return
   fi
   pass "$name"
+}
+
+case_startup_ordering_validation() {
+  local name=startup-ordering-validation
+  local ws output code mutated_root mutated_runner
+
+  ws=$(make_ws)
+  set +e
+  output=$(run_tick "$ws" TR_STEP_TIMEOUT_S=30 TR_GRACE_S=30 2>&1)
+  code=$?
+  set -e
+  if [[ "$code" -ne 2 ]] \
+    || ! grep -Fq 'ordering invariant failed: TR_GRACE_S(value=30) < TR_STEP_TIMEOUT_S(value=30)' <<<"$output" \
+    || [[ -e "$ws/loop/tasks/.tick.lock" ]] \
+    || [[ -d "$ws/loop/artifacts" ]]; then
+    fail "$name-TR_GRACE_S-TR_STEP_TIMEOUT_S" "rc=$code output=$output"
+    return
+  fi
+
+  ws=$(make_ws)
+  mutated_root=$(mktemp -d "${TMPDIR:-/tmp}/tr-mutated-root.XXXXXX")
+  mkdir -p "$mutated_root/scripts"
+  mutated_runner="$mutated_root/scripts/task-runner.sh"
+  sed 's/^TR_D21_NO_PROGRESS_THRESHOLD=2$/TR_D21_NO_PROGRESS_THRESHOLD=0/' \
+    "$RUNNER" >"$mutated_runner"
+  chmod +x "$mutated_runner"
+  set +e
+  output=$(TR_SPAWN_STEP="$MOCK" bash "$mutated_runner" "$ws" 2>&1)
+  code=$?
+  set -e
+  rm -rf "$mutated_root"
+  if [[ "$code" -ne 2 ]] \
+    || ! grep -Fq 'TR_D21_NO_PROGRESS_THRESHOLD must be greater than zero: value=0' <<<"$output" \
+    || [[ -e "$ws/loop/tasks/.tick.lock" ]] \
+    || [[ -d "$ws/loop/artifacts" ]]; then
+    fail "$name-TR_D21_NO_PROGRESS_THRESHOLD" "rc=$code output=$output"
+    return
+  fi
+
+  ws=$(make_ws)
+  copy_task "$FIX_BASIC" "$ws" tr-basic
+  if run_tick "$ws" TR_MOCK_BEHAVIOR=success >/dev/null \
+    && [[ -f "$ws/loop/tasks/delivered/tr-basic/tr-basic.task.md" ]]; then
+    pass "$name"
+  else
+    fail "$name" 'valid defaults did not complete the entry path'
+  fi
 }
 
 case_corrupt_state_quarantine_continues() {
@@ -1814,11 +1861,11 @@ case_stale_lease_reap() {
   ws=$(make_ws)
   copy_task "$FIX_BASIC" "$ws" tr-basic
   set +e
-  run_tick "$ws" TR_MOCK_BEHAVIOR=hang TR_CRASH_AFTER=spawn TR_STEP_TIMEOUT_S=1 TR_GRACE_S=1 >/dev/null 2>&1
+  run_tick "$ws" TR_MOCK_BEHAVIOR=hang TR_CRASH_AFTER=spawn TR_STEP_TIMEOUT_S=1 TR_GRACE_S=0 >/dev/null 2>&1
   set -e
   pgid=$(state_value "$ws" tr-basic lease.pgid)
   sleep 3
-  run_tick "$ws" TR_MOCK_BEHAVIOR=success TR_STEP_TIMEOUT_S=1 TR_GRACE_S=1
+  run_tick "$ws" TR_MOCK_BEHAVIOR=success TR_STEP_TIMEOUT_S=1 TR_GRACE_S=0
   if kill -0 "-$pgid" 2>/dev/null; then
     fail "$name" "orphaned process group still alive"
   elif [[ "$(state_value "$ws" tr-basic status)" = delivered ]]; then
@@ -1898,7 +1945,7 @@ case_time_exhaustion() {
   local ws
   ws=$(make_ws)
   copy_task "$FIX_TINY" "$ws" tr-tiny-budget
-  run_tick "$ws" TR_MOCK_BEHAVIOR=noncomplete TR_MOCK_ERROR_CLASS=time-one TR_STEP_TIMEOUT_S=1
+  run_tick "$ws" TR_MOCK_BEHAVIOR=noncomplete TR_MOCK_ERROR_CLASS=time-one TR_STEP_TIMEOUT_S=1 TR_GRACE_S=0
   if [[ "$(state_value "$ws" tr-tiny-budget status)" = dlq ]] && [[ "$(state_value "$ws" tr-tiny-budget terminal_reason)" = time-budget ]]; then
     pass "$name"
   else
@@ -1959,7 +2006,7 @@ case_timeout_is_chargeable_not_quarantined() {
   ws=$(make_ws)
   root="$ws/loop/artifacts/tr-basic"
   copy_task "$FIX_BASIC" "$ws" tr-basic
-  run_tick "$ws" TR_MOCK_BEHAVIOR=hang TR_STEP_TIMEOUT_S=1 TR_GRACE_S=1
+  run_tick "$ws" TR_MOCK_BEHAVIOR=hang TR_STEP_TIMEOUT_S=1 TR_GRACE_S=0
   if [[ ! -e "$root/attempts-infra" ]] \
     && [[ "$(state_value "$ws" tr-basic attempts_used)" = 1 ]] \
     && [[ "$(state_value "$ws" tr-basic infra_retries)" = 0 ]] \
@@ -3528,6 +3575,7 @@ PY
 }
 
 case_env_integer_validation
+case_startup_ordering_validation
 case_corrupt_state_quarantine_continues
 case_quoted_id_intake_runner_agree
 case_invalid_created_sorts_last

--- a/tests/verify-job.test.sh
+++ b/tests/verify-job.test.sh
@@ -333,6 +333,30 @@ else
   fail_case "valid verifier command runs and logs verdict" "rc=$rc output=$output"
 fi
 
+bundle=$(make_bundle ordering-guard)
+output=$(VERIFY_TIMEOUT_S=10 VERIFY_GRACE_S=10 bash "$SCRIPT" "$bundle" 2>&1)
+rc=$?
+if [ "$rc" -eq 2 ] \
+  && printf '%s\n' "$output" | grep -Fq 'ordering invariant failed: VERIFY_GRACE_S(value=10) < VERIFY_TIMEOUT_S(value=10)' \
+  && [ ! -e "$TMP_ROOT/ws-ordering-guard/loop/artifacts/task-one/verify.json" ]; then
+  pass "verify timeout ordering rejects equal grace at entry"
+else
+  fail_case "verify timeout ordering rejects equal grace at entry" "rc=$rc output=$output"
+fi
+
+bundle=$(make_bundle ordering-happy)
+verifier=$TMP_ROOT/ordering-happy-verifier.sh
+write_verifier "$verifier"
+attest_verifier_wrapper "$verifier" ordering-happy
+output=$(VERIFY_TIMEOUT_S=10 VERIFY_GRACE_S=1 VERIFIER_CMD="$verifier" \
+  VERIFIER_ID=ordering-happy bash "$SCRIPT" "$bundle" 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ] && printf '%s\n' "$output" | grep -Fq 'VERDICT: pass'; then
+  pass "verify timeout ordering accepts a smaller grace"
+else
+  fail_case "verify timeout ordering accepts a smaller grace" "rc=$rc output=$output"
+fi
+
 bundle=$(make_bundle success-stderr)
 verifier=$TMP_ROOT/warning-verifier.sh
 write_warning_verifier "$verifier"


### PR DESCRIPTION
Closes #108.

Threshold pairs with ordering invariants (grace < timeout, soft ≤ cap) were guarded by comments at best; a violated ordering produced silent misbehavior. This PR adds fail-closed startup/entry asserts (exit 2, named-pair message with both values) at all four entry points, each with a one-line comment naming the failure shape it replaces, plus the full pair inventory in docs/ordering-pairs-108.md (incl. examined near-misses with reasons).

Two commits: phase 1 (dcded50 — task-runner / spawn_step / verify-job) reviewed r1; phase 2 (ac640c8 — flush-intake assert after the PR #224 serial hold lifted, + adopted r1 fixes) reviewed as delta r2. Originally 0e2596e/6f6379a; rebased onto post-#229 main 2026-08-30, **range-diff 2/2 `=`** (byte-identical patches), full suite re-verified 43/43 green post-rebase.

## Done when — all PASS

| # | Done when | Result | Evidence |
|---|---|---|---|
| 1 | Enumerate ALL ordering pairs across the 5 files | **PASS** | docs/ordering-pairs-108.md: 5 phase-1 rows + positivity row + intake row (now asserted) + near-miss section; completeness grep-swept independently by 3 seats (r1) — no missed pair found |
| 2 | Fail-closed asserts (exit 2, named-pair) at all 4 entries | **PASS** | task-runner.sh:36-50 / spawn_step.sh:66-86 / verify-job.sh:629-637 / flush-intake.sh:256-261 (guarded-adapter entry). All 3 r1 seats + GLM r2 reproduced red cases through the REAL entry points in isolated workspaces (exit 2 + exact message + zero side effects: no tick.lock/artifacts/receipt/state-lock) |
| 3 | Failure-shape comment per assert | **PASS** | One comment line above each of the 6 asserts (verified by all seats; Kimi count: 3 spawn_step + 1 verify-job + 2 task-runner) |
| 4 | D21 literal → named constant, value unchanged | **PASS** | Constant promoted (value 2), both former literal sites converted, positivity self-checked. r1 F1 (Grok): the replaced literal is the TR-R3 persistent-failure counter, not DESIGN.md D21 → renamed TR_PERSISTENT_FAILURE_THRESHOLD in phase 2; `git grep TR_D21_` = empty |
| 5 | Red + happy test per assert via real entry | **PASS** | New cases in 4 test files; D21 red uses a sed-mutated COPY (constant is internal, not env). Suites: flush-intake 41/41, hermes-flush-intake 10/10, task-runner 119/119, spawn-step 20/20, verify-job 48/48; full `make test` 43/43 suites, `make lint` 89 files OK — run pre-rebase (orchestrator + GLM independent, bash 3.2) and **re-run post-rebase (43/43, 2026-08-30)** |

## Review (hetero 3-seat, writer-distinct)

- r1 (candidate 9de6481; content-identity across both rebases proven — GLM diff-of-diffs for the first, orchestrator range-diff 2/2 `=` for the second): **GLM 5.3 / Kimi K3 / Grok 4.6 = 3/3 GO-WITH-MINOR, zero CRITICAL/MAJOR**. Adjudication: [r1 record](https://github.com/caty-ai/caty-agent-harness/issues/108#issuecomment-5463551270) — 4 findings adopted (in phase 2), 1 refuted by cross-seat experiment, 1 informational.
- r2 delta: **3/3 CUMULATIVE GO** — [r2 record](https://github.com/caty-ai/caty-agent-harness/issues/108#issuecomment-5464045994). Kimi withdrew its remaining concern with its own supporting analysis.

## Completion record

- **Candidate SHA**: ac640c8 (= PR head after rebase; pre-rebase candidate 6f6379a, range-diff `=`)
- **Declared files vs diff**: 10 files, exact match — phase-1 set (7) + flush-intake pair (2, serial-after #224 as declared) + tests/hermes-flush-intake.test.sh (L0-2 [scope re-declaration](https://github.com/caty-ai/caty-agent-harness/issues/108#issuecomment-5463830255): inner-suite count literal 40→41). `git diff origin/main..HEAD --stat` = these 10 only
- **Identities**: writer = Codex GPT-5.6 Sol (phases 1+2); orchestrator + 1-line declared trivial edit = Alpha (Claude Fable 5, session 5da1d377); reviewers = GLM 5.3 / Kimi K3 / Grok 4.6 (requested = actual, all rounds)
- **CI**: pre-rebase run all green except pr-size (336 lines > 250 → owner size-exempt requested); post-rebase run pending at edit time; merge only on green
- **release**: v0.23.0 (annotated tag + GitHub Release via release-sync after merge — behavior-adding: new startup validation)
- **previous release**: **v0.22.6** (2026-08-29 — moved from v0.22.5 while this lane ran; re-measured at merge time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)