### PR TITLE
docs: document the v0.23.1–v0.23.3 sentinel surface in reference/engineering EN+JA (#238)

### DIFF
--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -154,7 +154,7 @@ task 途中で model や runtime が切り替わった場合は、regime を混�
 移動平均・傾き履歴・nudge hysteresis が再スタートし、model-keyed な閾値がすべて再解決されます —
 per-model 閾値表（`OVF_MODEL_THRESHOLDS`）もここに含まれ、表は空で出荷されるため、較正済みの
 per-model 値は後からコード変更なしの純粋な設定として投入できます。sentinel は自分の計器（tap）も
-監査します: turn ごとの生 usage を一定周期で正規化ルールに再適用し、数値が食い違う場合や regime 途中で
+監査します: turn ごとの生 usage を一定周期で正規化ルールに再適用し、突合した累積値が閾値を超えて食い違う場合や regime 途中で
 usage schema が変わった場合に `tap_drift` event を記録します — 「発火しなかった」「見えていなかった」と
 並ぶ、記録のみの第 3 の計器状態（「計器が嘘をついた」）です。
 

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -150,7 +150,15 @@ sentinel heuristic を選びます。
 Claude の明示的な `system/compact_boundary` event を観測すると measured series を reset します。
 この event が得られない場合は injected-token の急落 heuristic が fallback のままです。
 
-監視対象の各 attempt は `turn`、`fire`、`alert`、`attempt_end` を独立した
+task 途中で model や runtime が切り替わった場合は、regime を混ぜずに計測をリセットします:
+移動平均・傾き履歴・nudge hysteresis が再スタートし、model-keyed な閾値がすべて再解決されます —
+per-model 閾値表（`OVF_MODEL_THRESHOLDS`）もここに含まれ、表は空で出荷されるため、較正済みの
+per-model 値は後からコード変更なしの純粋な設定として投入できます。sentinel は自分の計器（tap）も
+監査します: turn ごとの生 usage を一定周期で正規化ルールに再適用し、数値が食い違う場合や regime 途中で
+usage schema が変わった場合に `tap_drift` event を記録します — 「発火しなかった」「見えていなかった」と
+並ぶ、記録のみの第 3 の計器状態（「計器が嘘をついた」）です。
+
+監視対象の各 attempt は `turn`、`fire`、`alert`、`regime_change`、`tap_drift`、`attempt_end` を独立した
 `sentinel-events.jsonl` へ append します。task-runner ledger に confluence point ができるまでは
 このファイルを分離して保持します。次 step 境界で nudge を配送するため、発火した attempt で task が
 終了すると pending nudge を受け取る runtime がない、という既知の制限があります。`suppressed` の

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -154,7 +154,7 @@ task 途中で model や runtime が切り替わった場合は、regime を混�
 移動平均・傾き履歴・nudge hysteresis が再スタートし、model-keyed な閾値がすべて再解決されます —
 per-model 閾値表（`OVF_MODEL_THRESHOLDS`）もここに含まれ、表は空で出荷されるため、較正済みの
 per-model 値は後からコード変更なしの純粋な設定として投入できます。sentinel は自分の計器（tap）も
-監査します: turn ごとの生 usage を正規化ルールに再適用し、一定周期の突合で突合した累積値が閾値を超えて食い違う場合や regime 途中で
+監査します: turn ごとの生 usage を正規化ルールに再適用し、一定周期で突合した累積値が閾値を超えて食い違う場合や regime 途中で
 usage schema が変わった場合に `tap_drift` event を記録します — 「発火しなかった」「見えていなかった」と
 並ぶ、記録のみの第 3 の計器状態（「計器が嘘をついた」）です。
 

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -154,7 +154,7 @@ task 途中で model や runtime が切り替わった場合は、regime を混�
 移動平均・傾き履歴・nudge hysteresis が再スタートし、model-keyed な閾値がすべて再解決されます —
 per-model 閾値表（`OVF_MODEL_THRESHOLDS`）もここに含まれ、表は空で出荷されるため、較正済みの
 per-model 値は後からコード変更なしの純粋な設定として投入できます。sentinel は自分の計器（tap）も
-監査します: turn ごとの生 usage を一定周期で正規化ルールに再適用し、突合した累積値が閾値を超えて食い違う場合や regime 途中で
+監査します: turn ごとの生 usage を正規化ルールに再適用し、一定周期の突合で突合した累積値が閾値を超えて食い違う場合や regime 途中で
 usage schema が変わった場合に `tap_drift` event を記録します — 「発火しなかった」「見えていなかった」と
 並ぶ、記録のみの第 3 の計器状態（「計器が嘘をついた」）です。
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -180,8 +180,8 @@ model-keyed thresholds re-resolve — including the per-model threshold table
 (`OVF_MODEL_THRESHOLDS`), which ships empty so calibrated per-model values can
 later land as pure configuration with no code change. The sentinel also audits
 its own tap: it replays each turn's raw usage through the normalization rules
-on a fixed cadence and records a `tap_drift` event when the numbers disagree or
-the usage schema changes mid-regime — a log-only third instrument state ("the
+on a fixed cadence and records a `tap_drift` event when the reconciled sums disagree beyond a
+threshold or the usage schema changes mid-regime — a log-only third instrument state ("the
 tap lied") alongside "didn't fire" and "couldn't see".
 
 Each monitored attempt appends `turn`, `fire`, `alert`, `regime_change`,

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -180,7 +180,7 @@ model-keyed thresholds re-resolve — including the per-model threshold table
 (`OVF_MODEL_THRESHOLDS`), which ships empty so calibrated per-model values can
 later land as pure configuration with no code change. The sentinel also audits
 its own tap: it replays each turn's raw usage through the normalization rules
-on a fixed cadence and records a `tap_drift` event when the reconciled sums disagree beyond a
+and, on a fixed cadence, records a `tap_drift` event when the reconciled sums disagree beyond a
 threshold or the usage schema changes mid-regime — a log-only third instrument state ("the
 tap lied") alongside "didn't fire" and "couldn't see".
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -174,7 +174,18 @@ An explicit Claude `system/compact_boundary` event resets the measured series;
 when that event is unavailable, the injected-token drop heuristic remains the
 fallback.
 
-Each monitored attempt appends `turn`, `fire`, `alert`, and `attempt_end` records
+A mid-task model or runtime switch resets the measurement instead of mixing
+regimes: moving averages, slope history, and nudge hysteresis restart, and all
+model-keyed thresholds re-resolve — including the per-model threshold table
+(`OVF_MODEL_THRESHOLDS`), which ships empty so calibrated per-model values can
+later land as pure configuration with no code change. The sentinel also audits
+its own tap: it replays each turn's raw usage through the normalization rules
+on a fixed cadence and records a `tap_drift` event when the numbers disagree or
+the usage schema changes mid-regime — a log-only third instrument state ("the
+tap lied") alongside "didn't fire" and "couldn't see".
+
+Each monitored attempt appends `turn`, `fire`, `alert`, `regime_change`,
+`tap_drift`, and `attempt_end` records
 to its standalone `sentinel-events.jsonl`. This file remains separate until the
 task-runner ledger has a confluence point. The next-step delivery boundary has
 one known limitation: a task that ends on its firing attempt cannot receive the

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -161,8 +161,10 @@ sentinel の動作も無効です。CLI は `prompt.md` を stdin から直接�
 | 変数 | 契約 |
 | --- | --- |
 | `OVF_SENTINEL` | unset/空 = off。それ以外は厳密に `shadow` または `active` |
-| `OVF_T_ABS` | 1 以上の整数。既定 `80000` token |
-| `OVF_W_PCT` | 1–99 の整数。既定 `50`、100 で割って変換 |
+| `OVF_T_ABS` | optional の 1 以上の整数。設定時のみ forward — unset なら閾値の解決順（明示上書き > per-model 表 > 製品既定 `80000`）で解決し、どの段が勝ったかを key ごとに `run_meta.threshold_sources` へ記録 |
+| `OVF_W_PCT` | optional の 1–99 の整数、100 で割って変換。設定時のみ forward — unset は `OVF_T_ABS` と同じ解決（製品既定 `0.50`） |
+| `OVF_MODEL_ALIASES` | optional の JSON object。model-id alias → canonical id の写像（string、trim+lowercase、single-step で連鎖なし）。不正な値は spawn 前に exit 2 |
+| `OVF_MODEL_THRESHOLDS` | optional の JSON object `{"models": {"<exact-id-or-glob>": {"T_abs"?, "w"?}}, "N_drift"?, "theta_drift"?}`。entry は key ごとの部分上書き。matching は canonical 完全一致 > 最長リテラル接頭辞の glob（`*` のみ）。重複 key・未知 key・リテラル接頭辞を共有する pattern の組・範囲外の値は spawn 前に exit 2。表は空で出荷され、書き戻しまで全 model が明示/既定の段で解決 |
 | `OVF_CTX_WINDOW` | optional の 1 以上の整数。context-window 梯子の第 1 段 |
 | `OVF_HF_CONFIG` | optional の local・non-symlink HF `config.json` path（またはその directory）。network lookup なし |
 | `OVF_HF_NETWORK` | unset/空/`0` = 無効、`1` = best-effort の HF network rung を有効化 |
@@ -196,13 +198,34 @@ last injected MA が厳密に 50k 超なら 150 秒、厳密に 100k 超なら 2
 見る heuristic が fallback です。異なる大きさの turn が混在すると、本来有効な nudge を 1 回だけ
 抑制することがありますが、これは v1 で受容する bounded false-positive cost です。
 
+turn 間で model または runtime が変わると、切替 turn でちょうど 1 回の regime reset が走ります
+（canonical な model identity は trim+lowercase に `OVF_MODEL_ALIASES` の single-step lookup を
+適用したもの。identity field を欠く turn は比較もresetもしません）。reset は measured series・
+pending nudge・軸ごとの nudge hysteresis・drift accumulator をクリアし、model-keyed config を
+すべて再解決します — context window（run-level の `OVF_CTX_WINDOW` 上書きは引き続き最優先）、
+閾値解決順による `T_abs`/`w`、TTFB floor。from/to identity・解決値・key ごとの source を持つ
+`regime_change` event を記録し、切替 turn を新 regime の sample 1 として評価します。
+compaction の急落 heuristic は regime 境界をまたいで評価されません。persist された regime
+identity により、attempt 境界での model 切替 retry も検出されます。
+
+さらに各 regime の tap 自体を突合します（第 3 の計器状態:「計器が嘘をついた」。「発火しなかった」
+「見えていなかった」と並ぶ区別です）。Claude Code adapter は `drift_reference: derived` を申告し、
+turn ごとの生 usage object をそのまま保存します。core が `N_drift` turn ごとに ledger 上で正規化を
+再適用して paired cumulative sum を比較し（参照を欠く turn は cadence を進めつつ両辺の和から対で
+除外）、`|bias_ratio| > theta_drift` で episode 起動・方向非依存の `tap_drift` event を、regime 内で
+生 usage の field set が変われば `schema-change` episode を記録します。v1 は記録のみで、`tap_drift`
+が発火・nudge・無効化を起こすことはなく、derived の count は provider drift の証拠になりません。
+
 hysteresis で block された predicate crossing は event flood 防止のため意図的に `fire` を追加しません。
 append-only の `turn` series から再構成できます。slope-only fire では level threshold を跨いでいないため、
 `threshold_hit` を省略します。
 
-`sentinel-events.jsonl` は append-only で、`turn`、`fire`、`alert`、run ごとの
-`attempt_end` を収録します。task runner はこれらを per-task ledger へ fold し、上記の distinct な
-task-level `task_end` を emit します。
+`sentinel-events.jsonl` は append-only で、`turn`、`fire`、`alert`、`regime_change`、
+`tap_drift`、run ごとの `attempt_end` を収録します。turn record は `runtime` を持ち、drift
+capability が `none` でない限り生の `raw_usage` object をそのまま持ちます。`attempt_end` と
+fold 後の task-level receipt は `regime_change_resets`、`tap_drift_count`（episode 数）、
+`drift_reference_status`（task 内の全 regime の最弱 capability）を持ちます。task runner は
+これらを per-task ledger へ fold し、上記の distinct な task-level `task_end` を emit します。
 `attempt.json` は厳密に `schema_version`、`task_id`、`attempt`、`mode`、`model`、
 `ctx_window`、`ctx_window_source`、`started_at`、nullable な `first_byte_at`、
 `cli_exit_code`、`tap_status_final`、`fired`、`events_path` の field で atomic に確定します。attempt identity は

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -164,7 +164,7 @@ sentinel の動作も無効です。CLI は `prompt.md` を stdin から直接�
 | `OVF_T_ABS` | optional の 1 以上の整数。設定時のみ forward — unset なら閾値の解決順（明示上書き > per-model 表 > 製品既定 `80000`）で解決し、どの段が勝ったかを key ごとに `run_meta.threshold_sources` へ記録 |
 | `OVF_W_PCT` | optional の 1–99 の整数、100 で割って変換。設定時のみ forward — unset は `OVF_T_ABS` と同じ解決（製品既定 `0.50`） |
 | `OVF_MODEL_ALIASES` | optional の JSON object。model-id alias → canonical id の写像（string、trim+lowercase、single-step で連鎖なし）。不正な値は spawn 前に exit 2 |
-| `OVF_MODEL_THRESHOLDS` | optional の JSON object `{"models": {"<exact-id-or-glob>": {"T_abs"?, "w"?}}, "N_drift"?, "theta_drift"?}`。entry は key ごとの部分上書き。matching は canonical 完全一致 > 最長リテラル接頭辞の glob（`*` のみ）。重複 key・未知 key・リテラル接頭辞を共有する pattern の組・範囲外の値は spawn 前に exit 2。表は空で出荷され、書き戻しまで全 model が明示/既定の段で解決 |
+| `OVF_MODEL_THRESHOLDS` | optional の JSON object `{"models": {"<exact-id-or-glob>": {"T_abs"?, "w"?}}, "N_drift"?, "theta_drift"?}`。entry は key ごとの部分上書き。matching は canonical 完全一致 > 最長リテラル接頭辞の glob（`*` のみ）。重複 key・未知 key・リテラル接頭辞が同一の pattern の組・範囲外の値は spawn 前に exit 2。placeholder 既定は `N_drift` `5` / `theta_drift` `0.10`。表は空で出荷され、書き戻しまで全 model が明示/既定の段で解決 |
 | `OVF_CTX_WINDOW` | optional の 1 以上の整数。context-window 梯子の第 1 段 |
 | `OVF_HF_CONFIG` | optional の local・non-symlink HF `config.json` path（またはその directory）。network lookup なし |
 | `OVF_HF_NETWORK` | unset/空/`0` = 無効、`1` = best-effort の HF network rung を有効化 |
@@ -210,8 +210,8 @@ identity により、attempt 境界での model 切替 retry も検出されま�
 
 さらに各 regime の tap 自体を突合します（第 3 の計器状態:「計器が嘘をついた」。「発火しなかった」
 「見えていなかった」と並ぶ区別です）。Claude Code adapter は `drift_reference: derived` を申告し、
-turn ごとの生 usage object をそのまま保存します。core が `N_drift` turn ごとに ledger 上で正規化を
-再適用して paired cumulative sum を比較し（参照を欠く turn は cadence を進めつつ両辺の和から対で
+turn ごとの生 usage object をそのまま保存します。core が毎 turn ledger 上で正規化を再適用し、`N_drift` turn ごとに
+paired cumulative sum を比較して（参照を欠く turn は cadence を進めつつ両辺の和から対で
 除外）、`|bias_ratio| > theta_drift` で episode 起動・方向非依存の `tap_drift` event を、regime 内で
 生 usage の field set が変われば `schema-change` episode を記録します。v1 は記録のみで、`tap_drift`
 が発火・nudge・無効化を起こすことはなく、derived の count は provider drift の証拠になりません。

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -194,8 +194,10 @@ is created.
 | Variable | Contract |
 | --- | --- |
 | `OVF_SENTINEL` | unset/empty = off; otherwise exactly `shadow` or `active` |
-| `OVF_T_ABS` | integer >= 1; default `80000` tokens |
-| `OVF_W_PCT` | integer 1–99; default `50`, converted by dividing by 100 |
+| `OVF_T_ABS` | optional integer >= 1; forwarded only when set — unset resolves through the threshold order (explicit override, then the per-model table, then the product default `80000`), and the winning tier is recorded per key in `run_meta.threshold_sources` |
+| `OVF_W_PCT` | optional integer 1–99, converted by dividing by 100; forwarded only when set — unset resolves like `OVF_T_ABS` (product default `0.50`) |
+| `OVF_MODEL_ALIASES` | optional JSON object mapping model-id aliases to canonical ids (strings; trimmed and lowercased; single-step, no chains); invalid values exit 2 before spawn |
+| `OVF_MODEL_THRESHOLDS` | optional JSON object `{"models": {"<exact-id-or-glob>": {"T_abs"?, "w"?}}, "N_drift"?, "theta_drift"?}`; entries are partial per-key overrides; matching is canonical exact id, then longest-literal-prefix glob (`*` only); duplicate or unknown keys, two patterns sharing a literal prefix, and out-of-range values exit 2 before spawn; ships empty, so every model uses the explicit/default tiers until values are written back |
 | `OVF_CTX_WINDOW` | optional integer >= 1; first context-window ladder rung |
 | `OVF_HF_CONFIG` | optional local non-symlink HF `config.json` path (or its directory); no network lookup |
 | `OVF_HF_NETWORK` | unset/empty/`0` = disabled; `1` enables one best-effort HF network rung |
@@ -236,13 +238,42 @@ strict greater-than-40% injected drop remains the fallback heuristic. This
 mixed-magnitude heuristic can suppress one otherwise valid nudge; that bounded
 false positive is an accepted v1 cost.
 
+A model or runtime change between turns triggers exactly one regime reset on
+the switch turn (canonical model identity is trimmed and lowercased with one
+`OVF_MODEL_ALIASES` lookup; a turn without an identity field neither compares
+nor resets). The reset clears the measured series, the pending nudge, the
+per-axis nudge hysteresis, and the drift accumulators, then re-resolves all
+model-keyed config — the context window (a run-level `OVF_CTX_WINDOW` override
+still wins), `T_abs`/`w` through the threshold order, and the TTFB floor —
+records a `regime_change` event with the from/to identities, resolved values,
+and per-key sources, and evaluates the switch turn as the first sample of the
+new regime. The compaction drop heuristic is never evaluated across a regime
+boundary, and the persisted regime identity also detects a model-changing retry
+at the attempt boundary.
+
+Each regime's tap is additionally reconciled (the third instrument state: "the
+tap lied", alongside "didn't fire" and "couldn't see"). The Claude Code adapter
+declares `drift_reference: derived` and persists each turn's verbatim raw usage
+object; core replays the normalization over the ledger every `N_drift` turns
+and compares paired cumulative sums — reference-missing turns advance the
+cadence but drop out of both sums — recording an episode-triggered,
+direction-agnostic `tap_drift` event when `|bias_ratio| > theta_drift`, and a
+`schema-change` episode when the raw-usage field set changes within a regime.
+v1 is log-only: `tap_drift` never fires, nudges, or disables anything, and
+derived counts are never evidence of provider drift.
+
 Hysteresis-blocked predicate crossings intentionally append no `fire` event to
 avoid event floods. They remain reconstructable from the append-only `turn`
 series. On slope-only fires, `threshold_hit` is omitted because neither level
 threshold crossed.
 
-`sentinel-events.jsonl` is append-only and contains `turn`, `fire`, `alert`, and
-per-run `attempt_end` records. The task runner folds those records into the
+`sentinel-events.jsonl` is append-only and contains `turn`, `fire`, `alert`,
+`regime_change`, `tap_drift`, and per-run `attempt_end` records. Turn records
+carry `runtime` and, whenever the drift capability is not `none`, the verbatim
+`raw_usage` object; `attempt_end` and the folded task-level receipt carry
+`regime_change_resets`, `tap_drift_count` (episodes), and
+`drift_reference_status` (the weakest capability across the task's regimes).
+The task runner folds those records into the
 per-task ledger and emits the distinct task-level `task_end` described above.
 `attempt.json` is atomically finalized with exactly
 these fields: `schema_version`, `task_id`, `attempt`, `mode`, `model`,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -197,7 +197,7 @@ is created.
 | `OVF_T_ABS` | optional integer >= 1; forwarded only when set — unset resolves through the threshold order (explicit override, then the per-model table, then the product default `80000`), and the winning tier is recorded per key in `run_meta.threshold_sources` |
 | `OVF_W_PCT` | optional integer 1–99, converted by dividing by 100; forwarded only when set — unset resolves like `OVF_T_ABS` (product default `0.50`) |
 | `OVF_MODEL_ALIASES` | optional JSON object mapping model-id aliases to canonical ids (strings; trimmed and lowercased; single-step, no chains); invalid values exit 2 before spawn |
-| `OVF_MODEL_THRESHOLDS` | optional JSON object `{"models": {"<exact-id-or-glob>": {"T_abs"?, "w"?}}, "N_drift"?, "theta_drift"?}`; entries are partial per-key overrides; matching is canonical exact id, then longest-literal-prefix glob (`*` only); duplicate or unknown keys, two patterns sharing a literal prefix, and out-of-range values exit 2 before spawn; ships empty, so every model uses the explicit/default tiers until values are written back |
+| `OVF_MODEL_THRESHOLDS` | optional JSON object `{"models": {"<exact-id-or-glob>": {"T_abs"?, "w"?}}, "N_drift"?, "theta_drift"?}`; entries are partial per-key overrides; matching is canonical exact id, then longest-literal-prefix glob (`*` only); duplicate or unknown keys, two patterns whose literal prefixes are identical, and out-of-range values exit 2 before spawn; placeholder defaults `N_drift` `5` / `theta_drift` `0.10`; ships empty, so every model uses the explicit/default tiers until values are written back |
 | `OVF_CTX_WINDOW` | optional integer >= 1; first context-window ladder rung |
 | `OVF_HF_CONFIG` | optional local non-symlink HF `config.json` path (or its directory); no network lookup |
 | `OVF_HF_NETWORK` | unset/empty/`0` = disabled; `1` enables one best-effort HF network rung |
@@ -254,8 +254,8 @@ at the attempt boundary.
 Each regime's tap is additionally reconciled (the third instrument state: "the
 tap lied", alongside "didn't fire" and "couldn't see"). The Claude Code adapter
 declares `drift_reference: derived` and persists each turn's verbatim raw usage
-object; core replays the normalization over the ledger every `N_drift` turns
-and compares paired cumulative sums — reference-missing turns advance the
+object; core replays the normalization over the ledger each turn and, every
+`N_drift` turns, compares the paired cumulative sums — reference-missing turns advance the
 cadence but drop out of both sums — recording an episode-triggered,
 direction-agnostic `tap_drift` event when `|bias_ratio| > theta_drift`, and a
 `schema-change` episode when the raw-usage field set changes within a regime.


### PR DESCRIPTION
Implements #238 — documents the operator-facing surface shipped by the v0.23.1–v0.23.3 sentinel lanes (#217/#219/#218). Docs-only; no behavior changes.

## Files touched (= WIP declaration on #238)

- `docs/reference.md` / `docs/reference.ja.md` — env contract table gains `OVF_MODEL_ALIASES` and `OVF_MODEL_THRESHOLDS` rows (load-time exit-2 semantics, ships-empty default); `OVF_T_ABS`/`OVF_W_PCT` rows corrected to forwarded-only-when-set + resolver order + per-key `threshold_sources` provenance; new paragraphs document the regime reset (identity canonicalization, single reset, re-resolution, attempt-boundary retry detection) and the tap reconciliation (`derived` capability, R_e pairwise exclusion, episode semantics, log-only); event inventory updated (`regime_change`, `tap_drift`, turn `runtime`/`raw_usage`, attempt_end + task-end receipt fields)
- `docs/engineering.md` / `docs/engineering.ja.md` — Overflow sentinel section gains the regime-reset / injection-point-writeback / third-instrument-state overview paragraph; event list updated

Out of scope: README×4 (locked by the active #231 README-redesign WIP; feature-level README claims ride that lane or follow it).

## Review

Heterogeneous 3-seat blind panel (GLM-5.3 / Kimi-K3 / Grok-4.6; writer = Alpha claude-fable-5 — docs-only lane, non-code). Claim-accuracy audit complete: r1 GO-WITH-MINOR ×3 (wording only) → all findings adopted → cumulative **GO / GO / GO**. Record: https://github.com/caty-ai/caty-agent-harness/issues/238#issuecomment-5467923505

## L1-7 completion record (#238 → PR #239)

**Candidate SHA**: `4f08202` (= PR head). Lineage: r1 candidate `35c247e` → panel fixes `9e95c4f` (all 4 r1 findings) → `5360ef5` (Kimi delta finding) → `4f08202` (cosmetic JA smoothing of a panel-verified sentence, zero semantic change — quoted in the review record).

### Done when → verdicts (evidence inline, 2026-08-30)

1. **reference EN+JA: new knob rows, corrected T_abs/W_PCT semantics, event-family paragraphs** — **PASS**
   Evidence: `OVF_MODEL_ALIASES` + `OVF_MODEL_THRESHOLDS` rows in the contract style (load-time exit-2, identical-prefix rejection, placeholder defaults 5/0.10, ships-empty); `OVF_T_ABS`/`OVF_W_PCT` state forwarded-only-when-set + resolver order + per-key `threshold_sources`; regime-reset and tap-reconciliation paragraphs + event inventory (`regime_change`, `tap_drift`, turn `runtime`/`raw_usage`, attempt_end/task-end receipt fields). All claims audited against shipped code by 3 seats (claim-audit tables in their reviews) — PASS across the board after fixes.
2. **engineering EN+JA: overview paragraphs** — **PASS**
   Evidence: regime reset / injection-point writeback / third-instrument-state paragraph + updated event list; cadence wording aligned with reference (Kimi delta confirm on `5360ef5`).
3. **No behavior changes; EN/JA in sync; claims match shipped code** — **PASS**
   Evidence: diff touches only the 4 declared docs files (`git diff --name-only origin/main...4f08202`); EN/JA parity explicitly verified per finding by the seats; zero code changes.

### Gate items

- **Identities**: writer = Alpha (claude-fable-5); seats GLM-5.3 / Kimi-K3 / Grok-4.6 (requested = actual) — pairwise heterogeneous, all ≠ writer's family; no same-family seat.
- **Review verdicts**: r1 GO-WITH-MINOR ×3 (wording/precision only, blocking 0 at every round) → cumulative **GO / GO / GO** (Kimi's final confirm on `5360ef5`). Record: https://github.com/caty-ai/caty-agent-harness/issues/238#issuecomment-5467923505
- **File set vs diff**: exactly the 4 declared files; README×4 untouched (respects the #231 lane's WIP).
- **Local full sweep**: `make test` at `4f08202` — `Suite Summary: 43 PASS, 0 FAIL` (2026-08-30, exit 0; log in session scratchpad `sweep-238-4f08202.log`)
- **CI**: all checks green on `4f08202` at record time, including pr-size (within budget, no exemption) — merge only on full green (T-4)
- **Tests added**: none — T-3 closed-enumeration reason 2 (docs-only change, no test target; the docs-claims suites that do exist run in the full sweep above).
- **pr-size**: within the 250-line budget (+84/−11) — no size-exempt needed.
- **release**: `v0.23.4` (docs are operator-facing norms in this repo; ship-relevant per the #229 → v0.22.6 precedent).
- **previous release**: `v0.23.3` — fulfilled (tag + Release verified: https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.23.3).
