### PR TITLE
fix(apply-promotions): Python 3.9-compatible stub write + declare python3 3.9+ floor in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ The tests are plain shell suites, but a few tools must be present:
 - **make** — the test and lint entry points are Makefile targets
 - **git 2.34+** — the updater suite exercises SSH signature verification, which older git cannot do
 - **ssh-keygen with `-Y` support** (OpenSSH 8.2+, the floor git documents for SSH signing) — the updater suite generates and verifies ed25519 signing keys; without it those cases cannot run
-- **python3** — several suites shell out to it for fixtures and checks (any recent 3.x)
+- **python3** — several suites shell out to it for fixtures and checks (3.9+)
 - **perl** — `scripts/task-runner.sh` detaches step sessions via `perl -MPOSIX=setsid`; when perl is absent, interpreter resolution (`scripts/lib-donecheck.sh`) fails closed with `cannot resolve interpreter` and task-runner steps cannot run. Stock macOS and Ubuntu ship perl; minimal WSL2/container images may not (CI installs it explicitly)
 - standard Unix tools (grep, sed, awk, mktemp) as shipped on macOS or Linux
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -23,7 +23,7 @@ Run these read-only checks and note the results for your final report:
 ```sh
 git --version
 bash --version          # 3.2+ is fine (macOS default works)
-command -v python3      # needed for hooks and automated paths
+command -v python3      # needed for hooks and automated paths (3.9+)
 ```
 
 If `python3` is missing, you can still complete steps 1–4; say so in your report and point the human at their platform's Python 3 install. This repository is public at <https://github.com/caty-ai/caty-agent-harness>, so no invitation is needed. If the repository URL is not reachable, stop and tell the human which error you saw.

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -83,7 +83,7 @@ Harness は各ツールが支えられる範囲で同じように役立ちます
 
 > AI エージェント経由で導入する場合は [agent-guide.md](agent-guide.md)（英語）を渡してください。runtime の選択・ヘルスチェック・必要な後続配線まで一本道で案内します。
 
-installer、scaffold、pause command の前提は、Git と bash 3.2+ が動く macOS、Linux、または [WSL2 サポートメモ](wsl2-support.md)の条件を満たす WSL2（Ubuntu on Windows）を使っていることです。native Windows は非対応です。runtime hook、`task-runner`、adapter integration、fully operational な runtime 配線には Python 3 が必要です。
+installer、scaffold、pause command の前提は、Git と bash 3.2+ が動く macOS、Linux、または [WSL2 サポートメモ](wsl2-support.md)の条件を満たす WSL2（Ubuntu on Windows）を使っていることです。native Windows は非対応です。runtime hook、`task-runner`、adapter integration、fully operational な runtime 配線には Python 3.9+ が必要です。
 
 ```sh
 git clone https://github.com/caty-ai/caty-agent-harness.git

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -83,7 +83,7 @@ The implementation is intentionally asymmetric. The Harness does not claim that 
 
 > Installing via your AI agent instead? Hand it [agent-guide.md](agent-guide.md) — it covers runtime selection, the health check, and required follow-up wiring.
 
-Prerequisites for the installer, scaffold, and pause commands: Git and bash 3.2+ on macOS, Linux, or WSL2 (Ubuntu on Windows, under the conditions in the [WSL2 support note](wsl2-support.md)); native Windows is unsupported. Python 3 is required for runtime hooks, `task-runner`, adapter integrations, and fully operational runtime wiring.
+Prerequisites for the installer, scaffold, and pause commands: Git and bash 3.2+ on macOS, Linux, or WSL2 (Ubuntu on Windows, under the conditions in the [WSL2 support note](wsl2-support.md)); native Windows is unsupported. Python 3.9+ is required for runtime hooks, `task-runner`, adapter integrations, and fully operational runtime wiring.
 
 ```sh
 git clone https://github.com/caty-ai/caty-agent-harness.git

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -121,7 +121,7 @@ review notification、48時間を超える沈黙、設定 threshold 以上の ze
   extraction を終了させるため、使用禁止です。
 - donecheck に渡るのは `TASK_ID`、`TASK_FILE`、`ARTIFACT_DIR`、`TR_DC_CWD`、固定の
   `PATH=/usr/bin:/bin:/usr/sbin:/sbin`、runner 側で set 済みの
