### PR TITLE
docs: python3 3.9+ floor in AGENTS.md and plugin-convention (#248, non-intersecting remainder)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ make lint    # syntax-checks every tracked shell script, rejects bash 4.2+ ANSI-
 <!-- claim: make-target lint -->
 
 - Expected: `Suite Summary: <n> PASS, 0 FAIL`. `make lint` refuses a vacuous green — zero files checked is a failure.
-- Prerequisites are listed in [CONTRIBUTING.md](CONTRIBUTING.md) — bash 3.2+, `make`, git 2.34+, `ssh-keygen -Y` (OpenSSH 8.2+), python3, and standard Unix tools.
+- Prerequisites are listed in [CONTRIBUTING.md](CONTRIBUTING.md) — bash 3.2+, `make`, git 2.34+, `ssh-keygen -Y` (OpenSSH 8.2+), python3 (3.9+), and standard Unix tools.
 - If you edit the Makefile `test` recipe, resync `.github/ci/make-test-recipe.pin` in the same change. That pin is checked after merge, not on your PR, so skipping it turns `main` red.
 
 CI, accurately:

--- a/docs/plugin-convention.md
+++ b/docs/plugin-convention.md
@@ -56,7 +56,7 @@ Anything not listed above is engine-internal and may change without notice.
   `ARTIFACT_DIR`, `TR_DC_CWD`, and `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, plus `HOME`,
   `LANG`, `LC_ALL`, and `TZ` only when the runner has them. The shell also creates
   variables such as `PWD`, `SHLVL`, and `_`. Because `PATH` is fixed, tools such as
-  `python3` must be reachable there or invoked by absolute path in donechecks. The
+  `python3` (3.9+) must be reachable there or invoked by absolute path in donechecks. The
   bundled `templates/examples/img-pilot.task.md` donecheck depends on `python3` in
   that `PATH`; macOS ships `/usr/bin/python3`, while Linux distributions may not.
   Donechecks that depended on any other inherited variable, including `TR_PUSH_CMD`,


### PR DESCRIPTION
Closes #248.

## What

#247（v0.23.5）で docs に明記した python3 の最小バージョン（3.9+）を、レビュー3席が指摘した残り箇所のうち**非交差の2ファイル**にも反映する（各1語の挿入）。

- `AGENTS.md:64` — CONTRIBUTING を指す prerequisites 要約行: `python3` → `python3 (3.9+)`
- `docs/plugin-convention.md:59` — donecheck PATH 段落: `` `python3` `` → `` `python3` (3.9+) ``（reference.md と同じ1箇所挿入方式。同段落の後続2文は直前の versioned 言及への参照のため対象外）

**README.md + 翻訳3本は本 PR から除外**: 生きた WIP を持つ #231（README 前面再設計・README×4 宣言済み）と交差するため、L0-2 に従い #231 への fold を提案済み（[#231 コメント](https://github.com/caty-ai/caty-agent-harness/issues/231#issuecomment-5474810119)・fallback = #231 merge 後に #248 系で直列拾い）。スコープ差し替え記録 = [#248 コメント](https://github.com/caty-ai/caty-agent-harness/issues/248#issuecomment-5474810331)。

## Files touched（WIP 宣言との照合 / L0-6）

宣言2ファイル = diff 2ファイル、過不足なし: `AGENTS.md` / `docs/plugin-convention.md`（各 +1/-1）。

## 完了記録（L1-7）

**候補 commit SHA: `adf65e1`**（PR head）

Done when（差し替え後）の対応:

1. **AGENTS.md:64 に (3.9+) 明記** — **PASS**。証拠: 本 PR diff（+1/-1）。2026-08-31。
2. **docs/plugin-convention.md:59 に (3.9+) 明記** — **PASS**。証拠: 本 PR diff（+1/-1）。2026-08-31。
3. **prerequisites 文脈の床なし python3 が 0** — **PASS**。証拠: 2026-08-31 worktree（adf65e1）で `grep -n "python3" AGENTS.md docs/plugin-convention.md | grep -v "3.9"` → 残 2 ヒットはいずれも plugin-convention.md:60-61 の同段落後続文（versioned 言及への参照）で prerequisites 宣言ではない。
4. **README×4 の帰結リンク** — **PASS（fold 提案済み）**。証拠: #231 comment-5474810119（2026-08-31）。

**回帰テスト（T-2）**: N/A — サイズ S・docs のみ（T-2 は S 免除）。テスト追加なし（T-3 理由②: 変更にテスト対象がない）。

**実装者 / レビュアー**: 実装 = Alpha（Fable 5・直接編集/S docs 類型）。レビュー席（S = 異種3席・L1-10/L1-11・writer と全席異種・同系統例外 不使用）= GLM 5.3 **GO** / Kimi K3 **GO** / Grok 4.6 **GO**（全会一致・本 diff 起因の findings 0・詳細記録は本 PR コメント）。

**CI 状態**: 全 green（2026-08-31・head adf65e1）。test-lint / test・test-macos 含む全 check pass、赤ゼロ（run: https://github.com/caty-ai/caty-agent-harness/actions/runs/33365928937 ）。

**release: v0.23.6**（規範 docs の変更 = 出荷相当の重い側判定。AGENTS.md はエージェント向け規範・plugin-convention は規約文書）
**previous release: v0.23.5**（PR #247・タグ + GitHub Release 実在・履行済み: https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.23.5 ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
