### PR TITLE
sentinel: per-model threshold injection point (#219)

### DIFF
--- a/adapters/claude-code/overflow_sentinel_monitor.py
+++ b/adapters/claude-code/overflow_sentinel_monitor.py
@@ -31,6 +31,7 @@ from lib_overflow_sentinel import (  # noqa: E402
     load_state,
     outcome_from_result,
     parse_model_aliases,
+    parse_model_thresholds,
     reset_regime_state,
     resolve_ctx_window,
     resolve_thresholds,
@@ -169,7 +170,10 @@ def _resolve_regime_config(
         hf_network=args.hf_network,
         hf_cache_dir=args.hf_cache_dir,
     )
-    t_abs, w, threshold_sources = resolve_thresholds(args.t_abs, args.w)
+    threshold_table, _, _ = args.model_thresholds
+    t_abs, w, threshold_sources = resolve_thresholds(
+        args.t_abs, args.w, model_identity, threshold_table
+    )
     floor_s = ttfb_floor_seconds(previous_injected_ma, model_identity)
     if os.environ.get("_CATY_TESTING") == "1" and os.environ.get("_CATY_OVF_TEST_TTFB_FLOOR_S"):
         floor_s = max(0, int(os.environ["_CATY_OVF_TEST_TTFB_FLOOR_S"]))
@@ -527,6 +531,11 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--t-abs", type=int)
     parser.add_argument("--w", type=float)
     parser.add_argument("--model-aliases", type=parse_model_aliases, default={})
+    parser.add_argument(
+        "--model-thresholds",
+        type=parse_model_thresholds,
+        default=parse_model_thresholds(None),
+    )
     parser.add_argument("--ctx-window", type=int)
     parser.add_argument("--hf-config")
     parser.add_argument("--hf-network", action="store_true")

--- a/adapters/claude-code/spawn_step.sh
+++ b/adapters/claude-code/spawn_step.sh
@@ -137,6 +137,12 @@ if [[ -n "$ovf_model_aliases" ]]; then
     || config_fail 'OVF_MODEL_ALIASES must be a JSON object mapping string aliases to strings'
 fi
 
+ovf_model_thresholds=${OVF_MODEL_THRESHOLDS:-}
+if [[ -n "$ovf_model_thresholds" ]]; then
+  python3 -B "$repo_root/scripts/lib_overflow_sentinel.py" validate-thresholds "$ovf_model_thresholds" >/dev/null \
+    || config_fail 'OVF_MODEL_THRESHOLDS must be a valid model-thresholds JSON object'
+fi
+
 ovf_hf_network=${OVF_HF_NETWORK:-}
 case "$ovf_hf_network" in
   ''|0|1) ;;
@@ -236,6 +242,7 @@ monitor_args=(
 [[ -z "$ovf_ctx_window" ]] || monitor_args+=(--ctx-window "$ovf_ctx_window")
 [[ -z "$ovf_hf_config" ]] || monitor_args+=(--hf-config "$ovf_hf_config")
 [[ -z "$ovf_model_aliases" ]] || monitor_args+=(--model-aliases "$ovf_model_aliases")
+[[ -z "$ovf_model_thresholds" ]] || monitor_args+=(--model-thresholds "$ovf_model_thresholds")
 if [[ "$ovf_hf_network" == 1 ]]; then
   monitor_args+=(--hf-network --hf-cache-dir "$ovf_hf_cache_dir")
 fi

--- a/scripts/lib_overflow_sentinel.py
+++ b/scripts/lib_overflow_sentinel.py
@@ -25,6 +25,9 @@ M = 10
 DEFAULT_T_ABS = 80000
 DEFAULT_W = 0.50
 DEFAULT_CTX_WINDOW = 200000
+# Placeholders pending calibration from the #218 drift-telemetry lane.
+DEFAULT_N_DRIFT = 5
+DEFAULT_THETA_DRIFT = 0.10
 HF_CACHE_SCHEMA_VERSION = 1
 HF_NETWORK_TIMEOUT_S = 5
 HF_NETWORK_MAX_BYTES = 1024 * 1024
@@ -78,6 +81,148 @@ def parse_model_aliases(raw: Optional[str]) -> Dict[str, str]:
     return aliases
 
 
+def parse_model_thresholds(
+    raw: Optional[str],
+) -> Tuple[Dict[str, Dict[str, Any]], int, float]:
+    """Parse the optional per-model threshold surface.
+
+    Model ids and glob patterns are canonicalized by trimming whitespace and
+    lowercasing, exactly like runtime model identities. Only ``*`` is treated
+    as glob syntax.
+    """
+    if raw is None or not str(raw).strip():
+        return {}, DEFAULT_N_DRIFT, DEFAULT_THETA_DRIFT
+
+    def reject_non_json_constant(value: str) -> None:
+        raise ValueError(f"non-standard JSON numeric constant: {value}")
+
+    try:
+        payload = json.loads(
+            raw,
+            object_pairs_hook=_JsonObjectPairs,
+            parse_constant=reject_non_json_constant,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("model thresholds must be valid JSON") from exc
+    if not isinstance(payload, _JsonObjectPairs):
+        raise ValueError("model thresholds must be a JSON object")
+
+    top_level: Dict[str, Any] = {}
+    allowed_top_level = {"models", "N_drift", "theta_drift"}
+    for key, value in payload:
+        if key in top_level:
+            raise ValueError(f"duplicate model-thresholds top-level key: {key}")
+        if key not in allowed_top_level:
+            raise ValueError(f"unknown model-thresholds top-level key: {key}")
+        top_level[key] = value
+
+    raw_models = top_level.get("models", _JsonObjectPairs())
+    if not isinstance(raw_models, _JsonObjectPairs):
+        raise ValueError("model thresholds models must be a JSON object")
+
+    table: Dict[str, Dict[str, Any]] = {}
+    raw_keys = set()
+    pattern_prefixes: Dict[str, str] = {}
+    for raw_key, raw_entry in raw_models:
+        normalized_key = raw_key.strip().lower()
+        is_pattern = "*" in normalized_key
+        if raw_key in raw_keys:
+            if is_pattern:
+                raise ValueError(f"duplicate model threshold pattern: {normalized_key}")
+            raise ValueError(f"duplicate JSON model threshold key: {raw_key}")
+        raw_keys.add(raw_key)
+        if not normalized_key:
+            raise ValueError("model threshold pattern must be non-empty")
+        if any(marker in normalized_key for marker in ("?", "[", "{")):
+            raise ValueError(
+                f"model threshold pattern contains unsupported glob syntax: {normalized_key}"
+            )
+        if normalized_key in table:
+            if is_pattern:
+                raise ValueError(f"duplicate model threshold pattern: {normalized_key}")
+            raise ValueError(
+                f"duplicate exact model threshold key after canonicalization: {normalized_key}"
+            )
+        if is_pattern:
+            literal_prefix = normalized_key.split("*", 1)[0]
+            previous_pattern = pattern_prefixes.get(literal_prefix)
+            if previous_pattern is not None:
+                raise ValueError(
+                    "same-specificity model threshold patterns share literal prefix "
+                    f"{literal_prefix!r}: {previous_pattern}, {normalized_key}"
+                )
+            pattern_prefixes[literal_prefix] = normalized_key
+        if not isinstance(raw_entry, _JsonObjectPairs):
+            raise ValueError(f"model threshold entry must be a JSON object: {normalized_key}")
+        if not raw_entry:
+            raise ValueError(
+                f"model threshold entry must contain T_abs or w: {normalized_key}"
+            )
+
+        entry: Dict[str, Any] = {}
+        for entry_key, value in raw_entry:
+            if entry_key in entry:
+                raise ValueError(
+                    f"duplicate model threshold entry key for {normalized_key}: {entry_key}"
+                )
+            if entry_key not in {"T_abs", "w"}:
+                raise ValueError(
+                    f"unknown model threshold entry key for {normalized_key}: {entry_key}"
+                )
+            if entry_key == "T_abs":
+                if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                    raise ValueError(
+                        f"model threshold T_abs must be an integer >= 1: {normalized_key}"
+                    )
+                entry[entry_key] = value
+            else:
+                if (
+                    not isinstance(value, (int, float))
+                    or isinstance(value, bool)
+                    or not 0 < value < 1
+                ):
+                    raise ValueError(
+                        f"model threshold w must be greater than 0 and less than 1: {normalized_key}"
+                    )
+                entry[entry_key] = float(value)
+        table[normalized_key] = entry
+
+    n_drift = top_level.get("N_drift", DEFAULT_N_DRIFT)
+    if not isinstance(n_drift, int) or isinstance(n_drift, bool) or n_drift < 1:
+        raise ValueError("model thresholds N_drift must be an integer >= 1")
+    theta_drift = top_level.get("theta_drift", DEFAULT_THETA_DRIFT)
+    if not isinstance(theta_drift, float) or theta_drift <= 0:
+        raise ValueError("model thresholds theta_drift must be a float greater than 0")
+    return table, n_drift, theta_drift
+
+
+def match_threshold_entry(
+    identity: Any, table: Optional[Mapping[str, Mapping[str, Any]]]
+) -> Optional[Mapping[str, Any]]:
+    """Return the exact or longest-literal-prefix threshold entry."""
+    normalized_identity = canonical_model(identity)
+    if normalized_identity is None or not table:
+        return None
+    exact = table.get(normalized_identity)
+    if exact is not None and "*" not in normalized_identity:
+        return exact
+
+    matches = []
+    for pattern, entry in table.items():
+        if "*" not in pattern:
+            continue
+        expression = "".join(".*" if char == "*" else re.escape(char) for char in pattern)
+        if re.fullmatch(expression, normalized_identity):
+            matches.append((len(pattern.split("*", 1)[0]), pattern, entry))
+    if not matches:
+        return None
+    longest = max(item[0] for item in matches)
+    winners = [item for item in matches if item[0] == longest]
+    if len(winners) != 1:
+        raise ValueError("same-specificity model threshold patterns matched at runtime")
+    return winners[0][2]
+
+
 def canonical_model(model: Any, aliases: Optional[Mapping[str, str]] = None) -> Optional[str]:
     """Return the lowercase/trimmed model identity with one alias lookup."""
     if not isinstance(model, str):
@@ -117,18 +262,36 @@ def reset_regime_state() -> Dict[str, Any]:
 
 
 def resolve_thresholds(
-    explicit_t_abs: Optional[int], explicit_w: Optional[float]
+    explicit_t_abs: Optional[int],
+    explicit_w: Optional[float],
+    model_identity: Any = None,
+    table: Optional[Mapping[str, Mapping[str, Any]]] = None,
 ) -> Tuple[int, float, Dict[str, str]]:
-    """Resolve product thresholds with per-key provenance."""
-    t_abs = DEFAULT_T_ABS if explicit_t_abs is None else explicit_t_abs
-    w = DEFAULT_W if explicit_w is None else explicit_w
+    """Resolve config, per-model, then product-default thresholds per key."""
+    entry = match_threshold_entry(model_identity, table)
+    table_t_abs = entry.get("T_abs") if entry is not None else None
+    table_w = entry.get("w") if entry is not None else None
+    t_abs = (
+        explicit_t_abs
+        if explicit_t_abs is not None
+        else table_t_abs if table_t_abs is not None else DEFAULT_T_ABS
+    )
+    w = explicit_w if explicit_w is not None else table_w if table_w is not None else DEFAULT_W
     if not isinstance(t_abs, int) or isinstance(t_abs, bool) or t_abs < 1:
         raise ValueError("T_abs must be an integer >= 1")
     if not isinstance(w, (int, float)) or isinstance(w, bool) or not 0 < w < 1:
         raise ValueError("w must be greater than 0 and less than 1")
     sources = {
-        "T_abs": "default" if explicit_t_abs is None else "config",
-        "w": "default" if explicit_w is None else "config",
+        "T_abs": (
+            "config"
+            if explicit_t_abs is not None
+            else "per-model" if table_t_abs is not None else "default"
+        ),
+        "w": (
+            "config"
+            if explicit_w is not None
+            else "per-model" if table_w is not None else "default"
+        ),
     }
     return t_abs, w, sources
 
@@ -314,7 +477,7 @@ def fire_axes(axis: Optional[str]) -> List[str]:
 def eligible_fire_axes(
     axis: Optional[str], ma_value: float, ctx_window: int, last_fire_ma: Mapping[str, float]
 ) -> List[str]:
-    """Apply task-scoped per-axis hysteresis; exact +10% re-arms (>=)."""
+    """Apply regime-scoped per-axis hysteresis; exact +10% re-arms (>=)."""
     eligible = []
     increment = 0.10 * ctx_window
     for candidate in fire_axes(axis):
@@ -587,6 +750,8 @@ def _main(argv: Optional[Sequence[str]] = None) -> int:
     validate_hf.add_argument("path")
     validate_aliases = sub.add_parser("validate-aliases")
     validate_aliases.add_argument("aliases")
+    validate_thresholds = sub.add_parser("validate-thresholds")
+    validate_thresholds.add_argument("thresholds")
     prepare_hf_cache = sub.add_parser("prepare-hf-cache")
     prepare_hf_cache.add_argument("path")
     args = parser.parse_args(argv)
@@ -604,6 +769,23 @@ def _main(argv: Optional[Sequence[str]] = None) -> int:
     if args.command == "validate-aliases":
         try:
             print(json.dumps(parse_model_aliases(args.aliases), sort_keys=True))
+        except ValueError as exc:
+            print(str(exc), file=os.sys.stderr)
+            return 2
+        return 0
+    if args.command == "validate-thresholds":
+        try:
+            table, n_drift, theta_drift = parse_model_thresholds(args.thresholds)
+            print(
+                json.dumps(
+                    {
+                        "models": table,
+                        "N_drift": n_drift,
+                        "theta_drift": theta_drift,
+                    },
+                    sort_keys=True,
+                )
+            )
         except ValueError as exc:
             print(str(exc), file=os.sys.stderr)
             return 2

--- a/tests/overflow-sentinel-tap.test.sh
+++ b/tests/overflow-sentinel-tap.test.sh
@@ -174,6 +174,44 @@ assert [(x["turn_idx"],x["slope"] is None) for x in fires]==[(6,True),(7,False)]
 assert end["regime_change_resets"]==1
 ' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
 
+case_root="$TMP_ROOT/regime-model-thresholds"
+make_attempt "$case_root"
+run_monitor_fixture_with_args regime-switch.jsonl "$case_root/artifact/attempts/001" shadow \
+  --model model-a \
+  --model-thresholds '{"models":{"model-a":{"T_abs":60000,"w":0.4},"model-b":{"T_abs":100000,"w":0.75}}}'
+assert_python "regime switch re-resolves two per-model threshold entries" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+fires=[x for x in events if x["event"]=="fire"]
+change=next(x for x in events if x["event"]=="regime_change")
+end=next(x for x in events if x["event"]=="attempt_end")
+source={"T_abs":"per-model","w":"per-model"}
+entry_a=next(x for x in fires if x["turn_idx"]==3)
+entry_b=next(x for x in fires if x["turn_idx"]==6)
+assert entry_a["run_meta"]["T_abs"]==60000 and entry_a["run_meta"]["w"]==0.4
+assert entry_a["run_meta"]["threshold_sources"]==source
+assert entry_b["run_meta"]["T_abs"]==100000 and entry_b["run_meta"]["w"]==0.75
+assert entry_b["run_meta"]["threshold_sources"]==source
+assert change["resolved"]["T_abs"]==100000 and change["resolved"]["w"]==0.75
+assert change["sources"]["threshold_sources"]==source
+assert end["run_meta"]["T_abs"]==100000 and end["run_meta"]["w"]==0.75
+assert end["run_meta"]["threshold_sources"]==source
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+
+case_root="$TMP_ROOT/explicit-over-model-threshold"
+make_attempt "$case_root"
+run_monitor_fixture_with_args fire.jsonl "$case_root/artifact/attempts/001" shadow \
+  --model claude-sonnet-4-5 --t-abs 85000 \
+  --model-thresholds '{"models":{"claude-sonnet-4-5":{"T_abs":70000,"w":0.4}}}'
+assert_python "explicit T_abs beats the table while w retains per-model provenance" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+fire=next(x for x in events if x["event"]=="fire")
+end=next(x for x in events if x["event"]=="attempt_end")
+expected={"T_abs":"config","w":"per-model"}
+assert fire["run_meta"]["T_abs"]==85000 and fire["run_meta"]["w"]==0.4
+assert fire["run_meta"]["threshold_sources"]==expected
+assert end["run_meta"]["threshold_sources"]==expected
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+
 case_root="$TMP_ROOT/alias-version-sway"
 make_attempt "$case_root"
 run_monitor_fixture_with_args alias-version-sway.jsonl "$case_root/artifact/attempts/001" shadow \
@@ -437,6 +475,22 @@ assert not [x for x in events if x["event"]=="regime_change"]
 assert next(x for x in events if x["event"]=="attempt_end")["regime_change_resets"]==0
 ' "$alias_adapter_root/artifact/attempts/001/sentinel-events.jsonl"
 
+threshold_adapter_root="$TMP_ROOT/threshold-adapter"
+make_attempt "$threshold_adapter_root"
+OVF_SENTINEL=shadow OVF_COMPACTION_OWNER=sentinel \
+CLAUDE_MODEL=claude-sonnet-4-5 \
+OVF_MODEL_THRESHOLDS='{"models":{"claude-sonnet-4-5":{"T_abs":70000,"w":0.4}}}' \
+OVF_STEP_CMD="$MOCK_CLI" MOCK_STREAM_FILE="$FIXTURES/fire.jsonl" \
+  "$ADAPTER" "$threshold_adapter_root/workspace/task.md" "$threshold_adapter_root/workspace" \
+  "$threshold_adapter_root/artifact/attempts/001" 1 \
+  >"$threshold_adapter_root/out" 2>"$threshold_adapter_root/err"
+assert_python "spawn-step validates and forwards OVF_MODEL_THRESHOLDS" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+fire=next(x for x in events if x["event"]=="fire")
+assert fire["run_meta"]["T_abs"]==70000 and fire["run_meta"]["w"]==0.4
+assert fire["run_meta"]["threshold_sources"]=={"T_abs":"per-model","w":"per-model"}
+' "$threshold_adapter_root/artifact/attempts/001/sentinel-events.jsonl"
+
 off_root="$TMP_ROOT/off"
 make_attempt "$off_root"
 off_attempt="$off_root/artifact/attempts/001"
@@ -488,6 +542,7 @@ OVF_W_PCT=x
 OVF_CTX_WINDOW=0
 OVF_CTX_WINDOW=x
 OVF_MODEL_ALIASES=[]
+OVF_MODEL_THRESHOLDS={
 OVF_COMPACTION_OWNER=bad
 OVF_FINALIZE_TIMEOUT_S=0
 OVF_FINALIZE_TIMEOUT_S=x

--- a/tests/overflow-sentinel.test.sh
+++ b/tests/overflow-sentinel.test.sh
@@ -121,6 +121,117 @@ else:
     raise AssertionError("non-integer T_abs accepted")
 '
 
+run_python_case "threshold resolution applies config then per-model then default per key" '
+table, _, _ = parse_model_thresholds(
+    "{\"models\":{\"model-a\":{\"T_abs\":70000,\"w\":0.4}}}"
+)
+assert resolve_thresholds(90000, None, "model-a", table) == (
+    90000, 0.4, {"T_abs": "config", "w": "per-model"}
+)
+assert resolve_thresholds(None, 0.7, "model-a", table) == (
+    70000, 0.7, {"T_abs": "per-model", "w": "config"}
+)
+'
+
+run_python_case "partial per-model T_abs falls through to default w with per-key attribution" '
+table, _, _ = parse_model_thresholds("{\"models\":{\"model-a\":{\"T_abs\":70000}}}")
+assert resolve_thresholds(None, None, " MODEL-A ", table) == (
+    70000, 0.50, {"T_abs": "per-model", "w": "default"}
+)
+'
+
+run_python_case "partial per-model w falls through to default T_abs with per-key attribution" '
+table, _, _ = parse_model_thresholds("{\"models\":{\"model-a\":{\"w\":0.25}}}")
+assert resolve_thresholds(None, None, "model-a", table) == (
+    80000, 0.25, {"T_abs": "default", "w": "per-model"}
+)
+'
+
+run_python_case "exact threshold key beats a matching glob" '
+table, _, _ = parse_model_thresholds(
+    "{\"models\":{\"claude-sonnet-4-5\":{\"T_abs\":91000},"
+    "\"claude-*\":{\"T_abs\":72000}}}"
+)
+assert match_threshold_entry("claude-sonnet-4-5", table)["T_abs"] == 91000
+assert match_threshold_entry("claude-opus-x", table)["T_abs"] == 72000
+'
+
+run_python_case "longest literal prefix selects the most specific matching glob" '
+table, _, _ = parse_model_thresholds(
+    "{\"models\":{\"claude-*\":{\"w\":0.3},"
+    "\"claude-sonnet-*\":{\"w\":0.4}}}"
+)
+assert match_threshold_entry("claude-sonnet-4-5", table)["w"] == 0.4
+'
+
+run_python_case "glob matching escapes regex metacharacters and no match uses defaults" '
+table, _, _ = parse_model_thresholds(
+    "{\"models\":{\"model.v1+*\":{\"T_abs\":1}}}"
+)
+assert match_threshold_entry("model.v1+x", table)["T_abs"] == 1
+assert match_threshold_entry("modelXv11x", table) is None
+assert resolve_thresholds(None, None, "unlisted", table) == (
+    80000, 0.50, {"T_abs": "default", "w": "default"}
+)
+'
+
+run_python_case "empty threshold surface exposes the placeholder drift defaults" '
+assert parse_model_thresholds(None) == ({}, DEFAULT_N_DRIFT, DEFAULT_THETA_DRIFT)
+assert parse_model_thresholds("") == ({}, 5, 0.10)
+assert parse_model_thresholds("{}") == ({}, 5, 0.10)
+table, n_drift, theta_drift = parse_model_thresholds(
+    "{\"N_drift\":7,\"theta_drift\":0.2}"
+)
+assert table == {} and n_drift == 7 and theta_drift == 0.2
+'
+
+run_python_case "threshold parser rejects every frozen invalid shape with a precise message" '
+cases = [
+    ("[]", "model thresholds must be a JSON object"),
+    ("{\"theta_drift\":NaN}", "model thresholds must be valid JSON"),
+    ("{\"theta_drift\":Infinity}", "model thresholds must be valid JSON"),
+    ("{\"theta_drift\":-Infinity}", "model thresholds must be valid JSON"),
+    ("{\"extra\":1}", "unknown model-thresholds top-level key: extra"),
+    ("{\"models\":{},\"models\":{}}", "duplicate model-thresholds top-level key"),
+    ("{\"models\":{\"m\":{\"extra\":1}}}", "unknown model threshold entry key"),
+    ("{\"models\":{\"m\":{\"T_abs\":0}}}", "T_abs must be an integer >= 1"),
+    ("{\"models\":{\"m\":{\"T_abs\":true}}}", "T_abs must be an integer >= 1"),
+    ("{\"models\":{\"m\":{\"T_abs\":1,\"T_abs\":2}}}",
+     "duplicate model threshold entry key"),
+    ("{\"models\":{\"m\":{\"w\":0}}}", "w must be greater than 0 and less than 1"),
+    ("{\"models\":{\"m\":{\"w\":1}}}", "w must be greater than 0 and less than 1"),
+    ("{\"models\":{\"m\":{\"w\":1.5}}}", "w must be greater than 0 and less than 1"),
+    ("{\"models\":{\"bad?\":{\"w\":0.5}}}", "unsupported glob syntax"),
+    ("{\"models\":{\"bad[\":{\"w\":0.5}}}", "unsupported glob syntax"),
+    ("{\"models\":{\"bad{\":{\"w\":0.5}}}", "unsupported glob syntax"),
+    ("{\"models\":{\"model-a\":{\"T_abs\":1},\"model-a\":{\"w\":0.5}}}",
+     "duplicate JSON model threshold key"),
+    ("{\"models\":{\" Model-A \":{\"T_abs\":1},\"model-a\":{\"w\":0.5}}}",
+     "duplicate exact model threshold key after canonicalization"),
+    ("{\"models\":{\"claude-*\":{\"T_abs\":1},\"claude-*\":{\"w\":0.5}}}",
+     "duplicate model threshold pattern"),
+    ("{\"models\":{\"claude-*a\":{\"T_abs\":1},\"claude-*b\":{\"w\":0.5}}}",
+     "same-specificity model threshold patterns share literal prefix"),
+    ("{\"models\":{\"\":{\"T_abs\":1}}}", "pattern must be non-empty"),
+    ("{\"models\":{\"m\":{}}}", "entry must contain T_abs or w"),
+    ("{\"models\":{\"m\":1}}", "entry must be a JSON object"),
+    ("{\"models\":[]}", "models must be a JSON object"),
+    ("{\"N_drift\":0}", "N_drift must be an integer >= 1"),
+    ("{\"N_drift\":true}", "N_drift must be an integer >= 1"),
+    ("{\"theta_drift\":0}", "theta_drift must be a float greater than 0"),
+    ("{\"theta_drift\":1}", "theta_drift must be a float greater than 0"),
+    ("{\"theta_drift\":true}", "theta_drift must be a float greater than 0"),
+    ("{\"theta_drift\":\"x\"}", "theta_drift must be a float greater than 0"),
+]
+for raw, expected in cases:
+    try:
+        parse_model_thresholds(raw)
+    except ValueError as exc:
+        assert expected in str(exc), (raw, str(exc))
+    else:
+        raise AssertionError("invalid threshold surface accepted: " + raw)
+'
+
 run_python_case "context-window ladder resolves all four sources offline" '
 import json
 from pathlib import Path
@@ -189,6 +300,31 @@ run_alias_cli_rejection() {
 run_alias_cli_rejection "validate-aliases rejects non-object JSON" '["model-a"]'
 run_alias_cli_rejection "validate-aliases rejects non-string values" '{"model-a":1}'
 run_alias_cli_rejection "validate-aliases rejects duplicate normalized keys" '{" Model-A ":"one","model-a":"two"}'
+
+set +e
+python3 -B "$ROOT/scripts/lib_overflow_sentinel.py" validate-thresholds \
+  '{"models":{"model-a":{"T_abs":70000}},"N_drift":5,"theta_drift":0.1}' \
+  >"$TMP_ROOT/thresholds.out" 2>"$TMP_ROOT/thresholds.err"
+thresholds_valid_rc=$?
+set -e
+if [[ "$thresholds_valid_rc" -eq 0 && ! -s "$TMP_ROOT/thresholds.err" ]]; then
+  pass "validate-thresholds accepts a valid threshold surface"
+else
+  fail_case "validate-thresholds accepts a valid threshold surface"
+fi
+
+set +e
+python3 -B "$ROOT/scripts/lib_overflow_sentinel.py" validate-thresholds \
+  '{"models":{"model-a":{"w":1}}}' \
+  >"$TMP_ROOT/thresholds.out" 2>"$TMP_ROOT/thresholds.err"
+thresholds_invalid_rc=$?
+set -e
+if [[ "$thresholds_invalid_rc" -eq 2 ]] \
+  && grep -Fq 'model threshold w must be greater than 0 and less than 1' "$TMP_ROOT/thresholds.err"; then
+  pass "validate-thresholds exits 2 with the validation message"
+else
+  fail_case "validate-thresholds exits 2 with the validation message"
+fi
 
 if (( failures )); then
   printf '%s overflow sentinel core test(s) failed; %s passed\n' "$failures" "$passes" >&2


### PR DESCRIPTION
Implements #219 — DESIGN v0.6.3 §5-1 (frozen, L1-9 5-seat PASS): the per-model threshold injection point. The table ships **empty**; P2 window-probe numbers later enter as pure config writeback (no code change, no re-review — owner decision 2026-08-29).

## Files touched (= WIP declaration on #219, verified against diff)

- `scripts/lib_overflow_sentinel.py` — `parse_model_thresholds` (load-time validation: unknown/duplicate/out-of-range/same-prefix-pattern rejection), `match_threshold_entry` (canonical exact > longest-literal-prefix glob, `*` only, runtime tie = fail-closed error), `resolve_thresholds` gains the per-model tier with per-key `config|per-model|default` provenance, `DEFAULT_N_DRIFT`/`DEFAULT_THETA_DRIFT` placeholders (consumed by #218, nothing reads them yet), new `validate-thresholds` subcommand, `eligible_fire_axes` docstring regime-scoped (folds in the #217 review INFO item)
- `adapters/claude-code/overflow_sentinel_monitor.py` — `--model-thresholds` arg; `_resolve_regime_config` passes identity+table (still exactly 2 call sites: task start + regime change)
- `adapters/claude-code/spawn_step.sh` — `OVF_MODEL_THRESHOLDS` knob, load-time `validate-thresholds` gate (`config_fail`), conditional forward
- `tests/overflow-sentinel.test.sh` — 21 → **31** cases (3-tier per-key resolution, partial attribution, exact-vs-pattern, specificity, load-time rejection battery, subcommand exit codes, empty-table defaults)
- `tests/overflow-sentinel-tap.test.sh` — 74 → **78** cases (regime switch re-resolves two table entries with per-model provenance in `regime_change`; explicit T_abs beats table while w stays per-model; spawn_step validation + forwarding)
- `tests/fixtures/overflow-sentinel/` — (reuses `regime-switch.jsonl` from #217; no new fixture files needed)

## Review

Heterogeneous 3-seat blind panel (GLM-5.3 / Kimi-K3 / Grok-4.6; writer = Codex GPT-5.6 Sol; loom-seats size M, quorum GO) — record will be posted to #219 and the L1-7 completion record added here before merge.

Size note: diff +397/-8 exceeds the 250-line pr-size budget (validation battery + tests); size-exempt to be requested per precedent (#220/#223/#224/#232).
## L1-7 completion record (#219 → PR #234)

**Candidate SHA**: `12119cf` (= PR head; single implementation commit, reviewed as-is by all 3 seats)

### Done when → verdicts (evidence inline, 2026-08-30)

1. **Config surface: per-model threshold table + N_drift/θ_drift keys (same file/section)** — **PASS**
   Evidence: `OVF_MODEL_THRESHOLDS` inline-JSON env on the spawn_step surface (`{"models": {...}, "N_drift", "theta_drift"}`), validated at load time via the new `validate-thresholds` subcommand (`config_fail` on rejection), forwarded as `--model-thresholds`. Placeholder defaults `DEFAULT_N_DRIFT=5` / `DEFAULT_THETA_DRIFT=0.10` exposed for #218; nothing consumes them yet. Tap case "spawn-step validates and forwards OVF_MODEL_THRESHOLDS" green.
2. **Resolver with frozen order + load-time validation** — **PASS**
   Evidence: `resolve_thresholds` = config explicit > per-model (partial, per-key fall-through) > product default; `match_threshold_entry` = canonical exact > longest-literal-prefix glob (`*` only), runtime specificity tie = fail-closed ValueError (belt-and-braces; load-time same-prefix rejection makes it unreachable). Load-time rejection battery: unknown top-level/entry keys, JSON + canonicalization duplicates, identical patterns, same-prefix pattern pairs, T_abs/w/N_drift/theta_drift range violations, `?`/`[`/`{` glob syntax — all ValueError, each tested. Core suite 21 → **31** green.
3. **Per-key threshold_sources in fire + task_end run_meta; wired into regime_change** — **PASS**
   Evidence: `_run_meta` stamps `threshold_sources` into fire + attempt_end run_meta; `regime_change.sources.threshold_sources` reports `per-model` when the table serves a key; `_resolve_regime_config` remains the only resolver call path (task start + regime change — grep-verified by 2 seats).
4. **§9-1 tests green (3-tier / partial attribution / rejections / mid-task table-entry switch)** — **PASS**
   Evidence: tap suite 74 → **78** green incl. "regime switch re-resolves two per-model threshold entries" (reuses the #217 `regime-switch.jsonl` fixture; asserts resolved T_abs/w flip between entry-a and entry-b with per-model provenance) and "explicit T_abs beats the table while w retains per-model provenance"; core partial-attribution case asserts `{T_abs: per-model, w: default}`.
5. **Ships with the table empty** — **PASS**
   Evidence: parser default = `({}, 5, 0.10)`; grep by 2 seats found per-model values only inside test inputs; no config data files committed.

### Gate items

- **Mutation evidence**: neutering the per-model tier turns **6 core + 3 tap** tests red; restore → 31/78 green (orchestrator, post-commit, no parallel sweeps).
- **File set vs diff**: `git diff --name-only 12119cf^..12119cf` = exactly the 5 declared files (fixtures dir declared but unused — existing fixture reused; narrower than declared is conformant). No `__pycache__`/pyc anywhere (verified by seats and orchestrator).
- **Identities**: writer = Codex GPT-5.6 Sol; seats GLM-5.3 / Kimi-K3 / Grok-4.6 (requested = actual); orchestrator Alpha (claude-fable-5), not a seat; writer ≠ seats, seats pairwise heterogeneous.
- **Review verdicts**: r1 **GO / GO / GO** on `12119cf` (zero blocking; MINOR adjudication in the record). Record: https://github.com/caty-ai/caty-agent-harness/issues/219#issuecomment-5466808114
- **Local full sweep**: `make test` at `12119cf` → `Suite Summary: 43 PASS, 0 FAIL` (2026-08-30, exit 0).
- **CI**: at record time: gitleaks / history-check / repo-state / risk-review-gate / lint = pass; test-lint test + test-macos = running; pr-size = fail pending the owner-only `size-exempt` label (+397/-8 over the 250 budget; precedent #220/#223/#224/#232). Merge proceeds only on full green (T-4).
- **Tests added**: +10 core / +4 tap (T-3).
- **release**: `v0.23.2` (ship-relevant: resolver behavior + config surface + event provenance values).
- **previous release**: `v0.23.1` — fulfilled (tag + Release verified: https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.23.1).