-  `HOME`/`LANG`/`LC_ALL`/`TZ`、および shell が作る変数だけです。`python3` などの tool は
+  `HOME`/`LANG`/`LC_ALL`/`TZ`、および shell が作る変数だけです。`python3`（3.9+）などの tool は
   この固定 `PATH` から到達できるか、donecheck 内で絶対パス指定する必要があります。
   同梱の `templates/examples/img-pilot.task.md` の donecheck はこの `PATH` 内の `python3` に
   依存します。macOS には `/usr/bin/python3` がありますが、Linux distribution にはない場合が

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -146,7 +146,7 @@ configuration.
   terminates extraction textually and is therefore prohibited.
 - Donechecks receive only `TASK_ID`, `TASK_FILE`, `ARTIFACT_DIR`, `TR_DC_CWD`, fixed
   `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, any set `HOME`/`LANG`/`LC_ALL`/`TZ`, and
-  shell-created variables. Tools such as `python3` must be reachable in that fixed
+  shell-created variables. Tools such as `python3` (3.9+) must be reachable in that fixed
   `PATH` or invoked by absolute path. The bundled `templates/examples/img-pilot.task.md`
   donecheck depends on `python3` there; macOS ships `/usr/bin/python3`, while Linux
   distributions may not. Other inherited variables disappear and dependent checks

--- a/scripts/apply-promotions.sh
+++ b/scripts/apply-promotions.sh
@@ -749,7 +749,8 @@ text = "\n".join([
     one("theme"),
     "",
 ])
-out.write_text(text, encoding="utf-8", newline="\n")
+with out.open("w", encoding="utf-8", newline="\n") as fh:
+    fh.write(text)
 PY
 }
 


### PR DESCRIPTION
Closes #240.

## What

`scripts/apply-promotions.sh` の `write_stub_template()` が使っていた `Path.write_text(text, encoding="utf-8", newline="\n")` は Python 3.10+ 専用（`newline` kwarg は 3.10 追加）。PATH 先頭が `/usr/bin` の環境（alpha-nightshift credential-free レーン等）では python3 = macOS システム 3.9.6 に解決され TypeError → `tests/apply-promotions.test.sh` が 4夜連続で 4 subtests FAIL。

- 該当1箇所を `out.open("w", encoding="utf-8", newline="\n")` コンテキストに置換（`io.open` の `newline` は 3.0 からあり 3.9 安全・書き出しバイト列は同一: UTF-8 / LF / 改行変換なし）
- docs の既存 python3 記載すべてに最小バージョン **3.9+** を明記

## Files touched（WIP 宣言との照合 / L0-6）

宣言7ファイル = diff 7ファイル、過不足なし:

| File | Change |
|---|---|
| `scripts/apply-promotions.sh` | L752 の write_text(newline=) → open(newline=) コンテキスト（3行差分） |
| `CONTRIBUTING.md` | `(any recent 3.x)` → `(3.9+)` |
| `docs/engineering.md` / `docs/engineering.ja.md` | `Python 3` → `Python 3.9+`（前提条件段落） |
| `docs/reference.md` / `docs/reference.ja.md` | donecheck PATH 段落の `python3` に `(3.9+)` を1箇所挿入 |
| `docs/agent-guide.md` | preflight コメントに `(3.9+)` |

INSTALL.md（Issue の予測に記載）はポインタ専用ファイルで前提条件の実文なし → 触らず、実体側の engineering.md/.ja.md に明記（WIP 宣言時に理由つきで差し替え済み）。

## 完了記録（L1-7）

**候補 commit SHA: `2aa9b88`**（PR head。レビュー後に変わったら差し替え記録を追記）

Done when の対応:

1. **write_text(..., newline=...) の排除 + 3.9 互換置換** — **PASS**
   証拠: `git diff origin/main...2aa9b88 -- scripts/apply-promotions.sh` = 該当1箇所のみの置換（本 PR の diff）。置換形は `with out.open("w", encoding="utf-8", newline="\n") as fh: fh.write(text)`。2026-08-31 実施。
2. **`grep -rn "write_text(.*newline" scripts/ tests/ adapters/` が 0 件** — **PASS**
   証拠: 2026-08-31 worktree（2aa9b88）で実行、ヒット 0・exit 1。
3. **/usr/bin/python3（3.9.6）PATH 先頭で tests green** — **PASS**
   証拠: 2026-08-31 実行 `PATH="/usr/bin:$PATH" bash tests/apply-promotions.test.sh`（`/usr/bin/python3 --version` = Python 3.9.6 確認済み）→ `Apply Promotions Summary: 43 PASS, 0 FAIL, 1 SKIP`（SKIP = env-gated private corpus replay・従来どおり）。
4. **現行開発環境（3.10+）でも green** — **PASS**
   証拠: 2026-08-31 実行、通常 PATH（python3 = 3.14.3）→ `Apply Promotions Summary: 43 PASS, 0 FAIL, 1 SKIP`。
5. **docs に python3 最小バージョン明記（3.9 サポート採用）** — **PASS**
   証拠: 本 PR diff の docs 6ファイル（CONTRIBUTING / engineering EN+JA / reference EN+JA / agent-guide）。3.9 互換化を採用したのでレーン側対応の別 Issue は不要。INSTALL.md は理由付き N/A（ポインタ専用・前提条件の実文なし）。

**回帰テスト（T-2）**: 追加なし — 既存 `tests/apply-promotions.test.sh` の 4 subtests が「fix 前に赤（08-27〜08-30 の夜番 4夜・`state/lanes/2026-08-{27..30}/lane_1/evidence/test-apply-promotions.log`）・fix 後に緑（上記3）」の再現テストそのもの（T-3 理由③: 既存テストが当該変更を担保）。

**実装者 / レビュアー**: 実装 writer = Codex（GPT-5.6 Sol・orchestrator = Alpha/Fable 5）。レビュー席（S/M 異種3席・L1-10/L1-11）= GLM 5.3 **GO-WITH-MINOR** / Kimi K3 **GO-WITH-MINOR** / Grok 4.6 **GO**（CRITICAL/MAJOR 0・全席 writer と異種・詳細記録は本 PR コメント）。収束 MINOR（スコープ外の床なし Python 3 記載）は follow-up #248 起票で採用。

**CI 状態**: 全 green（2026-08-31・head 2aa9b88）。test-lint / test **pass** 21m25s・test-lint / test-macos **pass** 26m9s（run: https://github.com/caty-ai/caty-agent-harness/actions/runs/33360687651 ）・lint / gitleaks / history-check / pr-size / repo-state / risk-review-gate すべて pass、赤ゼロ。

**release: v0.23.5**（出荷相当 — 3.9 環境での実挙動の修正）
**previous release: v0.23.4**（PR #239・タグ + GitHub Release 実在・履行済み: https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.23.4 ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
