### PR TITLE
ci: pin family-dev-handbook reusable workflows to ci-v1 peeled SHA (#245)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,5 +8,5 @@ permissions: {contents: read}
 concurrency: {group: 'gitleaks-${{ github.event.pull_request.number }}', cancel-in-progress: true}
 jobs:
   gitleaks:
-    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-gitleaks.yml@ci-v1
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-gitleaks.yml@8430452c1a22943c805ba2a940a75960299cfb2f # ci-v1
     permissions: {contents: read}

--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -8,5 +8,5 @@ permissions: {contents: read}
 concurrency: {group: 'history-check-${{ github.event.pull_request.number }}', cancel-in-progress: true}
 jobs:
   history-check:
-    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-history-check.yml@ci-v1
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-history-check.yml@8430452c1a22943c805ba2a940a75960299cfb2f # ci-v1
     permissions: {contents: read}

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -9,7 +9,7 @@ permissions: {contents: read}
 concurrency: {group: 'pr-size-${{ github.event.pull_request.number }}', cancel-in-progress: true}
 jobs:
   pr-size:
-    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-pr-size.yml@ci-v1
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-pr-size.yml@8430452c1a22943c805ba2a940a75960299cfb2f # ci-v1
     permissions: {contents: read, pull-requests: write}
     with:
       max_lines: '250'

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -8,5 +8,6 @@ concurrency:
   cancel-in-progress: false
 jobs:
   release-sync:
-    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-release-sync.yml@ci-v1
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-release-sync.yml@8430452c1a22943c805ba2a940a75960299cfb2f # ci-v1
+    # release 作成に contents: write が必要。pin により実行コードは SHA 固定済み。
     permissions: {contents: write}

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -9,7 +9,7 @@ permissions: {contents: read}
 concurrency: {group: 'risk-review-${{ github.event.pull_request.number }}', cancel-in-progress: true}
 jobs:
   risk-review-gate:
-    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-review-labels.yml@ci-v1
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-review-labels.yml@8430452c1a22943c805ba2a940a75960299cfb2f # ci-v1
     permissions: {contents: read, issues: read, pull-requests: write}
     with:
       risk_paths_billing: 'none' # 課金・支出コードなし (#30 で明示宣言)

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -8,7 +8,7 @@ permissions: {contents: read}
 concurrency: {group: 'test-lint-${{ github.event.pull_request.number }}', cancel-in-progress: true}
 jobs:
   test-lint:
-    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-test-lint.yml@ci-v1
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-test-lint.yml@8430452c1a22943c805ba2a940a75960299cfb2f # ci-v1
     permissions: {contents: read}
     with:
       run_macos: true

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -289,14 +289,18 @@ plugin は `tr-enqueue`、pinned template、read-only artifact consumption を�
 
 ## CI reusable workflow の pin 更新
 
-6 つの caller workflow は、`caty-ai/family-dev-handbook` の reusable workflow を commit SHA で pin しています。required merge gate の境界で可変な `ci-v1` tag を使うと、この repository で review 済みの CI コードを review なしで変更できるため、SHA pin でその supply-chain / review-bypass 経路を閉じます。first-party action はすでに SHA pin 済みです。
+6 つの caller workflow は、`caty-ai/family-dev-handbook` の reusable workflow を commit SHA で pin しています。required merge gate の境界で可変な `ci-v1` tag を使うと、この repository で review 済みの CI コードを review なしで変更できるため、SHA pin でその supply-chain / review-bypass 経路を閉じます。この repository の workflow 内の `actions/*` step はすでに SHA pin 済みです。一方、`repo-state.yml` と `external-input-caller.yml` は caty-ai の reusable workflow を tag / branch で参照しており、別途追跡されています。
 
 handbook が `ci-v1` を更新したときは、次の手順で pin を進めます。
 
 1. `git ls-remote https://github.com/caty-ai/family-dev-handbook.git 'refs/tags/ci-v1*'` を実行します。
 2. `ci-v1` は annotated tag なので、正確に `refs/tags/ci-v1^{}` と表示された行の SHA をコピーします。`refs/tags/ci-v1` の行は tag object です。その SHA を `uses:` に指定すると reusable workflow の解決に失敗します。
-3. 1 つの pull request で 6 つの caller（`test-lint.yml`、`gitleaks.yml`、`history-check.yml`、`pr-size.yml`、`review-labels.yml`、`release-sync.yml`）をすべて更新し、末尾の追跡コメント `# ci-v1` は残します。
-4. その pull request の CI が green になってから merge します。
+3. roll pull request を開く前に、6 つの `reusable-*.yml` がすべて新しい peeled SHA に存在することを確認し（例: `gh api 'repos/caty-ai/family-dev-handbook/contents/.github/workflows?ref=<new-sha>'`）、handbook の旧 SHA から新 SHA までの差分を review します。新しい pin がコードを固定しても、roll 自体は trust transfer です。
+4. permission の必要量は増減し得るため、各 reusable workflow の `permissions:` block を caller の grant と照合し直します。そのうえで、1 つの pull request で 6 つの caller（`test-lint.yml`、`gitleaks.yml`、`history-check.yml`、`pr-size.yml`、`review-labels.yml`、`release-sync.yml`）をすべて更新し、末尾の追跡コメント `# ci-v1` は残します。
+5. roll pull request の CI が実行するのは、pull request trigger を持つ 5 つの caller だけです。また、この変更は high-risk な `.github/workflows/*` path に触れるため、roster human が `risk-reviewed` を付けるまで `risk-review-gate` は red のままです。この red は process gate であり、workflow code の破損を示すものではありません。
+6. その pull request の CI が green になってから merge します。`release-sync` は `v*` tag push（`on.push.tags`）でのみ実行されるため、merge 後の次回 `v*` tag で `release-sync` の成功と GitHub Release の存在を確認します。
+
+pin roll は handbook の release note、または時折行う `git ls-remote` の比較で手動検知します。`ci-v1` の移動を監視する automation はありません。
 
 ---
 

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -287,6 +287,19 @@ plugin は `tr-enqueue`、pinned template、read-only artifact consumption を�
 
 ---
 
+## CI reusable workflow の pin 更新
+
+6 つの caller workflow は、`caty-ai/family-dev-handbook` の reusable workflow を commit SHA で pin しています。required merge gate の境界で可変な `ci-v1` tag を使うと、この repository で review 済みの CI コードを review なしで変更できるため、SHA pin でその supply-chain / review-bypass 経路を閉じます。first-party action はすでに SHA pin 済みです。
+
+handbook が `ci-v1` を更新したときは、次の手順で pin を進めます。
+
+1. `git ls-remote https://github.com/caty-ai/family-dev-handbook.git 'refs/tags/ci-v1*'` を実行します。
+2. `ci-v1` は annotated tag なので、正確に `refs/tags/ci-v1^{}` と表示された行の SHA をコピーします。`refs/tags/ci-v1` の行は tag object です。その SHA を `uses:` に指定すると reusable workflow の解決に失敗します。
+3. 1 つの pull request で 6 つの caller（`test-lint.yml`、`gitleaks.yml`、`history-check.yml`、`pr-size.yml`、`review-labels.yml`、`release-sync.yml`）をすべて更新し、末尾の追跡コメント `# ci-v1` は残します。
+4. その pull request の CI が green になってから merge します。
+
+---
+
 ## コントリビュートとテスト
 
 変更提案の流れ・issue-first のルール・コードスタイルは [CONTRIBUTING.md](../CONTRIBUTING.md)（英語）へ。現在の checkout の repository root で、canonical target を通して全 shell suite を実行します。

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -317,14 +317,18 @@ What this project owns, and what it deliberately does not.
 
 ## Updating CI reusable-workflow pins
 
-The six caller workflows pin `caty-ai/family-dev-handbook` reusable workflows to a commit SHA. A mutable `ci-v1` tag at the required merge-gate boundary could change reviewed CI code without a review in this repository; the SHA pins close that supply-chain and review-bypass path. First-party actions were already SHA-pinned.
+The six caller workflows pin `caty-ai/family-dev-handbook` reusable workflows to a commit SHA. A mutable `ci-v1` tag at the required merge-gate boundary could change reviewed CI code without a review in this repository; the SHA pins close that supply-chain and review-bypass path. The `actions/*` steps in this repository's workflows were already SHA-pinned; `repo-state.yml` and `external-input-caller.yml` reference caty-ai reusable workflows by tag/branch and are tracked separately.
 
 When the handbook rolls `ci-v1`:
 
 1. Run `git ls-remote https://github.com/caty-ai/family-dev-handbook.git 'refs/tags/ci-v1*'`.
 2. Because `ci-v1` is an annotated tag, copy the SHA from the exact `refs/tags/ci-v1^{}` line. The plain `refs/tags/ci-v1` line is the tag object; using that SHA in `uses:` breaks reusable-workflow resolution.
-3. In one pull request, update all six callers (`test-lint.yml`, `gitleaks.yml`, `history-check.yml`, `pr-size.yml`, `review-labels.yml`, and `release-sync.yml`) and retain the trailing `# ci-v1` tracking comment.
-4. Merge only after that pull request's CI is green.
+3. Before opening the roll pull request, confirm that all six `reusable-*.yml` files exist at the new peeled SHA (for example, `gh api 'repos/caty-ai/family-dev-handbook/contents/.github/workflows?ref=<new-sha>'`) and review the handbook diff from the old SHA to the new SHA. A roll is still a trust transfer even though the new pin freezes its code.
+4. Re-check each reusable workflow's `permissions:` block against its caller grant because permission needs can widen or narrow. Then, in one pull request, update all six callers (`test-lint.yml`, `gitleaks.yml`, `history-check.yml`, `pr-size.yml`, `review-labels.yml`, and `release-sync.yml`) and retain the trailing `# ci-v1` tracking comment.
+5. The roll pull request's CI exercises only the five pull-request-triggered callers. Because the change touches high-risk `.github/workflows/*` paths, `risk-review-gate` remains red until a roster human applies `risk-reviewed`; that red is a process gate, not evidence of broken workflow code.
+6. Merge only after that pull request's CI is green. `release-sync` runs only for `v*` tag pushes (`on.push.tags`), so after the merge, verify at the next `v*` tag that `release-sync` succeeds and the GitHub Release exists.
+
+Pin rolls are noticed manually through handbook release notes or an occasional `git ls-remote` comparison; no automation watches `ci-v1` movement.
 
 ---
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -315,6 +315,19 @@ What this project owns, and what it deliberately does not.
 
 ---
 
+## Updating CI reusable-workflow pins
+
+The six caller workflows pin `caty-ai/family-dev-handbook` reusable workflows to a commit SHA. A mutable `ci-v1` tag at the required merge-gate boundary could change reviewed CI code without a review in this repository; the SHA pins close that supply-chain and review-bypass path. First-party actions were already SHA-pinned.
+
+When the handbook rolls `ci-v1`:
+
+1. Run `git ls-remote https://github.com/caty-ai/family-dev-handbook.git 'refs/tags/ci-v1*'`.
+2. Because `ci-v1` is an annotated tag, copy the SHA from the exact `refs/tags/ci-v1^{}` line. The plain `refs/tags/ci-v1` line is the tag object; using that SHA in `uses:` breaks reusable-workflow resolution.
+3. In one pull request, update all six callers (`test-lint.yml`, `gitleaks.yml`, `history-check.yml`, `pr-size.yml`, `review-labels.yml`, and `release-sync.yml`) and retain the trailing `# ci-v1` tracking comment.
+4. Merge only after that pull request's CI is green.
+
+---
+
 ## Contributing and tests
 
 Contribution flow, issue-first rules, and code style live in [CONTRIBUTING.md](../CONTRIBUTING.md). From the repository root of the current checkout, run every shell suite through the canonical target:


### PR DESCRIPTION
Closes #245

Pin the six `caty-ai/family-dev-handbook` reusable-workflow references from the mutable `@ci-v1` tag to its current **peeled commit SHA** `8430452c1a22943c805ba2a940a75960299cfb2f` (tracking tag kept as a trailing `# ci-v1` comment), justify `release-sync.yml`'s `contents: write` next to the pin, and document the pin-roll procedure in `docs/engineering.md` / `docs/engineering.ja.md` (hardened per 5-seat review).

Owner-approved posture: SHA pinning (issue-title option, selected 2026-09-01). Note: `ci-v1` is an annotated tag — tag object `79bd3f3`, peeled commit `8430452c...`; `uses:` pins must use the peeled commit.

## Files touched (= WIP declaration, 8 files)

- `.github/workflows/test-lint.yml`
- `.github/workflows/gitleaks.yml`
- `.github/workflows/history-check.yml`
- `.github/workflows/pr-size.yml`
- `.github/workflows/review-labels.yml`
- `.github/workflows/release-sync.yml`
- `docs/engineering.md`
- `docs/engineering.ja.md`

`git diff --stat origin/main...c257fca` = exactly these 8 files (47 insertions / 12 deletions across 2 commits). No undeclared files.

## 完了記録 (L1-7)

**候補 commit SHA: `c257fca`** (= PR head at review completion; `5fcae53` implementation + `c257fca` docs-hardening delta)

### Done when → PASS/FAIL

1. **Six callers pinned to a full commit SHA with tracking-tag comment — PASS.**
   Evidence (2026-09-01): `git ls-remote https://github.com/caty-ai/family-dev-handbook.git 'refs/tags/ci-v1*'` → `79bd3f30... refs/tags/ci-v1` (tag object) / `8430452c... refs/tags/ci-v1^{}` (peeled commit). All six `uses:` lines carry `@8430452c1a22943c805ba2a940a75960299cfb2f # ci-v1`; `grep 'yml@ci-v1' .github/ -r` → 0 hits. All six `reusable-*.yml` exist at that commit (`gh api 'repos/caty-ai/family-dev-handbook/contents/.github/workflows?ref=8430452c...'` → 6 files). Independently re-derived by all 5 review seats.
2. **`release-sync.yml` permissions re-reviewed; `contents: write` justified next to the pin — PASS.**
   Evidence: reusable workflow at the pinned SHA declares `permissions: contents: write` and runs `gh release create --verify-tag`; it contains zero `uses:` steps and no checkout (write token never crosses into tag-controlled code — verified by Opus/GLM/Kimi/Grok seats independently). Justification comment added at `release-sync.yml:12`. Narrowing impossible (caller cannot grant less than the callee declares).
3. **Documented pin-roll procedure — PASS.**
   Evidence: `docs/engineering.md` "Updating CI reusable-workflow pins" + ja mirror (6 steps, en/ja parity verified by 5 seats + delta pass): ls-remote → peeled `^{}` copy (annotated-tag trap named) → existence check + upstream diff review at the new SHA → permissions re-check → 5-of-6 PR-probe scope + risk-reviewed process note → merge-after-green + release-sync verification at next `v*` tag. Anti-rot: manual detection stated honestly (no automation claimed).
4. **All six workflows pass on a probe PR — PASS (5 of 6 on this PR; release-sync structurally tag-only).**
   Evidence: this PR's CI on head `c257fca`: gitleaks PASS / history-check PASS / pr-size PASS / test-lint (lint PASS 6s / test PASS 22m4s / test-macos PASS 29m56s) / risk-review-gate detect+labels PASS — all five PR-triggered reusable workflows resolved and executed at the pinned SHA. `release-sync` triggers only on `v*` tag push (`on.push.tags`); verified at this lane's own release tag immediately after merge (release 欄参照). The `risk-review-gate / risk-review-gate` red before the roster label is the repo's human gate on `.github/workflows/*` (annotation: "high-risk paths changed but the risk-reviewed label is not present"), not a resolution failure.

### 宣言ファイル集合と diff の照合

`git diff --stat origin/main...c257fca` → exactly the 8 declared files above; nothing in the diff is outside the declaration.

### 実装者 / レビュアー

- Implementer: Codex GPT-5.6 Sol (`--profile sol`, sessions: implementation + delta resume), orchestration/inspection: Alpha (Claude Fable 5, session 29e8c072).
- 5-seat heterogeneous review (high-risk area: required merge-gate / supply-chain boundary → 5 seats per L1-11), blind, fresh-context, read-only, on candidate `5fcae53`:
  - **Opus 5** (requested opus / actual claude-opus-5, Agent seat): GO-WITH-CHANGES → delta pass on `c257fca`: **CUMULATIVE GO**
  - **GLM 5.3** (requested/actual glm-5.3): **GO**
  - **Grok 4.6** (requested/actual grok-4.6): **GO**
  - **Kimi K3** (requested/actual kimi-k3): **GO**
  - **Codex GPT-5.6 Sol** (same-family-as-writer seat under the recorded correlated-seats exception, review_council 2026-08-12, 6-field record; fresh read-only session): GO-WITH-CHANGES → delta pass on `c257fca`: **CUMULATIVE GO**
- Adjudication: CRITICAL 0 / MAJOR 1 (Codex: release-sync verification gap in docs — 3-seat convergence with Kimi/Grok MINORs) / adopted 4 changes, all docs-only, shipped as `c257fca`. Follow-up out-of-scope finding (4 seats): `repo-state.yml` mutable ref → issue #256.
- Review records: seat outputs archived in session scratchpad `seats-245/`; this record is the canonical inline summary.

### CI 状態

Head `c257fca` (2026-09-01): gitleaks PASS / history-check PASS / pr-size PASS / repo-state PASS / test-lint lint+test+test-macos PASS (22m4s / 29m56s) / risk-review-gate detect-risk-paths + apply-visibility-labels PASS. Only red: `risk-review-gate / risk-review-gate` — pending the roster human's `risk-reviewed` label (this PR touches `.github/workflows/*` high-risk paths by design; annotation: "high-risk paths changed but the risk-reviewed label is not present"). No unrelated red.

### release

- **release: v0.23.7** (annotated tag + GitHub Release via release-sync on tag push — the tag push also completes Done-when 4's release-sync verification)
- **previous release: v0.23.6** — 履行済み (https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.23.6 — verified existing, published 2026-08-31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
