### PR TITLE
sentinel: tap_drift — third instrument state with cadenced reconciliation (#218)

### DIFF
--- a/adapters/claude-code/overflow_sentinel_monitor.py
+++ b/adapters/claude-code/overflow_sentinel_monitor.py
@@ -27,19 +27,24 @@ from lib_overflow_sentinel import (  # noqa: E402
     compaction_suspected,
     compare_regime_identity,
     eligible_fire_axes,
+    evaluate_drift_turn,
     evaluate_series,
     load_state,
+    new_drift_accumulator,
     outcome_from_result,
     parse_model_aliases,
     parse_model_thresholds,
     reset_regime_state,
+    raw_usage_signature,
     resolve_ctx_window,
     resolve_thresholds,
     save_state,
     ttfb_floor_seconds,
+    weakest_drift_reference,
 )
 
 
+DRIFT_REFERENCE = "derived"
 ATTEMPT_FIELDS = {
     "schema_version",
     "task_id",
@@ -55,6 +60,25 @@ ATTEMPT_FIELDS = {
     "fired",
     "events_path",
 }
+
+
+def _drift_reference_for_model(model_identity: str) -> str:
+    """Return this adapter's capability, with a test-only regime override."""
+    if os.environ.get("_CATY_TESTING") != "1":
+        return DRIFT_REFERENCE
+    raw = os.environ.get("_CATY_OVF_TEST_DRIFT_REFERENCES")
+    if not raw:
+        return DRIFT_REFERENCE
+    try:
+        overrides = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("test drift references must be valid JSON") from exc
+    if not isinstance(overrides, dict):
+        raise ValueError("test drift references must be a JSON object")
+    value = overrides.get(model_identity, overrides.get("*", DRIFT_REFERENCE))
+    if value not in {"independent", "derived", "none"}:
+        raise ValueError("test drift reference must be independent, derived, or none")
+    return value
 
 
 def now_utc() -> str:
@@ -79,18 +103,6 @@ def _read_complete_lines(path: Path, offset: int, pending: bytes) -> Tuple[List[
     parts = data.split(b"\n")
     pending = parts.pop()
     return [part.decode("utf-8", errors="replace") for part in parts if part], offset, pending
-
-
-def _usage_from_assistant(event: Dict[str, Any]) -> Optional[Tuple[Dict[str, Any], Dict[str, Any]]]:
-    if event.get("type") != "assistant":
-        return None
-    message = event.get("message")
-    if not isinstance(message, dict):
-        return None
-    usage = message.get("usage")
-    if not isinstance(usage, dict) or usage.get("input_tokens") is None:
-        return None
-    return message, usage
 
 
 def _usage_int(value: Any) -> Optional[int]:
@@ -212,6 +224,7 @@ def monitor(args: argparse.Namespace) -> int:
         args, startup_model_identity, last_run_injected_ma
     )
     meta = _run_meta(args.mode, t_abs, w, threshold_sources)
+    _, n_drift, theta_drift = args.model_thresholds
 
     offset = 0
     pending = b""
@@ -227,7 +240,11 @@ def monitor(args: argparse.Namespace) -> int:
     runtime_compaction_seen = False
     runtime_compaction_pending = False
     regime_change_resets = 0
+    tap_drift_count = 0
     previous_identity: Optional[Dict[str, str]] = persisted_identity
+    current_drift_reference = _drift_reference_for_model(startup_model_identity)
+    drift_references = [current_drift_reference] if persisted_identity is not None else []
+    drift_accumulator = new_drift_accumulator()
     last_injected = None
     turn_count = 0
     blind_seen = False
@@ -262,35 +279,60 @@ def monitor(args: argparse.Namespace) -> int:
                 continue
             if first_byte_at is None:
                 first_byte_at = str(event.get("timestamp") or now_utc())
-            parsed = _usage_from_assistant(event)
-            if parsed is None or args.tap_status == "disabled-host":
+            message = event.get("message")
+            if not isinstance(message, dict) or args.tap_status == "disabled-host":
                 continue
-            message, usage = parsed
             identity = message.get("id")
             if isinstance(identity, str) and identity:
                 if identity in seen_ids:
                     continue
                 seen_ids.add(identity)
-            saw_usage = True
-            has_cache = "cache_read_input_tokens" in usage and "cache_creation_input_tokens" in usage
-            input_tokens = _usage_int(usage.get("input_tokens"))
-            cache_read = _usage_int(usage.get("cache_read_input_tokens", 0))
-            cache_creation = _usage_int(usage.get("cache_creation_input_tokens", 0))
-            output_tokens = _usage_int(usage.get("output_tokens", 0))
-            if None in (input_tokens, cache_read, cache_creation, output_tokens):
-                saw_no_cache = True
-                continue
-            injected = input_tokens + cache_read + cache_creation
-            blind = has_cache and injected == 0 and output_tokens == 0
+            usage_value = message.get("usage")
+            usage = usage_value if isinstance(usage_value, dict) else None
+            if usage is not None and usage.get("input_tokens") is not None:
+                saw_usage = True
+            has_cache = usage is not None and (
+                "cache_read_input_tokens" in usage
+                and "cache_creation_input_tokens" in usage
+            )
+            input_tokens = (
+                _usage_int(usage.get("input_tokens"))
+                if usage is not None and usage.get("input_tokens") is not None
+                else None
+            )
+            cache_read = (
+                _usage_int(usage.get("cache_read_input_tokens", 0))
+                if usage is not None
+                else None
+            )
+            cache_creation = (
+                _usage_int(usage.get("cache_creation_input_tokens", 0))
+                if usage is not None
+                else None
+            )
+            output_tokens = (
+                _usage_int(usage.get("output_tokens", 0)) if usage is not None else None
+            )
+            normalized = None not in (input_tokens, cache_read, cache_creation, output_tokens)
+            injected = (
+                int(input_tokens) + int(cache_read) + int(cache_creation) if normalized else None
+            )
+            blind = bool(
+                normalized and has_cache and injected == 0 and output_tokens == 0
+            )
             if blind:
                 turn_tap_status = "blind"
                 blind_seen = True
                 consecutive_blind += 1
-            else:
+            elif normalized:
                 turn_tap_status = "ok" if has_cache else "no-cache-accounting"
                 consecutive_blind = 0
                 if not has_cache:
                     saw_no_cache = True
+            else:
+                turn_tap_status = "absent" if usage is None else "no-cache-accounting"
+                consecutive_blind = 0
+                saw_no_cache = saw_no_cache or usage is not None
             turn_count += 1
             raw_model = message.get("model") if "model" in message else None
             regime_changed, current_identity = compare_regime_identity(
@@ -303,8 +345,7 @@ def monitor(args: argparse.Namespace) -> int:
                 series = cleared["series"]
                 last_injected = cleared["last_injected"]
                 last_fire_ma = cleared["last_fire_ma"]
-                # drift_accumulator and cadence_counter are intentionally unused until #218.
-                _ = (cleared["drift_accumulator"], cleared["cadence_counter"])
+                drift_accumulator = new_drift_accumulator()
                 _withdraw_pending(pending_path)
                 last_run_injected_ma = None
                 save_state(state_path, last_fire_ma, None, current_identity)
@@ -313,6 +354,11 @@ def monitor(args: argparse.Namespace) -> int:
                 )
                 meta = _run_meta(args.mode, t_abs, w, threshold_sources)
                 regime_change_resets += 1
+                old_drift_reference = current_drift_reference
+                current_drift_reference = _drift_reference_for_model(
+                    current_identity["model"]
+                )
+                drift_references.append(current_drift_reference)
                 append_event(
                     events_path,
                     {
@@ -336,7 +382,10 @@ def monitor(args: argparse.Namespace) -> int:
                             "ctx_window_source": ctx_source,
                             "threshold_sources": dict(threshold_sources),
                         },
-                        "drift_reference": {"from": "none", "to": "none"},
+                        "drift_reference": {
+                            "from": old_drift_reference,
+                            "to": current_drift_reference,
+                        },
                     },
                 )
                 runtime_compaction_pending = False
@@ -345,10 +394,13 @@ def monitor(args: argparse.Namespace) -> int:
                 last_injected = None
                 runtime_compaction_pending = False
             if identity_established:
+                current_drift_reference = _drift_reference_for_model(
+                    current_identity["model"]
+                )
+                drift_references.append(current_drift_reference)
                 save_state(state_path, last_fire_ma, last_run_injected_ma, current_identity)
             previous_identity = current_identity
             model = str(raw_model or model)
-            total_tokens += injected + output_tokens
             turn_event = {
                 "event": "turn",
                 "schema_version": SCHEMA_VERSION,
@@ -364,7 +416,23 @@ def monitor(args: argparse.Namespace) -> int:
                 "runtime": "claude-code",
                 "tap_status": turn_tap_status,
             }
+            if current_drift_reference != "none":
+                turn_event["raw_usage"] = usage
+                turn_event["raw_usage_schema"] = raw_usage_signature(usage)
             append_event(events_path, turn_event)
+            drift_events = evaluate_drift_turn(
+                drift_accumulator,
+                turn_event,
+                current_drift_reference,
+                n_drift,
+                theta_drift,
+            )
+            for drift_event in drift_events:
+                append_event(events_path, drift_event)
+            tap_drift_count += len(drift_events)
+            if not normalized:
+                continue
+            total_tokens += int(injected) + int(output_tokens)
             if blind:
                 if consecutive_blind >= 3:
                     evaluation_disabled = True
@@ -472,6 +540,9 @@ def monitor(args: argparse.Namespace) -> int:
         final_disposition = "shadow" if args.mode == "shadow" else "suppressed"
     else:
         final_disposition = "none"
+    drift_reference_status = weakest_drift_reference(
+        drift_references or [current_drift_reference]
+    )
     attempt_end = {
         "event": "attempt_end",
         "schema_version": SCHEMA_VERSION,
@@ -484,6 +555,8 @@ def monitor(args: argparse.Namespace) -> int:
         "runtime_compaction": runtime_compaction_seen,
         "compaction_suspected": compaction_seen,
         "regime_change_resets": regime_change_resets,
+        "tap_drift_count": tap_drift_count,
+        "drift_reference_status": drift_reference_status,
         "total_tokens": total_tokens,
         "injected_summary": {
             "max": max(series) if series else 0,

--- a/adapters/claude-code/overflow_sentinel_monitor.py
+++ b/adapters/claude-code/overflow_sentinel_monitor.py
@@ -331,7 +331,6 @@ def monitor(args: argparse.Namespace) -> int:
                     saw_no_cache = True
             else:
                 turn_tap_status = "absent" if usage is None else "no-cache-accounting"
-                consecutive_blind = 0
                 saw_no_cache = saw_no_cache or usage is not None
             turn_count += 1
             raw_model = message.get("model") if "model" in message else None

--- a/scripts/lib_overflow_sentinel.py
+++ b/scripts/lib_overflow_sentinel.py
@@ -28,6 +28,7 @@ DEFAULT_CTX_WINDOW = 200000
 # Placeholders pending calibration from the #218 drift-telemetry lane.
 DEFAULT_N_DRIFT = 5
 DEFAULT_THETA_DRIFT = 0.10
+DRIFT_REFERENCE_RANK = {"none": 0, "derived": 1, "independent": 2}
 HF_CACHE_SCHEMA_VERSION = 1
 HF_NETWORK_TIMEOUT_S = 5
 HF_NETWORK_MAX_BYTES = 1024 * 1024
@@ -259,6 +260,187 @@ def reset_regime_state() -> Dict[str, Any]:
         "drift_accumulator": None,
         "cadence_counter": 0,
     }
+
+
+def new_drift_accumulator() -> Dict[str, Any]:
+    """Return the empty core state for one model/runtime regime epoch."""
+    return {
+        "reported_cum_tokens": 0,
+        "reference_cum_tokens": 0,
+        "cadence_counter": 0,
+        "bias_active": False,
+        "schema_signature": None,
+    }
+
+
+def weakest_drift_reference(values: Sequence[str]) -> str:
+    """Return the weakest declared capability using none < derived < independent."""
+    valid = [value for value in values if value in DRIFT_REFERENCE_RANK]
+    if not valid:
+        return "none"
+    return min(valid, key=lambda value: DRIFT_REFERENCE_RANK[value])
+
+
+def raw_usage_signature(raw_usage: Any) -> Optional[List[str]]:
+    """Return the sorted field-set signature for a raw usage object."""
+    if not isinstance(raw_usage, dict):
+        return None
+    return sorted(str(key) for key in raw_usage)
+
+
+def _usage_token(value: Any) -> Optional[int]:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        token_count = int(value or 0)
+    except (TypeError, ValueError):
+        return None
+    return max(0, token_count)
+
+
+def normalize_raw_usage(raw_usage: Any, runtime: Any) -> Optional[int]:
+    """Replay the runtime normalization rule over a ledger-held raw usage object."""
+    if runtime != "claude-code" or not isinstance(raw_usage, dict):
+        return None
+    if raw_usage.get("input_tokens") is None:
+        return None
+    parts = (
+        _usage_token(raw_usage.get("input_tokens")),
+        _usage_token(raw_usage.get("cache_read_input_tokens", 0)),
+        _usage_token(raw_usage.get("cache_creation_input_tokens", 0)),
+    )
+    if any(part is None for part in parts):
+        return None
+    return sum(int(part) for part in parts if part is not None)
+
+
+def _reported_injected_tokens(turn: Mapping[str, Any]) -> Optional[int]:
+    parts = tuple(
+        _usage_token(turn.get(field))
+        for field in ("input_tokens", "cache_read_tokens", "cache_creation_tokens")
+    )
+    if any(part is None for part in parts):
+        return None
+    return sum(int(part) for part in parts if part is not None)
+
+
+def _drift_event(
+    turn: Mapping[str, Any],
+    accumulator: Mapping[str, Any],
+    drift_kind: str,
+    drift_reference: str,
+    n_drift: int,
+    theta_drift: float,
+) -> Dict[str, Any]:
+    reported = int(accumulator["reported_cum_tokens"])
+    reference = int(accumulator["reference_cum_tokens"])
+    signed_bias = reported - reference
+    event = {
+        "event": "tap_drift",
+        "schema_version": turn.get("schema_version", SCHEMA_VERSION),
+        "ts": turn.get("ts"),
+        "task_id": turn.get("task_id"),
+        "turn_idx": turn.get("turn_idx"),
+        "drift_kind": drift_kind,
+        "drift_reference": drift_reference,
+        "reported_cum_tokens": reported,
+        "reference_cum_tokens": reference,
+        "signed_bias": signed_bias,
+        "bias_ratio": signed_bias / float(max(reference, 1)),
+        "threshold": theta_drift,
+        "cadence_turns": n_drift,
+        "model": turn.get("model"),
+        "runtime": turn.get("runtime"),
+    }
+    if "attempt" in turn:
+        event["attempt"] = turn.get("attempt")
+    return event
+
+
+def evaluate_drift_turn(
+    accumulator: Dict[str, Any],
+    turn: Mapping[str, Any],
+    drift_reference: str,
+    n_drift: int,
+    theta_drift: float,
+) -> List[Dict[str, Any]]:
+    """Evaluate one ledger turn and mutate the regime-scoped drift state.
+
+    Missing observations advance cadence but are excluded from both cumulative
+    sums. Derived references are recomputed from ``raw_usage`` in core. Future
+    independent adapters may persist ``reference_injected_tokens`` on the turn.
+    """
+    if drift_reference not in DRIFT_REFERENCE_RANK:
+        raise ValueError(f"unknown drift reference capability: {drift_reference}")
+    if not isinstance(n_drift, int) or isinstance(n_drift, bool) or n_drift < 1:
+        raise ValueError("N_drift must be an integer >= 1")
+    if not isinstance(theta_drift, (int, float)) or isinstance(theta_drift, bool):
+        raise ValueError("theta_drift must be numeric")
+
+    accumulator["cadence_counter"] = int(accumulator.get("cadence_counter", 0)) + 1
+    if drift_reference == "none":
+        return []
+
+    events: List[Dict[str, Any]] = []
+    raw_usage = turn.get("raw_usage")
+    signature = raw_usage_signature(raw_usage)
+    previous_signature = accumulator.get("schema_signature")
+    schema_changed = (
+        signature is not None
+        and previous_signature is not None
+        and signature != previous_signature
+    )
+    if signature is not None:
+        accumulator["schema_signature"] = signature
+
+    reported = _reported_injected_tokens(turn)
+    if drift_reference == "derived":
+        reference = normalize_raw_usage(raw_usage, turn.get("runtime"))
+    else:
+        reference = _usage_token(turn.get("reference_injected_tokens"))
+    observation_exists = reported is not None and reference is not None
+    if observation_exists:
+        accumulator["reported_cum_tokens"] = int(
+            accumulator.get("reported_cum_tokens", 0)
+        ) + int(reported)
+        accumulator["reference_cum_tokens"] = int(
+            accumulator.get("reference_cum_tokens", 0)
+        ) + int(reference)
+
+    if schema_changed:
+        events.append(
+            _drift_event(
+                turn,
+                accumulator,
+                "schema-change",
+                drift_reference,
+                n_drift,
+                float(theta_drift),
+            )
+        )
+
+    cadence = int(accumulator["cadence_counter"])
+    if cadence % n_drift != 0 or not observation_exists:
+        return events
+
+    reported_cum = int(accumulator["reported_cum_tokens"])
+    reference_cum = int(accumulator["reference_cum_tokens"])
+    bias_ratio = (reported_cum - reference_cum) / float(max(reference_cum, 1))
+    in_drift = abs(bias_ratio) > float(theta_drift)
+    was_in_drift = bool(accumulator.get("bias_active"))
+    if in_drift and not was_in_drift:
+        events.append(
+            _drift_event(
+                turn,
+                accumulator,
+                "bias",
+                drift_reference,
+                n_drift,
+                float(theta_drift),
+            )
+        )
+    accumulator["bias_active"] = in_drift
+    return events
 
 
 def resolve_thresholds(

--- a/scripts/task-runner.sh
+++ b/scripts/task-runner.sh
@@ -910,6 +910,21 @@ def reducer(status, terminal_reason, emitted_at, vector):
         sourced = [end.get(field) for _, end in ends if field in end]
         return any(bool(value) for value in sourced) if sourced else None
 
+    def reduced_sum(field):
+        sourced = [
+            end.get(field) for _, end in ends
+            if isinstance(end.get(field), (int, float)) and not isinstance(end.get(field), bool)
+        ]
+        return sum(sourced) if sourced else None
+
+    def reduced_drift_reference():
+        rank = {"none": 0, "derived": 1, "independent": 2}
+        sourced = [
+            end.get("drift_reference_status") for _, end in ends
+            if end.get("drift_reference_status") in rank
+        ]
+        return min(sourced, key=lambda value: rank[value]) if sourced else None
+
     window_error = reduced_or("window_error")
     runtime_compaction = reduced_or("runtime_compaction")
     compaction_suspected = reduced_or("compaction_suspected")
@@ -957,6 +972,9 @@ def reducer(status, terminal_reason, emitted_at, vector):
         "window_error": window_error,
         "runtime_compaction": runtime_compaction,
         "compaction_suspected": compaction_suspected,
+        "tap_drift_count": reduced_sum("tap_drift_count"),
+        "regime_change_resets": reduced_sum("regime_change_resets"),
+        "drift_reference_status": reduced_drift_reference(),
         "total_tokens": total_tokens,
         "injected_summary": {"max": injected_max, "last3_mean": last3_mean},
         "fired_turns": fired_turns,

--- a/tests/fixtures/overflow-sentinel/blind-garbage-blind.jsonl
+++ b/tests/fixtures/overflow-sentinel/blind-garbage-blind.jsonl
@@ -1,0 +1,5 @@
+{"type":"assistant","message":{"id":"blind-mixed-1","model":"claude-sonnet-4-5","usage":{"input_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":0}}}
+{"type":"assistant","message":{"id":"blind-mixed-2","model":"claude-sonnet-4-5","usage":{"input_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":0}}}
+{"type":"assistant","message":{"id":"blind-mixed-unseen","model":"claude-sonnet-4-5","usage":{"input_tokens":1,"cache_read_input_tokens":"garbage","cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"assistant","message":{"id":"blind-mixed-3","model":"claude-sonnet-4-5","usage":{"input_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":0}}}
+{"type":"assistant","message":{"id":"blind-mixed-hot","model":"claude-sonnet-4-5","usage":{"input_tokens":90000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}

--- a/tests/fixtures/overflow-sentinel/drift-schema-regime.jsonl
+++ b/tests/fixtures/overflow-sentinel/drift-schema-regime.jsonl
@@ -1,0 +1,4 @@
+{"type":"assistant","timestamp":"2026-08-30T00:00:01Z","message":{"id":"drift-a-1","model":"model-a","usage":{"input_tokens":100,"cache_read_input_tokens":20,"cache_creation_input_tokens":10,"output_tokens":1}}}
+{"type":"assistant","timestamp":"2026-08-30T00:00:02Z","message":{"id":"drift-a-2","model":"model-a","usage":{"input_tokens":100,"cache_read_input_tokens":20,"cache_creation_input_tokens":10,"output_tokens":1,"provider_marker":"changed"}}}
+{"type":"assistant","timestamp":"2026-08-30T00:00:03Z","message":{"id":"drift-b-1","model":"model-b","usage":{"input_tokens":100,"cache_read_input_tokens":20,"cache_creation_input_tokens":10,"output_tokens":1,"other_marker":"new-regime"}}}
+{"type":"assistant","timestamp":"2026-08-30T00:00:04Z","message":{"id":"drift-b-2","model":"model-b","usage":{"input_tokens":100,"cache_read_input_tokens":20,"cache_creation_input_tokens":10,"output_tokens":1,"other_marker":"new-regime","new_epoch_change":true}}}

--- a/tests/overflow-sentinel-tap.test.sh
+++ b/tests/overflow-sentinel-tap.test.sh
@@ -433,6 +433,56 @@ assert not [x for x in events if x["event"]=="fire"]
 assert end["tap_status"]=="blind" and end["injected_summary"]=={"max":0,"last3_mean":0}
 ' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
 
+case_root="$TMP_ROOT/blind-garbage-blind"
+make_attempt "$case_root"
+run_monitor_fixture blind-garbage-blind.jsonl "$case_root/artifact/attempts/001"
+assert_python "unnormalizable usage preserves the blind streak and disables evaluation" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+turns=[x for x in events if x["event"]=="turn"]
+end=next(x for x in events if x["event"]=="attempt_end")
+receipt=json.loads(pathlib.Path(sys.argv[2]).read_text())
+assert [x["tap_status"] for x in turns]==[
+    "blind","blind","no-cache-accounting","blind","ok"
+]
+assert not [x for x in events if x["event"]=="fire"]
+assert end["fired_turns"]==[] and end["injected_summary"]=={"max":0,"last3_mean":0}
+assert receipt["fired"] is False
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl" \
+  "$case_root/artifact/attempts/001/attempt.json"
+
+case_root="$TMP_ROOT/blind-absent-blind"
+make_attempt "$case_root"
+python3 -B - "$FIXTURES/blind-garbage-blind.jsonl" \
+  "$case_root/artifact/attempts/001/stream.jsonl" <<'PY'
+import json
+import pathlib
+import sys
+events = [json.loads(line) for line in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+events[2]["message"].pop("usage")
+pathlib.Path(sys.argv[2]).write_text(
+    "".join(json.dumps(event, separators=(",", ":")) + "\n" for event in events)
+)
+PY
+printf '0\n' >"$case_root/artifact/attempts/001/overflow-stream.eof"
+python3 -B "$MONITOR" \
+  --stream "$case_root/artifact/attempts/001/stream.jsonl" \
+  --eof "$case_root/artifact/attempts/001/overflow-stream.eof" \
+  --attempt-dir "$case_root/artifact/attempts/001" \
+  --artifact-dir "$case_root/artifact" \
+  --task-id fixture-task --attempt 001 --mode shadow \
+  --model claude-sonnet-4-5 --t-abs 80000 --w 0.50
+assert_python "absent usage preserves the blind streak and disables evaluation" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+turns=[x for x in events if x["event"]=="turn"]
+end=next(x for x in events if x["event"]=="attempt_end")
+receipt=json.loads(pathlib.Path(sys.argv[2]).read_text())
+assert [x["tap_status"] for x in turns]==["blind","blind","absent","blind","ok"]
+assert not [x for x in events if x["event"]=="fire"]
+assert end["fired_turns"]==[] and end["injected_summary"]=={"max":0,"last3_mean":0}
+assert receipt["fired"] is False
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl" \
+  "$case_root/artifact/attempts/001/attempt.json"
+
 case_root="$TMP_ROOT/blind-short"
 make_attempt "$case_root"
 printf '%s\n' '{"last_fire_ma":{"level":91000.0},"last_run_injected_ma":87000.0,"schema_version":1}' \

--- a/tests/overflow-sentinel-tap.test.sh
+++ b/tests/overflow-sentinel-tap.test.sh
@@ -96,16 +96,22 @@ turns=[x for x in events if x["event"]=="turn"]
 assert len(turns)==2
 assert (turns[0]["input_tokens"],turns[0]["cache_read_tokens"],turns[0]["cache_creation_tokens"])==(100,20,10)
 assert turns[0]["input_tokens"]+turns[0]["cache_read_tokens"]+turns[0]["cache_creation_tokens"]==130
+assert turns[0]["raw_usage"]=={"input_tokens":100,"cache_read_input_tokens":20,"cache_creation_input_tokens":10,"output_tokens":5,"future_usage":999}
+assert turns[0]["raw_usage_schema"]==sorted(turns[0]["raw_usage"])
 assert turns[1]["tap_status"]=="no-cache-accounting"
 assert not [x for x in events if x["event"]=="fire"]
 ' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
 assert_python "unknown fields and init/keepalive noise do not create turns" '
 events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
 assert len([x for x in events if x["event"]=="turn"])==2
-assert {x["event"] for x in events}=={"turn","attempt_end"}
+assert {x["event"] for x in events}=={"turn","tap_drift","attempt_end"}
 assert all("task_end" not in x.values() for x in events)
 assert all(x["runtime"]=="claude-code" for x in events if x["event"]=="turn")
-assert next(x for x in events if x["event"]=="attempt_end")["regime_change_resets"]==0
+drift=next(x for x in events if x["event"]=="tap_drift")
+end=next(x for x in events if x["event"]=="attempt_end")
+assert drift["drift_kind"]=="schema-change" and drift["drift_reference"]=="derived"
+assert end["regime_change_resets"]==0 and end["tap_drift_count"]==1
+assert end["drift_reference_status"]=="derived" and end["fired_turns"]==[]
 ' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
 assert_python "attempt.json has the complete pinned field set and non-null first_byte_at" '
 p=json.loads(pathlib.Path(sys.argv[1]).read_text())
@@ -167,11 +173,57 @@ assert (change["from_model"],change["to_model"])==("model-a","model-b")
 assert (change["from_runtime"],change["to_runtime"])==("claude-code","claude-code")
 assert change["resolved"]=={"ctx_window":200000,"T_abs":100000,"w":0.9,"ttfb_floor":240}
 assert change["sources"]=={"ctx_window_source":"default","threshold_sources":{"T_abs":"config","w":"config"}}
-assert change["drift_reference"]=={"from":"none","to":"none"}
+assert change["drift_reference"]=={"from":"derived","to":"derived"}
 assert change["attempt"]=="001" and change["schema_version"]==1
 assert not [x for x in fires if x["turn_idx"]==4]
 assert [(x["turn_idx"],x["slope"] is None) for x in fires]==[(6,True),(7,False)]
 assert end["regime_change_resets"]==1
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
+
+case_root="$TMP_ROOT/drift-schema-regime"
+make_attempt "$case_root"
+run_monitor_fixture_with_args drift-schema-regime.jsonl "$case_root/artifact/attempts/001" shadow \
+  --model model-a --model-thresholds '{"N_drift":10,"theta_drift":0.1}'
+assert_python "schema signatures detect per-epoch episodes and reset accumulators at the regime boundary" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+turns=[x for x in events if x["event"]=="turn"]
+drifts=[x for x in events if x["event"]=="tap_drift"]
+change=next(x for x in events if x["event"]=="regime_change")
+end=next(x for x in events if x["event"]=="attempt_end")
+assert len(turns)==4 and all(isinstance(x["raw_usage"],dict) for x in turns)
+assert all(x["raw_usage_schema"]==sorted(x["raw_usage"]) for x in turns)
+assert [(x["turn_idx"],x["drift_kind"],x["drift_reference"]) for x in drifts]==[
+    (2,"schema-change","derived"),(4,"schema-change","derived")
+]
+drift_fields={"event","schema_version","ts","task_id","attempt","turn_idx","drift_kind",
+              "drift_reference","reported_cum_tokens","reference_cum_tokens","signed_bias",
+              "bias_ratio","threshold","cadence_turns","model","runtime"}
+assert all(set(x)==drift_fields for x in drifts)
+assert all(x["cadence_turns"]==10 and x["threshold"]==.1 for x in drifts)
+assert [(x["reported_cum_tokens"],x["reference_cum_tokens"]) for x in drifts]==[(260,260),(260,260)]
+assert change["turn_idx"]==3 and change["drift_reference"]=={"from":"derived","to":"derived"}
+assert end["tap_drift_count"]==2 and end["drift_reference_status"]=="derived"
+assert end["fired_turns"]==[] and not [x for x in events if x["event"]=="fire"]
+assert json.loads(pathlib.Path(sys.argv[2]).read_text())["fired"] is False
+' "$case_root/artifact/attempts/001/sentinel-events.jsonl" \
+  "$case_root/artifact/attempts/001/attempt.json"
+
+case_root="$TMP_ROOT/drift-capability-regimes"
+make_attempt "$case_root"
+_CATY_TESTING=1 \
+_CATY_OVF_TEST_DRIFT_REFERENCES='{"model-a":"independent","model-b":"none"}' \
+run_monitor_fixture_with_args drift-schema-regime.jsonl "$case_root/artifact/attempts/001" shadow \
+  --model model-a --model-thresholds '{"N_drift":10,"theta_drift":0.1}'
+assert_python "capability changes carry real values and attempt_end reports the weakest value" '
+events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
+drift=next(x for x in events if x["event"]=="tap_drift")
+change=next(x for x in events if x["event"]=="regime_change")
+end=next(x for x in events if x["event"]=="attempt_end")
+assert drift["drift_reference"]=="independent" and drift["drift_kind"]=="schema-change"
+assert change["drift_reference"]=={"from":"independent","to":"none"}
+assert end["drift_reference_status"]=="none" and end["tap_drift_count"]==1
+none_turns=[x for x in events if x["event"]=="turn" and x["model"]=="model-b"]
+assert all("raw_usage" not in x and "raw_usage_schema" not in x for x in none_turns)
 ' "$case_root/artifact/attempts/001/sentinel-events.jsonl"
 
 case_root="$TMP_ROOT/regime-model-thresholds"
@@ -351,8 +403,9 @@ assert_python "zero-injected and unparsable usage never corrupt the measured ser
 events=[json.loads(x) for x in pathlib.Path(sys.argv[1]).read_text().splitlines()]
 turns=[x for x in events if x["event"]=="turn"]
 end=next(x for x in events if x["event"]=="attempt_end")
-assert [x["input_tokens"] for x in turns]==[90000,0,90001]
-assert not any(x.get("cache_read_tokens")=="garbage" for x in turns)
+assert [x["input_tokens"] for x in turns]==[90000,0,1,90001]
+assert turns[2]["cache_read_tokens"] is None
+assert turns[2]["raw_usage"]["cache_read_input_tokens"]=="garbage"
 assert end["compaction_suspected"] is False
 assert end["injected_summary"]=={"max":90001,"last3_mean":90000.5}
 assert end["tap_status"]=="no-cache-accounting"
@@ -782,10 +835,10 @@ turn=next(x for x in fire_events if x["event"]=="turn")
 fire=next(x for x in fire_events if x["event"]=="fire")
 end=next(x for x in fire_events if x["event"]=="attempt_end")
 alert=next(x for x in alert_events if x["event"]=="alert")
-assert {"event","schema_version","ts","task_id","attempt","turn_idx","input_tokens","cache_read_tokens","cache_creation_tokens","output_tokens","model","runtime","tap_status"} <= set(turn)
+assert {"event","schema_version","ts","task_id","attempt","turn_idx","input_tokens","cache_read_tokens","cache_creation_tokens","output_tokens","model","runtime","tap_status","raw_usage","raw_usage_schema"} <= set(turn)
 assert {"event","schema_version","ts","started_at","task_id","attempt","turn_idx","axis","injected_ma","injected_last","value_kind","threshold_hit","ctx_window","ctx_window_source","slope","projection_turns","decision","nudge_disposition","model","runtime","tap_status","run_meta"} <= set(fire)
 assert {"event","schema_version","ts","task_id","attempt","turn_idx","ttfb_ms","floor_applied","model","runtime"} <= set(alert)
-assert {"event","schema_version","ts","started_at","task_id","attempt","outcome","window_error","runtime_compaction","compaction_suspected","regime_change_resets","total_tokens","injected_summary","fired_turns","alert_turns","nudge_disposition_final","tap_status","run_meta","elapsed_s"} <= set(end)
+assert {"event","schema_version","ts","started_at","task_id","attempt","outcome","window_error","runtime_compaction","compaction_suspected","regime_change_resets","tap_drift_count","drift_reference_status","total_tokens","injected_summary","fired_turns","alert_turns","nudge_disposition_final","tap_status","run_meta","elapsed_s"} <= set(end)
 assert end["outcome"] in {"step_completed","aborted","overflowed"}
 ' "$w_root/artifact/attempts/001/sentinel-events.jsonl" "$tier_root/artifact/attempts/001/sentinel-events.jsonl"
 

--- a/tests/overflow-sentinel.test.sh
+++ b/tests/overflow-sentinel.test.sh
@@ -107,6 +107,94 @@ run_python_case "regime reset clears predicate hysteresis and exposes the future
 cleared = reset_regime_state()
 assert cleared == {"series": [], "last_injected": None, "last_fire_ma": {},
                    "drift_accumulator": None, "cadence_counter": 0}
+state=new_drift_accumulator()
+turn={"input_tokens":120,"cache_read_tokens":0,"cache_creation_tokens":0,
+      "raw_usage":{"input_tokens":100},"runtime":"claude-code"}
+assert evaluate_drift_turn(state,turn,"derived",3,.1)==[]
+assert evaluate_drift_turn(state,turn,"derived",3,.1)==[]
+fresh=new_drift_accumulator()
+assert evaluate_drift_turn(fresh,turn,"derived",3,.1)==[]
+assert fresh["cadence_counter"]==1
+assert (fresh["reported_cum_tokens"],fresh["reference_cum_tokens"])==(120,100)
+'
+
+run_python_case "core reconciliation detects both bias directions and stamps reference capability" '
+def turn(reported, raw, idx=1, reference=None):
+    value={"schema_version":1,"ts":"2026-08-30T00:00:00Z","task_id":"t",
+           "attempt":"001","turn_idx":idx,"input_tokens":reported,
+           "cache_read_tokens":0,"cache_creation_tokens":0,"output_tokens":0,
+           "raw_usage":raw,"model":"m","runtime":"claude-code"}
+    if reference is not None: value["reference_injected_tokens"]=reference
+    return value
+high=evaluate_drift_turn(new_drift_accumulator(),turn(120,{"input_tokens":100}),"derived",1,.1)
+low=evaluate_drift_turn(new_drift_accumulator(),turn(80,{"input_tokens":100}),"derived",1,.1)
+independent=evaluate_drift_turn(
+    new_drift_accumulator(),turn(120,{"input_tokens":100},reference=100),"independent",1,.1
+)
+assert [(x[0]["signed_bias"],x[0]["drift_reference"]) for x in (high,low,independent)] == [
+    (20,"derived"),(-20,"derived"),(20,"independent")
+]
+assert all(x[0]["drift_kind"]=="bias" for x in (high,low,independent))
+'
+
+run_python_case "sub-threshold derived replay emits no drift and never claims independent PASS" '
+state=new_drift_accumulator()
+turn={"turn_idx":1,"input_tokens":105,"cache_read_tokens":0,"cache_creation_tokens":0,
+      "raw_usage":{"input_tokens":100},"runtime":"claude-code"}
+assert evaluate_drift_turn(state,turn,"derived",1,.1)==[]
+assert state["reported_cum_tokens"]==105 and state["reference_cum_tokens"]==100
+assert "independent" not in state and "verified" not in state
+'
+
+run_python_case "persistent bias is one episode and recovery re-arms a second episode" '
+state=new_drift_accumulator(); events=[]
+for idx,(reported,reference) in enumerate([(120,100),(120,100),(60,100),(120,100),(200,100)],1):
+    turn={"turn_idx":idx,"input_tokens":reported,"cache_read_tokens":0,
+          "cache_creation_tokens":0,"raw_usage":{"input_tokens":reference},
+          "runtime":"claude-code"}
+    events.extend(evaluate_drift_turn(state,turn,"derived",1,.1))
+assert [event["turn_idx"] for event in events if event["drift_kind"]=="bias"]==[1,5]
+'
+
+run_python_case "zero reference uses the denominator guard and returns a sane ratio" '
+state=new_drift_accumulator()
+turn={"turn_idx":1,"input_tokens":1,"cache_read_tokens":0,"cache_creation_tokens":0,
+      "raw_usage":{"input_tokens":0},"runtime":"claude-code"}
+event=evaluate_drift_turn(state,turn,"derived",1,.1)[0]
+assert event["reference_cum_tokens"]==0 and event["signed_bias"]==1
+assert event["bias_ratio"]==1.0
+'
+
+run_python_case "missing references advance cadence and are pairwise excluded from both sums" '
+state=new_drift_accumulator(); events=[]
+turns=[
+ {"input_tokens":120,"cache_read_tokens":0,"cache_creation_tokens":0,"raw_usage":{"input_tokens":100}},
+ {"input_tokens":None,"cache_read_tokens":None,"cache_creation_tokens":None,"raw_usage":None},
+ {"input_tokens":80,"cache_read_tokens":0,"cache_creation_tokens":0,"raw_usage":{"input_tokens":100}},
+ {"input_tokens":100,"cache_read_tokens":0,"cache_creation_tokens":0,"raw_usage":{"input_tokens":100}},
+]
+for idx,turn in enumerate(turns,1):
+    turn.update({"turn_idx":idx,"runtime":"claude-code"})
+    events.extend(evaluate_drift_turn(state,turn,"derived",2,.1))
+assert events==[] and state["cadence_counter"]==4
+assert state["reported_cum_tokens"]==300 and state["reference_cum_tokens"]==300
+'
+
+run_python_case "cache-inclusive replay shares one normalization basis and detects tampering" '
+raw={"input_tokens":100,"cache_read_input_tokens":20,"cache_creation_input_tokens":10}
+clean={"turn_idx":1,"input_tokens":100,"cache_read_tokens":20,"cache_creation_tokens":10,
+       "raw_usage":raw,"runtime":"claude-code"}
+assert evaluate_drift_turn(new_drift_accumulator(),clean,"derived",1,.1)==[]
+tampered=dict(clean); tampered["cache_read_tokens"]=0
+event=evaluate_drift_turn(new_drift_accumulator(),tampered,"derived",1,.1)[0]
+assert event["reported_cum_tokens"]==110 and event["reference_cum_tokens"]==130
+assert event["signed_bias"]==-20
+'
+
+run_python_case "weakest drift capability ordering is none then derived then independent" '
+assert weakest_drift_reference(["independent","derived"])=="derived"
+assert weakest_drift_reference(["independent","none","derived"])=="none"
+assert weakest_drift_reference(["independent"])=="independent"
 '
 
 run_python_case "threshold resolution preserves per-key explicit/default provenance" '

--- a/tests/overflow-sentinel.test.sh
+++ b/tests/overflow-sentinel.test.sh
@@ -156,6 +156,31 @@ for idx,(reported,reference) in enumerate([(120,100),(120,100),(60,100),(120,100
 assert [event["turn_idx"] for event in events if event["drift_kind"]=="bias"]==[1,5]
 '
 
+run_python_case "regime reset starts a fresh bias epoch without cumulative bleed" '
+def turn(idx, reported, reference):
+    return {"turn_idx":idx,"input_tokens":reported,"cache_read_tokens":0,
+            "cache_creation_tokens":0,"raw_usage":{"input_tokens":reference},
+            "runtime":"claude-code"}
+state=new_drift_accumulator(); events=[]
+for idx in range(1,5):
+    events.extend(evaluate_drift_turn(state,turn(idx,120,100),"derived",2,.1))
+assert [(event["turn_idx"],abs(event["bias_ratio"])>event["threshold"])
+        for event in events if event["drift_kind"]=="bias"]==[(2,True)]
+assert state["bias_active"] is True
+assert (state["reported_cum_tokens"],state["reference_cum_tokens"])==(480,400)
+state=new_drift_accumulator()
+assert state["bias_active"] is False
+assert (state["reported_cum_tokens"],state["reference_cum_tokens"])==(0,0)
+epoch_two=[]
+for idx in range(1,3):
+    epoch_two.extend(evaluate_drift_turn(state,turn(idx,105,100),"derived",2,.1))
+events.extend(epoch_two)
+assert epoch_two==[]
+assert len([event for event in events if event["drift_kind"]=="bias"])==1
+assert (state["reported_cum_tokens"],state["reference_cum_tokens"])==(210,200)
+assert state["bias_active"] is False
+'
+
 run_python_case "zero reference uses the denominator guard and returns a sane ratio" '
 state=new_drift_accumulator()
 turn={"turn_idx":1,"input_tokens":1,"cache_read_tokens":0,"cache_creation_tokens":0,

--- a/tests/task-runner.test.sh
+++ b/tests/task-runner.test.sh
@@ -3097,6 +3097,40 @@ case_ledger_fired_delivered_is_completed() {
   fi
 }
 
+case_ledger_drift_members_and_receipt_reduction() {
+  local name=ledger-drift-members-and-receipt-reduction ws artifact
+  ws=$(make_ws)
+  write_terminal_ledger_fixture "$ws" drift-fold delivered
+  artifact="$ws/loop/artifacts/drift-fold"
+  printf '%s\n' \
+    '{"event":"tap_drift","task_id":"drift-fold","attempt":"001","turn_idx":2,"drift_kind":"bias"}' \
+    '{"event":"regime_change","task_id":"drift-fold","attempt":"001","turn_idx":3,"drift_reference":{"from":"independent","to":"derived"}}' \
+    '{"event":"attempt_end","task_id":"drift-fold","attempt":"001","started_at":"2026-08-27T00:00:00Z","tap_drift_count":1,"regime_change_resets":2,"drift_reference_status":"independent","fired_turns":[],"alert_turns":[]}' \
+    >"$artifact/attempts/001/sentinel-events.jsonl"
+  mkdir -p "$artifact/attempts/002"
+  printf '%s\n' '{"started":"2026-08-27T00:00:02Z"}' >"$artifact/attempts/002/driver.json"
+  printf '%s\n' \
+    '{"event":"tap_drift","task_id":"drift-fold","attempt":"002","turn_idx":4,"drift_kind":"schema-change"}' \
+    '{"event":"attempt_end","task_id":"drift-fold","attempt":"002","started_at":"2026-08-27T00:00:02Z","tap_drift_count":2,"regime_change_resets":1,"drift_reference_status":"derived","fired_turns":[],"alert_turns":[]}' \
+    >"$artifact/attempts/002/sentinel-events.jsonl"
+  run_tick "$ws" >/dev/null
+  if [[ "$(ledger_event_count "$artifact/ledger.jsonl" tap_drift)" -eq 2 ]] \
+    && [[ "$(ledger_event_count "$artifact/ledger.jsonl" regime_change)" -eq 1 ]] \
+    && python3 - "$artifact/task-end.json" <<'PY'
+import json, sys
+r=json.load(open(sys.argv[1],encoding="utf-8"))
+assert r["tap_drift_count"]==3
+assert r["regime_change_resets"]==3
+assert r["drift_reference_status"]=="derived"
+assert r["fired_turns"]==[]
+PY
+  then
+    pass "$name"
+  else
+    fail "$name" "drift members were filtered or receipt fields reduced incorrectly"
+  fi
+}
+
 case_ledger_direct_dlq_reap_folds_once() {
   local name=ledger-direct-dlq-reap-folds-once ws artifact
   ws=$(make_ws)
@@ -3674,6 +3708,7 @@ case_empty_stderr_is_degenerate_and_retries
 case_metrics_idempotent
 case_ledger_terminal_pre_projection_reconcile
 case_ledger_fired_delivered_is_completed
+case_ledger_drift_members_and_receipt_reduction
 case_ledger_direct_dlq_reap_folds_once
 case_ledger_torn_tail_repair
 case_ledger_zero_attempt_dlq


### PR DESCRIPTION
Implements #218 — DESIGN v0.6.3 §3-1 (frozen, L1-9 5-seat PASS): tap_drift, the third instrument state ("the tap lied"), with cadenced core-side reconciliation over ledger-held values. **v1 is log-only** (owner decision): record, never fire/degrade/nudge.

External-review credit (spec, not courtesy): implements adoption #1 by **@pm25coder** (issue #159, review comment 2026-08-27). The commit carries the `Suggested-by:` trailer per the issue spec.

## Files touched (= WIP declaration on #218, verified against diff)

- `scripts/lib_overflow_sentinel.py` — §3-1 core: `new_drift_accumulator`, `raw_usage_signature`, `normalize_raw_usage` (§3 replay), `evaluate_drift_turn` (frozen predicate: cadence advance on every turn, R_e pairwise exclusion, paired cumulative sums, `signed_bias/max(reference_cum,1)`, direction-agnostic θ, episode edge-trigger + re-arm, schema-change as independent episodes), `weakest_drift_reference`
- `adapters/claude-code/overflow_sentinel_monitor.py` — capability constant `derived`; `raw_usage` + field-set signature persisted on turn events; drift evaluation driven off the ledger-form turn event (core computes, adapter never self-grades); `attempt_end` gains `tap_drift_count` + `drift_reference_status` (weakest across regimes); `regime_change.drift_reference` now carries real per-regime values; §4 reset clears the drift accumulator/cadence/signature; **turn-ingestion honesty**: non-normalizable-usage assistant turns are now ledger-visible (nulled normalized fields + preserved raw_usage) so the reference-missing case can be excluded pairwise — fire predicate consumes normalized turns only (unchanged); test-only `_CATY_OVF_TEST_DRIFT_REFERENCES` override (gated on `_CATY_TESTING=1`)
- `scripts/task-runner.sh` — #187 ledger-fold reducer surfacing only: task-end receipt gains `tap_drift_count` (sum), `regime_change_resets` (sum), `drift_reference_status` (weakest)
- `tests/task-runner.test.sh` — receipt pin extended with the three new fields + pass-through regression assertion
- `tests/overflow-sentinel.test.sh` — 31 → **38** (predicate units: both bias directions, sub-threshold, episode semantics, zero-reference denominator, R_e pairwise exclusion, capability validation, weakest-rule)
- `tests/overflow-sentinel-tap.test.sh` — 78 → **80** (schema-change episodes + regime-boundary signature reset; capability-change-across-regimes with task_end weakest + per-regime regime_change values); 2 existing pins updated for honest new behavior (documented in the L1-7 record)
- `tests/fixtures/overflow-sentinel/drift-schema-regime.jsonl` — new fixture

## Review

Heterogeneous 3-seat blind panel (GLM-5.3 / Kimi-K3 / Grok-4.6; writer = Codex GPT-5.6 Sol): r1 GWM/NO-GO/GWM converged on one finding (blind-streak reset), adopted and fixed in `58a691f`; delta cumulative **GO / GO-WITH-MINOR / GO**. Record: https://github.com/caty-ai/caty-agent-harness/issues/218#issuecomment-5467529888

Size note: diff +487/-38 exceeds the 250-line pr-size budget (§9-1-mandated fixture battery); size-exempt per precedent (#232/#234).

## L1-7 completion record (#218 → PR #236)

**Candidate SHA**: `58a691f` (= PR head). Lineage: r1 candidate `4d55797` + panel-adopted fix `58a691f` (1-line blind-streak preservation + pins; all 3 seats delta-reviewed the fix with cumulative verdicts).

### Done when → verdicts (evidence inline, 2026-08-30)

1. **Adapter capability declaration + raw_usage persistence (claude-code: derived)** — **PASS**
   Evidence: module constant `DRIFT_REFERENCE = "derived"`; turn events carry verbatim `raw_usage` + sorted field-set signature whenever capability ≠ none; Grok probe verified the stored object is byte-honest (includes unknown fields like `future_usage`, normalized ints kept separate). Suites: core 39 / tap 82 green (orchestrator + 3 seats independently).
2. **Core reconciliation per §3-1; tap_drift events per §6** — **PASS**
   Evidence: `evaluate_drift_turn` in core evaluates ledger-form turns (adapter never self-grades — the monitor passes the just-appended turn event); paired sums over R_e with pairwise exclusion (fixture-proven: gaps create no fake bias); `signed_bias/max(reference_cum,1)`; direction-agnostic θ; episode edge-trigger + re-arm (persistent drift = 1 episode; re-entry = 2 — pinned); schema-change flips recorded as independent episodes with epoch-scoped signatures; v1 log-only (family-separation test: tap_drift-only task reports fires=0, receipt fired=false).
3. **attempt_end tap_drift_count + drift_reference_status (weakest rule)** — **PASS**
   Evidence: `weakest_drift_reference` (none < derived < independent); capability-change-across-regimes fixture asserts task-level weakest + per-regime real values in `regime_change.drift_reference {from,to}` (replacing the #217 placeholders).
4. **tap_drift + regime_change in the #187 ledger-fold member types** — **PASS**
   Evidence: fold ingest is type-agnostic (measured; no change needed); the type-aware reducer now surfaces `tap_drift_count` (sum) / `regime_change_resets` (sum) / `drift_reference_status` (weakest) into the task-end receipt with a pass-through regression assertion; `tests/task-runner.test.sh` → `TOTAL pass=120 fail=0` (orchestrator run; GLM delta re-ran it green).
5. **§9-1 fixtures green** — **PASS**
   Evidence: both bias directions; sub-threshold no-event; episode semantics; zero-reference denominator; derived/independent stamping (independent only via the `_CATY_TESTING`-gated hook); no independent-PASS from same-provenance equality (asserted absence); cache-basis construction guard (clean replay = zero bias, tampered raw = detected); schema-change detection + regime-boundary signature reset; R_e intermittent-reference pairwise exclusion; capability-change-across-regimes; bias-through-regime-reset (1 episode epoch-1, clean epoch-2, no bleed — added in `58a691f`). Core 31→**39**, tap 78→**82**.
6. **Family-separation assertion (tap_drift without fire ⇒ fires=0)** — **PASS**
   Evidence: pinned in the tap suite; Grok's schema-flap probe confirmed `fired_turns=[]`, `attempt.json fired=false`, no nudge file.

### Gate items

- **Panel-adopted behavioral decisions (recorded in the review record)**: (a) turn-ingestion widening — non-normalizable turns are ledger-visible (required by the R_e contract in derived mode) — 3-seat unanimous ACCEPT with evidence tables; (b) blind-streak preservation on unseen turns — 3-seat convergent finding, fixed in `58a691f`, both variants pinned, mutation-verified.
- **Mutation evidence**: drift-check neuter → 7 core + 3 tap red (restore: green); streak-rule revert → the 3 new pins red (GLM delta).
- **File set vs diff**: `git diff --name-only origin/main...58a691f` = exactly the 7 declared paths (6 files + 2 new fixtures under the declared fixtures dir). No pyc (verified per lane discipline).
- **Identities**: writer = Codex GPT-5.6 Sol; seats GLM-5.3 / Kimi-K3 / Grok-4.6 (requested = actual); orchestrator Alpha (claude-fable-5), not a seat; writer ≠ seats, seats pairwise heterogeneous.
- **Review verdicts**: r1 GWM / NO-GO / GWM → delta cumulative **GO / GO-WITH-MINOR / GO**, blocking 0. Record: https://github.com/caty-ai/caty-agent-harness/issues/218#issuecomment-5467529888
- **Local full sweep**: `make test` at `58a691f` → `Suite Summary: 43 PASS, 0 FAIL` (2026-08-30, exit 0; log in session scratchpad `sweep-218-58a691f.log`)
- **CI**: at record time on `58a691f`: gitleaks / history-check / repo-state / risk-review-gate / lint = pass; test-lint **test** = pass; test-macos = running (merge only after green); pr-size = fail pending the owner-only `size-exempt` label (+562/-39 cumulative over the 250 budget; §9-1 fixture battery; precedent #232/#234). Merge only on full green (T-4).
- **Tests added**: +8 core / +4 tap / task-runner receipt pin +3 fields (T-3).
- **Credit**: both commits carry `Suggested-by: @pm25coder (issue #159, comment of 2026-08-27)` per the issue spec. Outward thank-you on #159 remains owner-gated (not posted).
- **release**: `v0.23.3` (ship-relevant: new event family + ledger schema additions + receipt fields).
- **previous release**: `v0.23.2` — fulfilled (tag + Release verified: https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.23.2).
