### PR TITLE
security: SECRETS_ENV hygiene — fail-closed wrapper, $-path audit, reduced hermes step env (#243)

### DIFF
--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -431,23 +431,30 @@ Accepted glued gaps include `echo x|wc`, `2>`, `&>`, `|&`, and `<<`. `TR_PUSH_CM
 move to argv is a breaking contract change, so shell snippets must move into a wrapper
 script with explicit arguments.
 
-`adapters/hermes/spawn_step.sh` no longer passes the provider command the full caller
-environment. That old full-inheritance shape trusted every secret the cron wrapper
-loaded to every provider binary. The provider now runs under `/usr/bin/env -i` with an
-explicit contract only:
+`adapters/hermes/spawn_step.sh` no longer passes the probe or the provider command the
+full caller environment. That old full-inheritance shape trusted every secret the cron
+wrapper loaded to every probe and provider binary. The adapter now reduces its own
+environment in place before the probe runs, then launches the same reduced environment
+for the step. No secret value is copied into a process command line during that handoff.
 
-- Baseline pass-through when set: `PATH`, `HOME`, `TMPDIR`, `LANG`, `LC_ALL`
+- Baseline pass-through when set: `PATH`, `HOME`, `TMPDIR`, `LANG`, `LC_ALL`,
+  `HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`
 - Step-contract vars always passed: `TASK_FILE`, `ARTIFACT_DIR`, `ATTEMPT_DIR`,
   `WORKSPACE`, `HERMES_HTTP_TIMEOUT_S`, `HERMES_STEP_TIMEOUT_S`,
   `HERMES_STEP_GRACE_S`
 - Operator extension: `HERMES_STEP_ENV_ALLOW`, a whitespace-separated list of variable
   names to pass through when those variables are set in the parent environment
 
-Every other parent variable is stripped from the provider invocation. `HERMES_STEP_ENV_ALLOW`
-accepts names only; quotes are not special, and each name must match
-`[A-Za-z_][A-Za-z0-9_]*`. Any invalid name fails the step before launch with an infra
-diagnostic instead of being ignored. Use this extension sparingly and prefer dedicated
-non-secret configuration files where possible.
+Every other parent variable is stripped from both the probe and the provider invocation.
+`HERMES_STEP_ENV_ALLOW` accepts names only; quotes are not special, and each name must
+match `[A-Za-z_][A-Za-z0-9_]*`. Any invalid name fails the step before launch with an
+infra diagnostic naming the rejected identifier instead of ignoring it. Use this
+extension sparingly and prefer dedicated non-secret configuration files where possible.
+
+Migration note: upgrading an existing install drops every parent variable outside that
+explicit contract. The first visible symptom is usually a provider network or auth
+failure on the next cron tick. If a provider still needs one specific parent variable,
+add only that variable name to `HERMES_STEP_ENV_ALLOW`.
 
 When configured, `push.log` persists the push command's combined output. Only shell
 diagnostics whose basename is exactly `task-runner.sh` and that match

--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -404,7 +404,8 @@ the absolute adapter/script path and pass the target arguments after the wrapper
 
 Adapter stdout is now captured per attempt in `attempts/NNN/model.stdout` and no longer appears in the tick log.
 
-`SECRETS_ENV` is optional. When set and present, the wrapper parses it as data-only
+`SECRETS_ENV` is optional. When set, the wrapper fails closed unless the path exists,
+is readable, and passes the data-only validation below. It parses the file as
 `KEY=VALUE`, one assignment per physical line; it does not source or execute the file.
 The file must be owned by the cron user, have `0600` or `0400` permissions, and not be
 a symlink. Interpreter- and loader-control names are refused by a deliberately
@@ -429,6 +430,24 @@ inspected, so glued operator fragments stay literal arguments and are not diagno
 Accepted glued gaps include `echo x|wc`, `2>`, `&>`, `|&`, and `<<`. `TR_PUSH_CMD`'s
 move to argv is a breaking contract change, so shell snippets must move into a wrapper
 script with explicit arguments.
+
+`adapters/hermes/spawn_step.sh` no longer passes the provider command the full caller
+environment. That old full-inheritance shape trusted every secret the cron wrapper
+loaded to every provider binary. The provider now runs under `/usr/bin/env -i` with an
+explicit contract only:
+
+- Baseline pass-through when set: `PATH`, `HOME`, `TMPDIR`, `LANG`, `LC_ALL`
+- Step-contract vars always passed: `TASK_FILE`, `ARTIFACT_DIR`, `ATTEMPT_DIR`,
+  `WORKSPACE`, `HERMES_HTTP_TIMEOUT_S`, `HERMES_STEP_TIMEOUT_S`,
+  `HERMES_STEP_GRACE_S`
+- Operator extension: `HERMES_STEP_ENV_ALLOW`, a whitespace-separated list of variable
+  names to pass through when those variables are set in the parent environment
+
+Every other parent variable is stripped from the provider invocation. `HERMES_STEP_ENV_ALLOW`
+accepts names only; quotes are not special, and each name must match
+`[A-Za-z_][A-Za-z0-9_]*`. Any invalid name fails the step before launch with an infra
+diagnostic instead of being ignored. Use this extension sparingly and prefer dedicated
+non-secret configuration files where possible.
 
 When configured, `push.log` persists the push command's combined output. Only shell
 diagnostics whose basename is exactly `task-runner.sh` and that match

--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -451,6 +451,13 @@ match `[A-Za-z_][A-Za-z0-9_]*`. Any invalid name fails the step before launch wi
 infra diagnostic naming the rejected identifier instead of ignoring it. Use this
 extension sparingly and prefer dedicated non-secret configuration files where possible.
 
+Environment reduction is fail-closed. If the parent shell readonly-exports a variable
+that is not on the keep list, Bash 3.2 cannot unset it, so `spawn_step.sh` exits 111
+before the probe or provider launches and names the surviving variable. Remediation:
+do not `readonly -x` secrets into the cron wrapper environment; keep them in
+`SECRETS_ENV` or pass through only the needed variable names with
+`HERMES_STEP_ENV_ALLOW`.
+
 Migration note: upgrading an existing install drops every parent variable outside that
 explicit contract. The first visible symptom is usually a provider network or auth
 failure on the next cron tick. If a provider still needs one specific parent variable,

--- a/adapters/hermes/spawn_step.sh
+++ b/adapters/hermes/spawn_step.sh
@@ -17,8 +17,11 @@ set -euo pipefail
 # Optional env:
 #   HERMES_PROBE_CMD
 #     Cheap pre-flight reachability check. Failure exits 111 before launch.
+#   HERMES_STEP_ENV_ALLOW
+#     Whitespace-separated environment variable names to pass through to the
+#     provider command when set. Names must match [A-Za-z_][A-Za-z0-9_]*.
 #   HERMES_HTTP_TIMEOUT_S
-#     Exported to the CLI environment. Defaults to 540.
+#     Exported to the provider environment. Defaults to 540.
 #   HERMES_STEP_TIMEOUT_S
 #     Wall-clock limit for the step command. It must stay below the driver's
 #     TR_STEP_TIMEOUT_S (scripts/task-runner.sh), or the driver's hard group
@@ -44,6 +47,14 @@ infra_fail() {
   exit 111
 }
 
+append_step_env_if_set() {
+  local name=$1
+
+  if [[ -n "${!name+x}" ]]; then
+    step_env_vars+=("$name=${!name}")
+  fi
+}
+
 if (($# != 4)); then
   usage
   exit 2
@@ -54,9 +65,13 @@ workspace=$2
 attempt_dir=$3
 step_k=$4
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+# shellcheck disable=SC1091
 source "$repo_root/scripts/lib-classify.sh"
+# shellcheck disable=SC1091
 source "$repo_root/scripts/lib-bounded.sh"
+# shellcheck disable=SC1091
 source "$repo_root/scripts/lib-command-argv.sh"
+# shellcheck disable=SC1091
 source "$repo_root/scripts/lib-pause.sh"
 prompt_file="$attempt_dir/prompt.md"
 
@@ -112,21 +127,27 @@ if [[ -z "${HERMES_STEP_CMD:-}" ]]; then
 fi
 
 if ! validate_cmd_argv HERMES_STEP_CMD "$HERMES_STEP_CMD"; then
+  # shellcheck disable=SC2154
   infra_fail "HERMES_STEP_CMD: $_validated_reason"
 fi
 if ! resolve_cmd_argv0 HERMES_STEP_CMD; then
+  # shellcheck disable=SC2154
   infra_fail "HERMES_STEP_CMD: $_validated_reason"
 fi
+# shellcheck disable=SC2154
 step_argv=("${_validated_argv[@]+"${_validated_argv[@]}"}")
 
 probe_argv=()
 if [[ -n "${HERMES_PROBE_CMD:-}" ]]; then
   if ! validate_cmd_argv HERMES_PROBE_CMD "$HERMES_PROBE_CMD"; then
+    # shellcheck disable=SC2154
     infra_fail "HERMES_PROBE_CMD: $_validated_reason"
   fi
   if ! resolve_cmd_argv0 HERMES_PROBE_CMD; then
+    # shellcheck disable=SC2154
     infra_fail "HERMES_PROBE_CMD: $_validated_reason"
   fi
+  # shellcheck disable=SC2154
   probe_argv=("${_validated_argv[@]+"${_validated_argv[@]}"}")
   cd "$workspace"
   if ! "${probe_argv[@]+"${probe_argv[@]}"}"; then
@@ -140,9 +161,44 @@ fi
 artifact_dir=$(cd "$attempt_dir/.." && cd .. && pwd)
 export TASK_FILE="$task_file" ARTIFACT_DIR="$artifact_dir" ATTEMPT_DIR="$attempt_dir" WORKSPACE="$workspace"
 
+step_env_vars=()
+append_step_env_if_set PATH
+append_step_env_if_set HOME
+append_step_env_if_set TMPDIR
+append_step_env_if_set LANG
+append_step_env_if_set LC_ALL
+step_env_vars+=(
+  "TASK_FILE=$TASK_FILE"
+  "ARTIFACT_DIR=$ARTIFACT_DIR"
+  "ATTEMPT_DIR=$ATTEMPT_DIR"
+  "WORKSPACE=$WORKSPACE"
+  "HERMES_HTTP_TIMEOUT_S=$HERMES_HTTP_TIMEOUT_S"
+  "HERMES_STEP_TIMEOUT_S=$HERMES_STEP_TIMEOUT_S"
+  "HERMES_STEP_GRACE_S=$HERMES_STEP_GRACE_S"
+)
+step_env_allow_had_noglob=0
+case $- in
+  *f*) step_env_allow_had_noglob=1 ;;
+esac
+set -f
+for allowed_name in ${HERMES_STEP_ENV_ALLOW:-}; do
+  if [[ ! "$allowed_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    if (( step_env_allow_had_noglob == 0 )); then
+      set +f
+    fi
+    infra_fail 'HERMES_STEP_ENV_ALLOW contains an invalid variable name'
+  fi
+  append_step_env_if_set "$allowed_name"
+done
+if (( step_env_allow_had_noglob == 0 )); then
+  set +f
+fi
+step_exec_argv=(/usr/bin/env -i "${step_env_vars[@]}" "${step_argv[@]+"${step_argv[@]}"}")
+
 cd "$workspace"
 step_stderr="$attempt_dir/step.stderr"
 step_call_finished=0
+# shellcheck disable=SC2329
 _spawn_step_exit_quarantine() {
   if [[ "${step_call_finished:-0}" -eq 0 ]] && [[ -f "${attempt_dir:-}/step-result.json" ]]; then
     mv -f "$attempt_dir/step-result.json" "$attempt_dir/step-result.json.partial"
@@ -150,7 +206,7 @@ _spawn_step_exit_quarantine() {
 }
 trap _spawn_step_exit_quarantine EXIT
 set +e
-run_bounded "$HERMES_STEP_TIMEOUT_S" "$HERMES_STEP_GRACE_S" "${step_argv[@]+"${step_argv[@]}"}" "$prompt_file" "$attempt_dir" 2>"$step_stderr"
+run_bounded "$HERMES_STEP_TIMEOUT_S" "$HERMES_STEP_GRACE_S" "${step_exec_argv[@]+"${step_exec_argv[@]}"}" "$prompt_file" "$attempt_dir" 2>"$step_stderr"
 step_status=$?
 set -e
 step_call_finished=1

--- a/adapters/hermes/spawn_step.sh
+++ b/adapters/hermes/spawn_step.sh
@@ -74,6 +74,14 @@ reduce_current_exported_environment() {
     fi
     unset -v "$exported_name" 2>/dev/null || true
   done < <(compgen -A export)
+
+  while IFS= read -r exported_name; do
+    [[ -n "$exported_name" ]] || continue
+    if step_env_name_is_kept "$exported_name"; then
+      continue
+    fi
+    infra_fail "environment reduction could not strip: $exported_name"
+  done < <(compgen -A export)
 }
 
 if (($# != 4)); then

--- a/adapters/hermes/spawn_step.sh
+++ b/adapters/hermes/spawn_step.sh
@@ -47,12 +47,33 @@ infra_fail() {
   exit 111
 }
 
-append_step_env_if_set() {
-  local name=$1
+append_step_env_keep_name() {
+  step_env_keep_names+=("$1")
+}
 
-  if [[ -n "${!name+x}" ]]; then
-    step_env_vars+=("$name=${!name}")
-  fi
+step_env_name_is_kept() {
+  local candidate=$1
+  local kept_name
+
+  for kept_name in "${step_env_keep_names[@]+"${step_env_keep_names[@]}"}"; do
+    if [[ "$kept_name" == "$candidate" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+reduce_current_exported_environment() {
+  local exported_name
+
+  while IFS= read -r exported_name; do
+    [[ -n "$exported_name" ]] || continue
+    if step_env_name_is_kept "$exported_name"; then
+      continue
+    fi
+    unset -v "$exported_name" 2>/dev/null || true
+  done < <(compgen -A export)
 }
 
 if (($# != 4)); then
@@ -149,10 +170,6 @@ if [[ -n "${HERMES_PROBE_CMD:-}" ]]; then
   fi
   # shellcheck disable=SC2154
   probe_argv=("${_validated_argv[@]+"${_validated_argv[@]}"}")
-  cd "$workspace"
-  if ! "${probe_argv[@]+"${probe_argv[@]}"}"; then
-    infra_fail 'HERMES_PROBE_CMD failed'
-  fi
 fi
 
 # Weak-model sessions lean on env vars they can echo — export the location
@@ -161,20 +178,23 @@ fi
 artifact_dir=$(cd "$attempt_dir/.." && cd .. && pwd)
 export TASK_FILE="$task_file" ARTIFACT_DIR="$artifact_dir" ATTEMPT_DIR="$attempt_dir" WORKSPACE="$workspace"
 
-step_env_vars=()
-append_step_env_if_set PATH
-append_step_env_if_set HOME
-append_step_env_if_set TMPDIR
-append_step_env_if_set LANG
-append_step_env_if_set LC_ALL
-step_env_vars+=(
-  "TASK_FILE=$TASK_FILE"
-  "ARTIFACT_DIR=$ARTIFACT_DIR"
-  "ATTEMPT_DIR=$ATTEMPT_DIR"
-  "WORKSPACE=$WORKSPACE"
-  "HERMES_HTTP_TIMEOUT_S=$HERMES_HTTP_TIMEOUT_S"
-  "HERMES_STEP_TIMEOUT_S=$HERMES_STEP_TIMEOUT_S"
-  "HERMES_STEP_GRACE_S=$HERMES_STEP_GRACE_S"
+export HERMES_HTTP_TIMEOUT_S HERMES_STEP_TIMEOUT_S HERMES_STEP_GRACE_S
+step_env_keep_names=(
+  PATH
+  HOME
+  TMPDIR
+  LANG
+  LC_ALL
+  HTTPS_PROXY
+  HTTP_PROXY
+  ALL_PROXY
+  TASK_FILE
+  ARTIFACT_DIR
+  ATTEMPT_DIR
+  WORKSPACE
+  HERMES_HTTP_TIMEOUT_S
+  HERMES_STEP_TIMEOUT_S
+  HERMES_STEP_GRACE_S
 )
 step_env_allow_had_noglob=0
 case $- in
@@ -186,16 +206,28 @@ for allowed_name in ${HERMES_STEP_ENV_ALLOW:-}; do
     if (( step_env_allow_had_noglob == 0 )); then
       set +f
     fi
-    infra_fail 'HERMES_STEP_ENV_ALLOW contains an invalid variable name'
+    infra_fail "HERMES_STEP_ENV_ALLOW contains an invalid variable name: $allowed_name"
   fi
-  append_step_env_if_set "$allowed_name"
+  append_step_env_keep_name "$allowed_name"
 done
 if (( step_env_allow_had_noglob == 0 )); then
   set +f
 fi
-step_exec_argv=(/usr/bin/env -i "${step_env_vars[@]}" "${step_argv[@]+"${step_argv[@]}"}")
+
+export -n task_file workspace attempt_dir step_k repo_root prompt_file artifact_dir \
+  pause_state step_env_allow_had_noglob allowed_name step_stderr step_call_finished \
+  failure_class step_status nul_line 2>/dev/null || true
+export -n step_argv probe_argv step_env_keep_names 2>/dev/null || true
+
+reduce_current_exported_environment
 
 cd "$workspace"
+if [[ ${#probe_argv[@]} -gt 0 ]]; then
+  if ! "${probe_argv[@]+"${probe_argv[@]}"}"; then
+    infra_fail 'HERMES_PROBE_CMD failed'
+  fi
+fi
+
 step_stderr="$attempt_dir/step.stderr"
 step_call_finished=0
 # shellcheck disable=SC2329
@@ -206,7 +238,7 @@ _spawn_step_exit_quarantine() {
 }
 trap _spawn_step_exit_quarantine EXIT
 set +e
-run_bounded "$HERMES_STEP_TIMEOUT_S" "$HERMES_STEP_GRACE_S" "${step_exec_argv[@]+"${step_exec_argv[@]}"}" "$prompt_file" "$attempt_dir" 2>"$step_stderr"
+run_bounded "$HERMES_STEP_TIMEOUT_S" "$HERMES_STEP_GRACE_S" "${step_argv[@]+"${step_argv[@]}"}" "$prompt_file" "$attempt_dir" 2>"$step_stderr"
 step_status=$?
 set -e
 step_call_finished=1

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -133,6 +133,23 @@ fold 経路は workspace につき 1 本だけです。この consumer か、Ope
 
 詳しいセットアップ手順・ledger の形式・schedule の詳細は [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) を参照してください。
 
+<a id="accepted-risk-cron-wrapper-secrets-env-race"></a>
+
+### Accepted risk: cron wrapper `SECRETS_ENV` race
+
+チェックイン済みの cron wrapper は `SECRETS_ENV` を open 前後で検証しますが、portable な
+Bash 3.2 では依然として `O_NOFOLLOW` 付きで path を open できません。したがって、同じ
+実行 user としてすでに filesystem write 権限を持つ local attacker は、その検証と実際の
+open/read の境界のあいだで path replacement race をまだ狙えます。
+
+この risk は現時点では受容します。残る window は狭く、実際の前提条件として attacker は
+もともとその invoking user の filesystem context に書き込めなければならず、wrapper 自体も
+より安価な abuse class には fail closed します: symlink、owner mismatch、missing /
+unreadable file、open 後の identity drift、embedded NUL、data-only でない assignment です。
+この residual window を完全になくすには、Bash 3.2 が expose していない substrate が必要です。
+したがってこの accepted-risk record は「race が消えた」という主張ではなく、documentation と
+fail-closed guardrail の明文化です。
+
 ### Overflow sentinel
 
 Claude Code の step adapter は、passive な overflow sentinel を opt-in で利用できます。

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -154,6 +154,23 @@ Exactly one fold route may run per workspace: this consumer, or OpenClaw's `dist
 
 See [adapters/claude-code/INSTALL.md](../adapters/claude-code/INSTALL.md) for the full setup steps, ledger format, and scheduling detail.
 
+<a id="accepted-risk-cron-wrapper-secrets-env-race"></a>
+
+### Accepted risk: cron wrapper `SECRETS_ENV` race
+
+The checked-in cron wrapper validates `SECRETS_ENV` before and after opening it, but on
+portable Bash 3.2 it still cannot open the path with `O_NOFOLLOW`. A local attacker who
+already has filesystem-write access as the same invoking user could still race the path
+replacement between those checks and the actual open/read boundary.
+
+This risk is accepted for now because the remaining window is narrow, every practical
+deployment already requires the attacker to write into the invoking user's filesystem
+context, and the current wrapper already fails closed on the cheaper classes of abuse:
+symlinks, ownership mismatch, unreadable or missing files, post-open identity drift,
+embedded NUL, and non-data assignments. Eliminating the residual window would require a
+different implementation substrate than Bash 3.2 exposes. The accepted-risk record is
+therefore documentation plus fail-closed guardrails, not a claim that the race is gone.
+
 ### Overflow sentinel
 
 The Claude Code step adapter can opt into a passive overflow sentinel. It tails

--- a/install.sh
+++ b/install.sh
@@ -629,8 +629,12 @@ $shape_reasons
 EOF
     return 0
   fi
+  if [[ ! -e "$secrets_file" ]]; then
+    printf 'FAIL: cron wrapper %s SECRETS_ENV file not found: %s\n' "$wrapper_rel" "$secrets_file" >&2
+    return 1
+  fi
   if [[ ! -f "$secrets_file" ]]; then
-    printf 'warning: cron wrapper %s SECRETS_ENV file not found: %s\n' "$wrapper_rel" "$secrets_file" >&2
+    printf 'warning: cron wrapper %s SECRETS_ENV must be a regular file: %s\n' "$wrapper_rel" "$secrets_file" >&2
     return 0
   fi
 
@@ -650,6 +654,11 @@ EOF
 $shape_reasons
 EOF
 
+  if [[ ! -r "$secrets_file" ]]; then
+    printf 'FAIL: cron wrapper %s SECRETS_ENV file is not readable: %s\n' "$wrapper_rel" "$secrets_file" >&2
+    return 1
+  fi
+
   if ! nul_line=$(secrets_env_first_nul_line "$secrets_file"); then
     printf 'warning: cron wrapper %s SECRETS_ENV could not be scanned for embedded NUL bytes: %s\n' "$wrapper_rel" "$secrets_file" >&2
     return 0
@@ -660,8 +669,8 @@ EOF
   fi
 
   if ! exec 8<"$secrets_file"; then
-    printf 'warning: cron wrapper %s SECRETS_ENV file is not readable: %s\n' "$wrapper_rel" "$secrets_file" >&2
-    return 0
+    printf 'FAIL: cron wrapper %s SECRETS_ENV file is not readable: %s\n' "$wrapper_rel" "$secrets_file" >&2
+    return 1
   fi
   while IFS= read -r -u 8 raw_line || [[ -n "$raw_line" ]]; do
     line_number=$((line_number + 1))
@@ -696,6 +705,41 @@ EOF
   exec 8<&-
 }
 
+resolve_wrapper_secrets_env_audit_path() {
+  local secrets_assignment=$1
+  local resolved=$secrets_assignment
+  local home_value=${HOME:-}
+  local prefix suffix next_char
+  local home_brace_pattern="\${HOME}"
+  local home_plain_pattern="\$HOME"
+
+  if [[ -n "$home_value" ]]; then
+    while [[ "$resolved" == *"$home_brace_pattern"* ]]; do
+      prefix=${resolved%%"$home_brace_pattern"*}
+      suffix=${resolved#*"$home_brace_pattern"}
+      resolved=$prefix$home_value$suffix
+    done
+
+    while [[ "$resolved" == *"$home_plain_pattern"* ]]; do
+      prefix=${resolved%%"$home_plain_pattern"*}
+      suffix=${resolved#*"$home_plain_pattern"}
+      next_char=${suffix:0:1}
+      if [[ -z "$next_char" || ! "$next_char" =~ [A-Za-z0-9_] ]]; then
+        resolved=$prefix$home_value$suffix
+      else
+        resolved=$prefix$home_plain_pattern$suffix
+        break
+      fi
+    done
+  fi
+
+  if [[ "$resolved" == *'$'* ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "$resolved"
+}
+
 extract_wrapper_secrets_env() {
   local wrapper=$1
 
@@ -718,19 +762,38 @@ check_cron_wrappers() {
   local workspace=$1
   local scripts_dir="$workspace/scripts"
   local wrapper
-  local secrets_file
+  local secrets_assignment secrets_file
+  local wrapper_rel
+  local failures=0
+  local unauditable_count=0
 
   [[ -d "$scripts_dir" ]] || return 0
 
   while IFS= read -r wrapper; do
     [[ -n "$wrapper" ]] || continue
     if grep -Fq '# fable-loop cron wrapper template v1' "$wrapper"; then
-      secrets_file=$(extract_wrapper_secrets_env "$wrapper")
-      if [[ -n "$secrets_file" && "$secrets_file" != *'$'* ]]; then
-        check_secrets_env_file "$workspace" "$secrets_file" "$wrapper"
+      secrets_assignment=$(extract_wrapper_secrets_env "$wrapper")
+      if [[ -z "$secrets_assignment" ]]; then
+        continue
+      fi
+      if secrets_file=$(resolve_wrapper_secrets_env_audit_path "$secrets_assignment"); then
+        if ! check_secrets_env_file "$workspace" "$secrets_file" "$wrapper"; then
+          failures=1
+        fi
+      else
+        wrapper_rel=$(print_relative "$workspace" "$wrapper")
+        printf 'warning: cron wrapper %s SECRETS_ENV unauditable - manual check required: SECRETS_ENV=%s\n' \
+          "$wrapper_rel" "$secrets_assignment" >&2
+        unauditable_count=$((unauditable_count + 1))
       fi
     fi
   done < <(find "$scripts_dir" -type f -print)
+
+  if (( unauditable_count > 0 )); then
+    printf 'warning: cron wrapper SECRETS_ENV unauditable count: %s\n' "$unauditable_count" >&2
+  fi
+
+  return "$failures"
 }
 
 check_instruction_files() {
@@ -999,6 +1062,7 @@ probe_adapter_distiller_cron() {
 
   case "$adapter" in
     claude-code|codex|kimi)
+      # shellcheck disable=SC2016
       probe_executable_contains "$repo_root/adapters/claude-code/flush-intake.sh" \
         'source "$repo_root/scripts/flush-intake.sh"' \
         && grep -Fq -- "snapshot_pending_dedup_keys \"\$pending_dir\"" \
@@ -1335,7 +1399,9 @@ EOF
     done
   done < <(find "$workspace/skills" -type f -name 'SKILL.md' -print 2>/dev/null)
 
-  check_cron_wrappers "$workspace"
+  if ! check_cron_wrappers "$workspace"; then
+    failures=1
+  fi
   check_instruction_files "$workspace"
   check_raw_review "$workspace"
   check_learning_paths

--- a/install.sh
+++ b/install.sh
@@ -612,6 +612,7 @@ check_secrets_env_file() {
   local workspace=$1
   local secrets_file=$2
   local source_file=$3
+  local home_resolution_note=${4:-}
   local wrapper_rel
   local shape_reasons shape_reason mode
   local nul_line
@@ -623,19 +624,19 @@ check_secrets_env_file() {
     shape_reasons=$(secrets_env_file_shape_reasons "$secrets_file")
     while IFS= read -r shape_reason; do
       [[ -n "$shape_reason" ]] || continue
-      printf 'warning: cron wrapper %s SECRETS_ENV %s: %s\n' "$wrapper_rel" "$shape_reason" "$secrets_file" >&2
+      printf 'FAIL: cron wrapper %s SECRETS_ENV %s: %s%s\n' "$wrapper_rel" "$shape_reason" "$secrets_file" "$home_resolution_note" >&2
     done <<EOF
 $shape_reasons
 EOF
-    return 0
+    return 1
   fi
   if [[ ! -e "$secrets_file" ]]; then
-    printf 'FAIL: cron wrapper %s SECRETS_ENV file not found: %s\n' "$wrapper_rel" "$secrets_file" >&2
+    printf 'FAIL: cron wrapper %s SECRETS_ENV file not found: %s%s\n' "$wrapper_rel" "$secrets_file" "$home_resolution_note" >&2
     return 1
   fi
   if [[ ! -f "$secrets_file" ]]; then
-    printf 'warning: cron wrapper %s SECRETS_ENV must be a regular file: %s\n' "$wrapper_rel" "$secrets_file" >&2
-    return 0
+    printf 'FAIL: cron wrapper %s SECRETS_ENV must be a regular file: %s%s\n' "$wrapper_rel" "$secrets_file" "$home_resolution_note" >&2
+    return 1
   fi
 
   shape_reasons=$(secrets_env_file_shape_reasons "$secrets_file")
@@ -655,7 +656,7 @@ $shape_reasons
 EOF
 
   if [[ ! -r "$secrets_file" ]]; then
-    printf 'FAIL: cron wrapper %s SECRETS_ENV file is not readable: %s\n' "$wrapper_rel" "$secrets_file" >&2
+    printf 'FAIL: cron wrapper %s SECRETS_ENV file is not readable: %s%s\n' "$wrapper_rel" "$secrets_file" "$home_resolution_note" >&2
     return 1
   fi
 
@@ -669,7 +670,7 @@ EOF
   fi
 
   if ! exec 8<"$secrets_file"; then
-    printf 'FAIL: cron wrapper %s SECRETS_ENV file is not readable: %s\n' "$wrapper_rel" "$secrets_file" >&2
+    printf 'FAIL: cron wrapper %s SECRETS_ENV file is not readable: %s%s\n' "$wrapper_rel" "$secrets_file" "$home_resolution_note" >&2
     return 1
   fi
   while IFS= read -r -u 8 raw_line || [[ -n "$raw_line" ]]; do
@@ -705,33 +706,84 @@ EOF
   exec 8<&-
 }
 
-resolve_wrapper_secrets_env_audit_path() {
+trim_wrapper_secrets_env_value() {
+  local value=$1
+
+  value=${value#"${value%%[![:space:]]*}"}
+  case "$value" in
+    *[![:space:]]*)
+      value=${value%"${value##*[![:space:]]}"}
+      ;;
+    *)
+      value=
+      ;;
+  esac
+
+  printf '%s\n' "$value"
+}
+
+strip_wrapper_secrets_env_comment() {
+  local value=$1
+  local idx char quote='' prev_char=''
+
+  for (( idx=0; idx<${#value}; idx++ )); do
+    char=${value:idx:1}
+    if [[ -z "$quote" ]]; then
+      case "$char" in
+        "'"|'"'|'`')
+          quote=$char
+          ;;
+        '#')
+          if [[ "$prev_char" =~ [[:space:]] ]]; then
+            value=${value:0:idx}
+            break
+          fi
+          ;;
+      esac
+    elif [[ "$char" == "$quote" ]]; then
+      quote=
+    fi
+    prev_char=$char
+  done
+
+  trim_wrapper_secrets_env_value "$value"
+}
+
+wrapper_secrets_env_home_note() {
   local secrets_assignment=$1
-  local resolved=$secrets_assignment
-  local home_value=${HOME:-}
-  local prefix suffix next_char
   local home_brace_pattern="\${HOME}"
-  local home_plain_pattern="\$HOME"
 
-  if [[ -n "$home_value" ]]; then
-    while [[ "$resolved" == *"$home_brace_pattern"* ]]; do
-      prefix=${resolved%%"$home_brace_pattern"*}
-      suffix=${resolved#*"$home_brace_pattern"}
-      resolved=$prefix$home_value$suffix
-    done
-
-    while [[ "$resolved" == *"$home_plain_pattern"* ]]; do
-      prefix=${resolved%%"$home_plain_pattern"*}
-      suffix=${resolved#*"$home_plain_pattern"}
-      next_char=${suffix:0:1}
-      if [[ -z "$next_char" || ! "$next_char" =~ [A-Za-z0-9_] ]]; then
-        resolved=$prefix$home_value$suffix
-      else
-        resolved=$prefix$home_plain_pattern$suffix
-        break
-      fi
-    done
+  if [[ "$secrets_assignment" == *"$home_brace_pattern"* ]] \
+    || [[ "$secrets_assignment" =~ \$HOME([^A-Za-z0-9_]|$) ]]; then
+    printf ' (resolution uses the checking process HOME and may differ under sudo/other users)'
   fi
+}
+
+substitute_wrapper_home_tokens() {
+  local value=$1
+  local home_value=${HOME:-}
+  local resolved=
+  local cursor=0
+  local remaining token_suffix
+
+  while (( cursor < ${#value} )); do
+    remaining=${value:cursor}
+    if [[ "$remaining" == "\${HOME}"* ]]; then
+      resolved=$resolved$home_value
+      cursor=$((cursor + 7))
+      continue
+    fi
+    if [[ "$remaining" == "\$HOME"* ]]; then
+      token_suffix=${remaining:5:1}
+      if [[ -z "$token_suffix" || ! "$token_suffix" =~ [A-Za-z0-9_] ]]; then
+        resolved=$resolved$home_value
+        cursor=$((cursor + 5))
+        continue
+      fi
+    fi
+    resolved=$resolved${value:cursor:1}
+    cursor=$((cursor + 1))
+  done
 
   if [[ "$resolved" == *'$'* ]]; then
     return 1
@@ -740,22 +792,66 @@ resolve_wrapper_secrets_env_audit_path() {
   printf '%s\n' "$resolved"
 }
 
+resolve_wrapper_secrets_env_audit_path() {
+  local secrets_assignment=$1
+  local stripped_assignment first_char last_char inner_value
+
+  stripped_assignment=$(strip_wrapper_secrets_env_comment "$secrets_assignment")
+  WRAPPER_SECRETS_ENV_HOME_NOTE=$(wrapper_secrets_env_home_note "$stripped_assignment")
+  WRAPPER_SECRETS_ENV_AUDIT_PATH=
+
+  if [[ -z "$stripped_assignment" ]]; then
+    return 1
+  fi
+  if [[ "$stripped_assignment" == *'`'* ]]; then
+    return 1
+  fi
+
+  first_char=${stripped_assignment:0:1}
+  last_char=${stripped_assignment: -1}
+
+  if [[ "$stripped_assignment" != *"'"* && "$stripped_assignment" != *'"'* ]]; then
+    if ! WRAPPER_SECRETS_ENV_AUDIT_PATH=$(substitute_wrapper_home_tokens "$stripped_assignment"); then
+      return 1
+    fi
+    return 0
+  fi
+
+  if (( ${#stripped_assignment} >= 2 )) && [[ "$first_char" == '"' && "$last_char" == '"' ]]; then
+    inner_value=${stripped_assignment:1:${#stripped_assignment}-2}
+    if [[ "$inner_value" == *'"'* || "$inner_value" == *"'"* || "$inner_value" == *'`'* ]]; then
+      return 1
+    fi
+    if ! WRAPPER_SECRETS_ENV_AUDIT_PATH=$(substitute_wrapper_home_tokens "$inner_value"); then
+      return 1
+    fi
+    return 0
+  fi
+
+  if (( ${#stripped_assignment} >= 2 )) && [[ "$first_char" == "'" && "$last_char" == "'" ]]; then
+    inner_value=${stripped_assignment:1:${#stripped_assignment}-2}
+    if [[ "$inner_value" == *'"'* || "$inner_value" == *"'"* || "$inner_value" == *'`'* ]]; then
+      return 1
+    fi
+    WRAPPER_SECRETS_ENV_HOME_NOTE=
+    WRAPPER_SECRETS_ENV_AUDIT_PATH=$inner_value
+    return 0
+  fi
+
+  return 1
+}
+
 extract_wrapper_secrets_env() {
   local wrapper=$1
+  local line assignment
 
-  awk '
-    /^[[:space:]]*SECRETS_ENV=/ {
-      line = $0
-      sub(/^[[:space:]]*SECRETS_ENV=/, "", line)
-      sub(/[[:space:]]+#.*$/, "", line)
-      sub(/^[[:space:]]+/, "", line)
-      sub(/[[:space:]]+$/, "", line)
-      gsub(/^"|"$/, "", line)
-      gsub(/^'\''|'\''$/, "", line)
-      print line
-      exit
-    }
-  ' "$wrapper"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" =~ ^[[:space:]]*SECRETS_ENV= ]]; then
+      assignment=${line#*=}
+      trim_wrapper_secrets_env_value "$assignment"
+      return 0
+    fi
+  done <"$wrapper"
 }
 
 check_cron_wrappers() {
@@ -766,6 +862,7 @@ check_cron_wrappers() {
   local wrapper_rel
   local failures=0
   local unauditable_count=0
+  local home_resolution_note
 
   [[ -d "$scripts_dir" ]] || return 0
 
@@ -776,14 +873,17 @@ check_cron_wrappers() {
       if [[ -z "$secrets_assignment" ]]; then
         continue
       fi
-      if secrets_file=$(resolve_wrapper_secrets_env_audit_path "$secrets_assignment"); then
-        if ! check_secrets_env_file "$workspace" "$secrets_file" "$wrapper"; then
+      if resolve_wrapper_secrets_env_audit_path "$secrets_assignment"; then
+        secrets_file=$WRAPPER_SECRETS_ENV_AUDIT_PATH
+        home_resolution_note=${WRAPPER_SECRETS_ENV_HOME_NOTE:-}
+        if ! check_secrets_env_file "$workspace" "$secrets_file" "$wrapper" "$home_resolution_note"; then
           failures=1
         fi
       else
         wrapper_rel=$(print_relative "$workspace" "$wrapper")
-        printf 'warning: cron wrapper %s SECRETS_ENV unauditable - manual check required: SECRETS_ENV=%s\n' \
-          "$wrapper_rel" "$secrets_assignment" >&2
+        home_resolution_note=${WRAPPER_SECRETS_ENV_HOME_NOTE:-}
+        printf 'warning: cron wrapper %s SECRETS_ENV unauditable - manual check required: SECRETS_ENV=%s%s\n' \
+          "$wrapper_rel" "$secrets_assignment" "$home_resolution_note" >&2
         unauditable_count=$((unauditable_count + 1))
       fi
     fi

--- a/install.sh
+++ b/install.sh
@@ -844,11 +844,20 @@ resolve_wrapper_secrets_env_audit_path() {
 extract_wrapper_secrets_env() {
   local wrapper=$1
   local line assignment
+  local default_rhs_braced="\${SECRETS_ENV:-}"
+  local default_rhs_plain="\${SECRETS_ENV-}"
+  local default_rhs_braced_quoted="\"\${SECRETS_ENV:-}\""
+  local default_rhs_plain_quoted="\"\${SECRETS_ENV-}\""
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     if [[ "$line" =~ ^[[:space:]]*SECRETS_ENV= ]]; then
       assignment=${line#*=}
-      trim_wrapper_secrets_env_value "$assignment"
+      assignment=$(trim_wrapper_secrets_env_value "$assignment")
+      if [[ "$assignment" == "$default_rhs_braced" || "$assignment" == "$default_rhs_plain" \
+        || "$assignment" == "$default_rhs_braced_quoted" || "$assignment" == "$default_rhs_plain_quoted" ]]; then
+        continue
+      fi
+      printf '%s\n' "$assignment"
       return 0
     fi
   done <"$wrapper"

--- a/templates/cron-wrapper.tmpl.sh
+++ b/templates/cron-wrapper.tmpl.sh
@@ -18,7 +18,8 @@ set -euo pipefail
 # are refused by scripts/lib-secrets-env.sh, which must be installed beside the
 # pause helper. The refusal list is a hazard guard, not an exhaustive safety
 # boundary. Portable Bash 3.2 cannot open with O_NOFOLLOW, so a residual path
-# replacement race remains despite the pre/post-open identity checks.
+# replacement race remains despite the pre/post-open identity checks; accepted
+# risk record: docs/engineering.md#accepted-risk-cron-wrapper-secrets-env-race.
 
 fail() {
   printf 'cron-wrapper infra error: %s\n' "$1" >&2
@@ -214,36 +215,44 @@ if [[ -n "$SECRETS_ENV" ]]; then
   if [[ -L "$SECRETS_ENV" ]]; then
     validate_secrets_env "$SECRETS_ENV"
   fi
-  if [[ -f "$SECRETS_ENV" ]]; then
-    validate_secrets_env "$SECRETS_ENV"
-
-    if ! exec 9<"$SECRETS_ENV"; then
-      fail "SECRETS_ENV is not readable: $SECRETS_ENV"
-    fi
-    if [[ -L "$SECRETS_ENV" ]] || ! same_open_file "$SECRETS_ENV" /dev/fd/9; then
-      exec 9<&-
-      fail "SECRETS_ENV changed while opening: $SECRETS_ENV"
-    fi
-
-    validate_secrets_env "$SECRETS_ENV"
-
-    if ! nul_line=$(secrets_env_first_nul_line "$SECRETS_ENV"); then
-      exec 9<&-
-      fail "SECRETS_ENV could not be scanned for embedded NUL bytes: $SECRETS_ENV"
-    fi
-    if [[ -n "$nul_line" ]]; then
-      exec 9<&-
-      fail "SECRETS_ENV line $nul_line contains an embedded NUL byte: $SECRETS_ENV"
-    fi
-
-    if [[ -L "$SECRETS_ENV" ]] || ! same_open_file "$SECRETS_ENV" /dev/fd/9; then
-      exec 9<&-
-      fail "SECRETS_ENV changed while validating: $SECRETS_ENV"
-    fi
-
-    parse_secrets_env "$SECRETS_ENV"
-    exec 9<&-
+  if [[ ! -e "$SECRETS_ENV" ]]; then
+    fail "SECRETS_ENV file not found: $SECRETS_ENV"
   fi
+  if [[ ! -f "$SECRETS_ENV" ]]; then
+    fail "SECRETS_ENV must be a regular file: $SECRETS_ENV"
+  fi
+
+  validate_secrets_env "$SECRETS_ENV"
+
+  if [[ ! -r "$SECRETS_ENV" ]]; then
+    fail "SECRETS_ENV is not readable: $SECRETS_ENV"
+  fi
+  if ! exec 9<"$SECRETS_ENV"; then
+    fail "SECRETS_ENV is not readable: $SECRETS_ENV"
+  fi
+  if [[ -L "$SECRETS_ENV" ]] || ! same_open_file "$SECRETS_ENV" /dev/fd/9; then
+    exec 9<&-
+    fail "SECRETS_ENV changed while opening: $SECRETS_ENV"
+  fi
+
+  validate_secrets_env "$SECRETS_ENV"
+
+  if ! nul_line=$(secrets_env_first_nul_line "$SECRETS_ENV"); then
+    exec 9<&-
+    fail "SECRETS_ENV could not be scanned for embedded NUL bytes: $SECRETS_ENV"
+  fi
+  if [[ -n "$nul_line" ]]; then
+    exec 9<&-
+    fail "SECRETS_ENV line $nul_line contains an embedded NUL byte: $SECRETS_ENV"
+  fi
+
+  if [[ -L "$SECRETS_ENV" ]] || ! same_open_file "$SECRETS_ENV" /dev/fd/9; then
+    exec 9<&-
+    fail "SECRETS_ENV changed while validating: $SECRETS_ENV"
+  fi
+
+  parse_secrets_env "$SECRETS_ENV"
+  exec 9<&-
 fi
 
 if [[ "$TARGET" != /* || ! -x "$TARGET" ]]; then

--- a/tests/cron-wrapper-path.test.sh
+++ b/tests/cron-wrapper-path.test.sh
@@ -24,6 +24,31 @@ fail_case() {
   printf 'FAIL %s: %s\n' "$1" "$2"
 }
 
+seed_check_workspace() {
+  local name=$1
+  local workspace=$TMP_ROOT/check-$name
+
+  "$ROOT/install.sh" --workspace "$workspace" >/dev/null 2>&1
+  printf '%s\n' '- fixture; 2026-09-01T00:00' >>"$workspace/STATE.md"
+  printf '%s\n' '- 2026-09-01 | task=fixture | verifier=test | verdict=pass | fixture' >>"$workspace/loop/VERIFY.log.md"
+  printf '%s\n' "$workspace"
+}
+
+install_wrapper_with_secrets_assignment() {
+  local workspace=$1
+  local wrapper_name=$2
+  local secrets_assignment=$3
+  local wrapper=$workspace/scripts/$wrapper_name
+
+  mkdir -p "$workspace/scripts"
+  awk -v secrets_assignment="$secrets_assignment" '
+    NR == 2 { printf "SECRETS_ENV=%s\n", secrets_assignment }
+    { print }
+  ' "$CRON_WRAPPER" >"$wrapper"
+  chmod +x "$wrapper"
+  printf '%s\n' "$wrapper"
+}
+
 capture_run() {
   local key=$1
   shift
@@ -147,6 +172,61 @@ if [[ "$CAPTURE_RC" -eq 3 \
 else
   fail_case 'updater wrapper accepts valid missing directory and reaches next precondition' \
     "rc=$CAPTURE_RC stderr=$(cat "$CAPTURE_STDERR")"
+fi
+
+check_workspace=$(seed_check_workspace home-resolution)
+fake_home=$TMP_ROOT/fake-home
+mkdir -p "$fake_home"
+home_secret=$fake_home/home-resolution.env
+printf 'GOOD=plain\n' >"$home_secret"
+chmod 644 "$home_secret"
+install_wrapper_with_secrets_assignment "$check_workspace" cron-home-resolution.sh '"$HOME/home-resolution.env"' >/dev/null
+set +e
+home_output=$(HOME="$fake_home" "$ROOT/install.sh" --check --workspace "$check_workspace" 2>&1)
+home_rc=$?
+set -e
+if [[ "$home_rc" -eq 0 \
+  && "$home_output" == *"warning: cron wrapper scripts/cron-home-resolution.sh SECRETS_ENV permissions should be 0600 or 0400: $home_secret has 644"* \
+  && "$home_output" != *'unauditable - manual check required'* ]]; then
+  pass 'install check resolves $HOME SECRETS_ENV paths and audits the resolved file'
+else
+  fail_case 'install check resolves $HOME SECRETS_ENV paths and audits the resolved file' \
+    "rc=$home_rc output=$home_output"
+fi
+
+check_workspace=$(seed_check_workspace home-brace-resolution)
+brace_secret=$fake_home/home-brace-resolution.env
+printf 'GOOD=plain\n' >"$brace_secret"
+chmod 644 "$brace_secret"
+install_wrapper_with_secrets_assignment "$check_workspace" cron-home-brace-resolution.sh '"${HOME}/home-brace-resolution.env"' >/dev/null
+set +e
+brace_output=$(HOME="$fake_home" "$ROOT/install.sh" --check --workspace "$check_workspace" 2>&1)
+brace_rc=$?
+set -e
+if [[ "$brace_rc" -eq 0 \
+  && "$brace_output" == *"warning: cron wrapper scripts/cron-home-brace-resolution.sh SECRETS_ENV permissions should be 0600 or 0400: $brace_secret has 644"* \
+  && "$brace_output" != *'unauditable - manual check required'* ]]; then
+  pass 'install check resolves ${HOME} SECRETS_ENV paths and audits the resolved file'
+else
+  fail_case 'install check resolves ${HOME} SECRETS_ENV paths and audits the resolved file' \
+    "rc=$brace_rc output=$brace_output"
+fi
+
+check_workspace=$(seed_check_workspace unresolved-dollar)
+install_wrapper_with_secrets_assignment "$check_workspace" cron-unresolved.sh '"$SECRETS_DIR/unresolved.env"' >/dev/null
+install_wrapper_with_secrets_assignment "$check_workspace" cron-home-boundary.sh '"$HOMELESS/not-home.env"' >/dev/null
+set +e
+unresolved_output=$("$ROOT/install.sh" --check --workspace "$check_workspace" 2>&1)
+unresolved_rc=$?
+set -e
+if [[ "$unresolved_rc" -eq 0 \
+  && "$unresolved_output" == *'warning: cron wrapper scripts/cron-unresolved.sh SECRETS_ENV unauditable - manual check required: SECRETS_ENV=$SECRETS_DIR/unresolved.env'* \
+  && "$unresolved_output" == *'warning: cron wrapper scripts/cron-home-boundary.sh SECRETS_ENV unauditable - manual check required: SECRETS_ENV=$HOMELESS/not-home.env'* \
+  && "$unresolved_output" == *'warning: cron wrapper SECRETS_ENV unauditable count: 2'* ]]; then
+  pass 'install check reports unresolved dollar paths and $HOME boundary misses as unauditable with a summary count'
+else
+  fail_case 'install check reports unresolved dollar paths and $HOME boundary misses as unauditable with a summary count' \
+    "rc=$unresolved_rc output=$unresolved_output"
 fi
 
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"

--- a/tests/cron-wrapper-path.test.sh
+++ b/tests/cron-wrapper-path.test.sh
@@ -50,6 +50,23 @@ install_wrapper_with_secrets_assignment() {
   printf '%s\n' "$wrapper"
 }
 
+insert_wrapper_secrets_assignment_after_default() {
+  local workspace=$1
+  local wrapper_name=$2
+  local secrets_assignment=$3
+  local wrapper=$workspace/scripts/$wrapper_name
+
+  mkdir -p "$workspace/scripts"
+  awk -v secrets_assignment="$secrets_assignment" '
+    { print }
+    $0 == "SECRETS_ENV=${SECRETS_ENV:-}" {
+      printf "SECRETS_ENV=%s\n", secrets_assignment
+    }
+  ' "$CRON_WRAPPER" >"$wrapper"
+  chmod +x "$wrapper"
+  printf '%s\n' "$wrapper"
+}
+
 capture_run() {
   local key=$1
   shift
@@ -225,6 +242,41 @@ if [[ "$home_missing_rc" -ne 0 \
 else
   fail_case 'install check appends the HOME-resolution note on resolved FAIL diagnostics' \
     "rc=$home_missing_rc output=$home_missing_output"
+fi
+
+check_workspace=$(seed_check_workspace pristine-template-default)
+mkdir -p "$check_workspace/scripts"
+cp "$CRON_WRAPPER" "$check_workspace/scripts/cron-pristine.sh"
+chmod +x "$check_workspace/scripts/cron-pristine.sh"
+set +e
+pristine_output=$("$ROOT/install.sh" --check --workspace "$check_workspace" 2>&1)
+pristine_rc=$?
+set -e
+if [[ "$pristine_rc" -eq 0 \
+  && "$pristine_output" != *'scripts/cron-pristine.sh SECRETS_ENV unauditable - manual check required'* \
+  && "$pristine_output" != *'warning: cron wrapper SECRETS_ENV unauditable count:'* ]]; then
+  pass 'install check skips the template default SECRETS_ENV assignment without noise'
+else
+  fail_case 'install check skips the template default SECRETS_ENV assignment without noise' \
+    "rc=$pristine_rc output=$pristine_output"
+fi
+
+check_workspace=$(seed_check_workspace trailing-operator-assignment)
+late_secret=$TMP_ROOT/trailing-operator.env
+printf 'GOOD=plain\n' >"$late_secret"
+chmod 644 "$late_secret"
+insert_wrapper_secrets_assignment_after_default "$check_workspace" cron-trailing-assignment.sh "\"$late_secret\"" >/dev/null
+set +e
+trailing_assignment_output=$("$ROOT/install.sh" --check --workspace "$check_workspace" 2>&1)
+trailing_assignment_rc=$?
+set -e
+if [[ "$trailing_assignment_rc" -eq 0 \
+  && "$trailing_assignment_output" == *"warning: cron wrapper scripts/cron-trailing-assignment.sh SECRETS_ENV permissions should be 0600 or 0400: $late_secret has 644"* \
+  && "$trailing_assignment_output" != *'scripts/cron-trailing-assignment.sh SECRETS_ENV unauditable - manual check required'* ]]; then
+  pass 'install check audits an operator SECRETS_ENV assignment that appears after the template default'
+else
+  fail_case 'install check audits an operator SECRETS_ENV assignment that appears after the template default' \
+    "rc=$trailing_assignment_rc output=$trailing_assignment_output"
 fi
 
 check_workspace=$(seed_check_workspace unresolved-dollar)

--- a/tests/cron-wrapper-path.test.sh
+++ b/tests/cron-wrapper-path.test.sh
@@ -5,6 +5,7 @@ ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 CRON_WRAPPER=$ROOT/templates/cron-wrapper.tmpl.sh
 UPDATER_WRAPPER=$ROOT/templates/updater-cron.tmpl.sh
 BASELINE_PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+HOME_RESOLUTION_NOTE=' (resolution uses the checking process HOME and may differ under sudo/other users)'
 TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/cron-wrapper-path-test.XXXXXX")
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -212,6 +213,20 @@ else
     "rc=$brace_rc output=$brace_output"
 fi
 
+check_workspace=$(seed_check_workspace home-resolution-fail-note)
+install_wrapper_with_secrets_assignment "$check_workspace" cron-home-missing.sh '"$HOME/home-missing.env"' >/dev/null
+set +e
+home_missing_output=$(HOME="$fake_home" "$ROOT/install.sh" --check --workspace "$check_workspace" 2>&1)
+home_missing_rc=$?
+set -e
+if [[ "$home_missing_rc" -ne 0 \
+  && "$home_missing_output" == *"FAIL: cron wrapper scripts/cron-home-missing.sh SECRETS_ENV file not found: $fake_home/home-missing.env$HOME_RESOLUTION_NOTE"* ]]; then
+  pass 'install check appends the HOME-resolution note on resolved FAIL diagnostics'
+else
+  fail_case 'install check appends the HOME-resolution note on resolved FAIL diagnostics' \
+    "rc=$home_missing_rc output=$home_missing_output"
+fi
+
 check_workspace=$(seed_check_workspace unresolved-dollar)
 install_wrapper_with_secrets_assignment "$check_workspace" cron-unresolved.sh '"$SECRETS_DIR/unresolved.env"' >/dev/null
 install_wrapper_with_secrets_assignment "$check_workspace" cron-home-boundary.sh '"$HOMELESS/not-home.env"' >/dev/null
@@ -220,13 +235,48 @@ unresolved_output=$("$ROOT/install.sh" --check --workspace "$check_workspace" 2>
 unresolved_rc=$?
 set -e
 if [[ "$unresolved_rc" -eq 0 \
-  && "$unresolved_output" == *'warning: cron wrapper scripts/cron-unresolved.sh SECRETS_ENV unauditable - manual check required: SECRETS_ENV=$SECRETS_DIR/unresolved.env'* \
-  && "$unresolved_output" == *'warning: cron wrapper scripts/cron-home-boundary.sh SECRETS_ENV unauditable - manual check required: SECRETS_ENV=$HOMELESS/not-home.env'* \
+  && "$unresolved_output" == *'warning: cron wrapper scripts/cron-unresolved.sh SECRETS_ENV unauditable - manual check required: SECRETS_ENV="$SECRETS_DIR/unresolved.env"'* \
+  && "$unresolved_output" == *'warning: cron wrapper scripts/cron-home-boundary.sh SECRETS_ENV unauditable - manual check required: SECRETS_ENV="$HOMELESS/not-home.env"'* \
   && "$unresolved_output" == *'warning: cron wrapper SECRETS_ENV unauditable count: 2'* ]]; then
   pass 'install check reports unresolved dollar paths and $HOME boundary misses as unauditable with a summary count'
 else
   fail_case 'install check reports unresolved dollar paths and $HOME boundary misses as unauditable with a summary count' \
     "rc=$unresolved_rc output=$unresolved_output"
+fi
+
+check_workspace=$(seed_check_workspace invalid-quote-shapes)
+install_wrapper_with_secrets_assignment "$check_workspace" cron-internal-double-quote.sh '"$HOME"/split.env' >/dev/null
+install_wrapper_with_secrets_assignment "$check_workspace" cron-single-quoted-literal.sh "'\$HOME/literal.env'" >/dev/null
+install_wrapper_with_secrets_assignment "$check_workspace" cron-backtick.sh '`$HOME/backtick.env`' >/dev/null
+set +e
+quote_shape_output=$(HOME="$fake_home" "$ROOT/install.sh" --check --workspace "$check_workspace" 2>&1)
+quote_shape_rc=$?
+set -e
+if [[ "$quote_shape_rc" -ne 0 \
+  && "$quote_shape_output" == *'warning: cron wrapper scripts/cron-internal-double-quote.sh SECRETS_ENV unauditable - manual check required: SECRETS_ENV="$HOME"/split.env'"$HOME_RESOLUTION_NOTE"* \
+  && "$quote_shape_output" == *'FAIL: cron wrapper scripts/cron-single-quoted-literal.sh SECRETS_ENV file not found: $HOME/literal.env'* \
+  && "$quote_shape_output" != *"$fake_home/literal.env"* \
+  && "$quote_shape_output" == *'warning: cron wrapper scripts/cron-backtick.sh SECRETS_ENV unauditable - manual check required: SECRETS_ENV=`$HOME/backtick.env`'"$HOME_RESOLUTION_NOTE"* \
+  && "$quote_shape_output" == *'warning: cron wrapper SECRETS_ENV unauditable count: 2'* ]]; then
+  pass 'install check treats internal quotes and backticks as unauditable and single quotes as literal paths'
+else
+  fail_case 'install check treats internal quotes and backticks as unauditable and single quotes as literal paths' \
+    "rc=$quote_shape_rc output=$quote_shape_output"
+fi
+
+check_workspace=$(seed_check_workspace pathological-home)
+install_wrapper_with_secrets_assignment "$check_workspace" cron-pathological-home.sh '"$HOME/pathological.env"' >/dev/null
+set +e
+pathological_home_output=$(HOME='$HOME' "$ROOT/install.sh" --check --workspace "$check_workspace" 2>&1)
+pathological_home_rc=$?
+set -e
+if [[ "$pathological_home_rc" -eq 0 \
+  && "$pathological_home_output" == *'warning: cron wrapper scripts/cron-pathological-home.sh SECRETS_ENV unauditable - manual check required: SECRETS_ENV="$HOME/pathological.env"'"$HOME_RESOLUTION_NOTE"* \
+  && "$pathological_home_output" == *'warning: cron wrapper SECRETS_ENV unauditable count: 1'* ]]; then
+  pass 'install check bounds pathological HOME resolution and reports unauditable'
+else
+  fail_case 'install check bounds pathological HOME resolution and reports unauditable' \
+    "rc=$pathological_home_rc output=$pathological_home_output"
 fi
 
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"

--- a/tests/secrets-env-rules.test.sh
+++ b/tests/secrets-env-rules.test.sh
@@ -89,6 +89,43 @@ assert_prediction() {
   fi
 }
 
+assert_fail_closed_missing_or_unreadable() {
+  local name=$1
+  local secrets_file=$2
+  local check_fragment=$3
+  local wrapper_fragment=$4
+  local workspace wrapper check_rc wrapper_rc canary
+
+  workspace=$(seed_workspace "$name")
+  wrapper=$(install_configured_wrapper "$workspace" "$secrets_file")
+  canary=$TMP_ROOT/$name.canary
+  cat >"$TMP_ROOT/$name-target" <<EOF
+#!/usr/bin/env bash
+printf 'target-ran\n' >"$canary"
+EOF
+  chmod +x "$TMP_ROOT/$name-target"
+
+  "$ROOT/install.sh" --check --workspace "$workspace" \
+    >"$TMP_ROOT/$name.check.out" 2>"$TMP_ROOT/$name.check.err"
+  check_rc=$?
+
+  TARGET="$TMP_ROOT/$name-target" CATY_HARNESS_ROOT="$ROOT" CATY_WORKSPACE="$workspace" \
+    "$wrapper" >"$TMP_ROOT/$name.wrapper.out" 2>"$TMP_ROOT/$name.wrapper.err"
+  wrapper_rc=$?
+
+  if [ "$check_rc" -ne 0 ] \
+    && grep -Fq 'FAIL: cron wrapper scripts/cron-wrapper.sh SECRETS_ENV ' "$TMP_ROOT/$name.check.err" \
+    && grep -Fq "$check_fragment" "$TMP_ROOT/$name.check.err" \
+    && [ "$wrapper_rc" -eq 3 ] \
+    && grep -Fq "cron-wrapper infra error: $wrapper_fragment" "$TMP_ROOT/$name.wrapper.err" \
+    && [ ! -e "$canary" ]; then
+    pass "$name missing/unreadable SECRETS_ENV fails closed in check and wrapper"
+  else
+    fail_case "$name fail-closed contract" \
+      "check_rc=$check_rc wrapper_rc=$wrapper_rc canary=$(test -e "$canary" && printf present || printf absent) check_stderr=$(cat "$TMP_ROOT/$name.check.err") wrapper_stderr=$(cat "$TMP_ROOT/$name.wrapper.err")"
+  fi
+}
+
 assert_secrets_lib_failure() {
   local name=$1
   local harness_root=$2
@@ -158,6 +195,22 @@ assert_prediction symlink "$symlink_file" reject 'SECRETS_ENV must not be a syml
 dangling_file=$TMP_ROOT/dangling.env
 ln -s "$TMP_ROOT/absent.env" "$dangling_file"
 assert_prediction dangling-symlink "$dangling_file" reject 'SECRETS_ENV must not be a symlink'
+
+missing_file=$TMP_ROOT/missing.env
+assert_fail_closed_missing_or_unreadable missing-file "$missing_file" \
+  'SECRETS_ENV file not found:' \
+  'SECRETS_ENV file not found:'
+
+unreadable_file=$TMP_ROOT/unreadable.env
+printf 'GOOD=plain\n' >"$unreadable_file"
+chmod 000 "$unreadable_file"
+if [ -r "$unreadable_file" ]; then
+  pass 'unreadable SECRETS_ENV check skipped because this user can read mode 000 files'
+else
+  assert_fail_closed_missing_or_unreadable unreadable-file "$unreadable_file" \
+    'SECRETS_ENV file is not readable:' \
+    'SECRETS_ENV permissions must be 0600 or 0400:'
+fi
 
 fake_root=$TMP_ROOT/harness-without-secrets-lib
 mkdir -p "$fake_root/scripts"

--- a/tests/secrets-env-rules.test.sh
+++ b/tests/secrets-env-rules.test.sh
@@ -89,7 +89,7 @@ assert_prediction() {
   fi
 }
 
-assert_fail_closed_missing_or_unreadable() {
+assert_fail_closed_path_rejection() {
   local name=$1
   local secrets_file=$2
   local check_fragment=$3
@@ -190,14 +190,24 @@ assert_prediction readonly-name "$readonly_name_file" reject 'line 1 cannot expo
 assert_prediction non-assignment "$non_assignment_file" reject 'line 1 is not a KEY=VALUE assignment'
 assert_prediction embedded-nul "$nul_file" reject 'line 2 contains an embedded NUL byte'
 assert_prediction bad-mode "$bad_mode_file" reject 'SECRETS_ENV permissions should be 0600 or 0400'
-assert_prediction symlink "$symlink_file" reject 'SECRETS_ENV must not be a symlink'
-
 dangling_file=$TMP_ROOT/dangling.env
 ln -s "$TMP_ROOT/absent.env" "$dangling_file"
-assert_prediction dangling-symlink "$dangling_file" reject 'SECRETS_ENV must not be a symlink'
+assert_fail_closed_path_rejection symlink "$symlink_file" \
+  'SECRETS_ENV must not be a symlink:' \
+  'SECRETS_ENV must not be a symlink:'
+
+assert_fail_closed_path_rejection dangling-symlink "$dangling_file" \
+  'SECRETS_ENV must not be a symlink:' \
+  'SECRETS_ENV must not be a symlink:'
+
+directory_file=$TMP_ROOT/secrets-dir
+mkdir -p "$directory_file"
+assert_fail_closed_path_rejection non-regular-directory "$directory_file" \
+  'SECRETS_ENV must be a regular file:' \
+  'SECRETS_ENV must be a regular file:'
 
 missing_file=$TMP_ROOT/missing.env
-assert_fail_closed_missing_or_unreadable missing-file "$missing_file" \
+assert_fail_closed_path_rejection missing-file "$missing_file" \
   'SECRETS_ENV file not found:' \
   'SECRETS_ENV file not found:'
 
@@ -207,7 +217,7 @@ chmod 000 "$unreadable_file"
 if [ -r "$unreadable_file" ]; then
   pass 'unreadable SECRETS_ENV check skipped because this user can read mode 000 files'
 else
-  assert_fail_closed_missing_or_unreadable unreadable-file "$unreadable_file" \
+  assert_fail_closed_path_rejection unreadable-file "$unreadable_file" \
     'SECRETS_ENV file is not readable:' \
     'SECRETS_ENV permissions must be 0600 or 0400:'
 fi

--- a/tests/spawn-step.test.sh
+++ b/tests/spawn-step.test.sh
@@ -705,6 +705,48 @@ case_provider_runs_with_reduced_environment() {
   fi
 }
 
+case_readonly_export_survivor_fails_closed() {
+  local name=readonly-export-survivor-fails-closed
+  local dir code output probe_env_file probe_argv_file named_var
+  local probe_started provider_started
+  dir=$(make_case_dir)
+  write_env_dump_cli "$dir/fake-hermes"
+  probe_env_file="$dir/attempt/probe.env"
+  probe_argv_file="$dir/attempt/probe.argv"
+  write_probe_env_dump_cli "$dir/fake-probe" "$probe_env_file" "$probe_argv_file"
+  set +e
+  output=$(
+    (
+      declare -rx LEAKED_READONLY_SECRET_CANARY=sentinel
+      HERMES_STEP_CMD="$dir/fake-hermes"
+      HERMES_PROBE_CMD="$dir/fake-probe"
+      set -- "$dir/task.md" "$dir/ws" "$dir/attempt" 1
+      # Source in a subshell so the exported readonly state survives into the
+      # reducer. `exit 111` then terminates only this isolated shell.
+      . "$ADAPTER"
+    ) 2>&1
+  )
+  code=$?
+  set -e
+  named_var=0
+  probe_started=0
+  provider_started=0
+  if grep -Fq 'environment reduction could not strip: LEAKED_READONLY_SECRET_CANARY' <<<"$output"; then
+    named_var=1
+  fi
+  if [[ -e "$probe_env_file" || -e "$probe_argv_file" ]]; then
+    probe_started=1
+  fi
+  if [[ -e "$dir/attempt/provider.env" || -e "$dir/attempt/provider.argv" || -e "$dir/attempt/step-result.json" ]]; then
+    provider_started=1
+  fi
+  if [[ "$code" -eq 111 && "$named_var" -eq 1 && "$probe_started" -eq 0 && "$provider_started" -eq 0 ]]; then
+    pass "$name"
+  else
+    fail "$name" "expected pre-probe rc=111 and no child launch: rc=$code named_var=$named_var probe_started=$probe_started provider_started=$provider_started"
+  fi
+}
+
 case_invalid_step_env_allow_fails_closed() {
   local name=invalid-step-env-allow-fails-closed
   local dir code output
@@ -721,6 +763,33 @@ case_invalid_step_env_allow_fails_closed() {
     pass "$name"
   else
     fail "$name" "expected rc=111 without provider launch: rc=$code output=$output"
+  fi
+}
+
+case_step_env_allow_glob_is_not_expanded() {
+  local name=step-env-allow-glob-is-not-expanded
+  local dir code output
+  dir=$(make_case_dir)
+  mkdir -p "$dir/glob-cwd"
+  : >"$dir/glob-cwd/VALID_AB"
+  write_env_dump_cli "$dir/fake-hermes"
+  set +e
+  output=$(
+    (
+      cd "$dir/glob-cwd" || exit 1
+      HERMES_STEP_CMD="$dir/fake-hermes" HERMES_STEP_ENV_ALLOW='VALID_A*' run_adapter "$dir"
+    ) 2>&1
+  )
+  code=$?
+  set -e
+  if [[ "$code" -eq 111 ]] \
+    && grep -Fq 'HERMES_STEP_ENV_ALLOW contains an invalid variable name: VALID_A*' <<<"$output" \
+    && ! grep -Fq 'VALID_AB' <<<"$output" \
+    && [[ ! -e "$dir/attempt/provider.env" ]] \
+    && [[ ! -e "$dir/attempt/step-result.json" ]]; then
+    pass "$name"
+  else
+    fail "$name" "expected literal glob rejection before launch: rc=$code"
   fi
 }
 
@@ -745,7 +814,9 @@ case_underlying_exit75_passthrough
 case_runner_rejects_relative_spawn_step
 case_runner_rejects_nonexecutable_spawn_step
 case_provider_runs_with_reduced_environment
+case_readonly_export_survivor_fails_closed
 case_invalid_step_env_allow_fails_closed
+case_step_env_allow_glob_is_not_expanded
 
 log "TOTAL pass=$pass_count fail=$fail_count"
 if (( fail_count > 0 )); then

--- a/tests/spawn-step.test.sh
+++ b/tests/spawn-step.test.sh
@@ -442,6 +442,18 @@ SH
   chmod +x "$path"
 }
 
+write_env_dump_cli() {
+  local path=$1
+  cat >"$path" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+attempt_dir=$2
+env | LC_ALL=C sort >"$attempt_dir/provider.env"
+printf '{"step_complete":true}\n' >"$attempt_dir/step-result.json"
+SH
+  chmod +x "$path"
+}
+
 case_timeout_quarantines_partial_output_and_kills_group() {
   local name=timeout-quarantines-partial-output-and-kills-group
   local dir code grandchild_pid tries
@@ -613,6 +625,69 @@ case_runner_rejects_nonexecutable_spawn_step() {
   fi
 }
 
+case_provider_runs_with_reduced_environment() {
+  local name=provider-runs-with-reduced-environment
+  local dir env_file expected_workspace expected_artifact_dir
+  dir=$(make_case_dir)
+  mkdir -p "$dir/tmp"
+  expected_workspace=$(cd "$dir/ws" && pwd -P)
+  expected_artifact_dir=$(cd "$dir/attempt/.." && cd .. && pwd)
+  write_env_dump_cli "$dir/fake-hermes"
+  if LEAKED_SECRET_CANARY=sentinel \
+    EXTRA_VISIBLE_CANARY=visible \
+    HERMES_STEP_CMD="$dir/fake-hermes" \
+    HERMES_STEP_ENV_ALLOW='EXTRA_VISIBLE_CANARY' \
+    HERMES_HTTP_TIMEOUT_S=31 \
+    HERMES_STEP_TIMEOUT_S=40 \
+    HERMES_STEP_GRACE_S=5 \
+    LANG=C \
+    LC_ALL=C \
+    TMPDIR="$dir/tmp" \
+    run_adapter "$dir" >/dev/null 2>&1; then
+    env_file="$dir/attempt/provider.env"
+    if [[ -f "$dir/attempt/step-result.json" ]] \
+      && grep -Fqx "PATH=$PATH" "$env_file" \
+      && grep -Fqx "HOME=$HOME" "$env_file" \
+      && grep -Fqx "TMPDIR=$dir/tmp" "$env_file" \
+      && grep -Fqx 'LANG=C' "$env_file" \
+      && grep -Fqx 'LC_ALL=C' "$env_file" \
+      && grep -Fqx "TASK_FILE=$dir/task.md" "$env_file" \
+      && grep -Fqx "ARTIFACT_DIR=$expected_artifact_dir" "$env_file" \
+      && grep -Fqx "ATTEMPT_DIR=$dir/attempt" "$env_file" \
+      && grep -Fqx "WORKSPACE=$expected_workspace" "$env_file" \
+      && grep -Fqx 'HERMES_HTTP_TIMEOUT_S=31' "$env_file" \
+      && grep -Fqx 'HERMES_STEP_TIMEOUT_S=40' "$env_file" \
+      && grep -Fqx 'HERMES_STEP_GRACE_S=5' "$env_file" \
+      && grep -Fqx 'EXTRA_VISIBLE_CANARY=visible' "$env_file" \
+      && ! grep -Fq 'LEAKED_SECRET_CANARY=sentinel' "$env_file"; then
+      pass "$name"
+    else
+      fail "$name" 'provider env contract check failed'
+    fi
+  else
+    fail "$name" "expected reduced-env provider launch to succeed"
+  fi
+}
+
+case_invalid_step_env_allow_fails_closed() {
+  local name=invalid-step-env-allow-fails-closed
+  local dir code output
+  dir=$(make_case_dir)
+  write_env_dump_cli "$dir/fake-hermes"
+  set +e
+  output=$(HERMES_STEP_CMD="$dir/fake-hermes" HERMES_STEP_ENV_ALLOW='GOOD-NAME *.bad' run_adapter "$dir" 2>&1)
+  code=$?
+  set -e
+  if [[ "$code" -eq 111 ]] \
+    && grep -Fq 'HERMES_STEP_ENV_ALLOW contains an invalid variable name' <<<"$output" \
+    && [[ ! -e "$dir/attempt/provider.env" ]] \
+    && [[ ! -e "$dir/attempt/step-result.json" ]]; then
+    pass "$name"
+  else
+    fail "$name" "expected rc=111 without provider launch: rc=$code output=$output"
+  fi
+}
+
 case_success
 case_ordering_guards
 case_step_cmd_unset
@@ -633,6 +708,8 @@ case_pause_boundary_returns_zero_status_record
 case_underlying_exit75_passthrough
 case_runner_rejects_relative_spawn_step
 case_runner_rejects_nonexecutable_spawn_step
+case_provider_runs_with_reduced_environment
+case_invalid_step_env_allow_fails_closed
 
 log "TOTAL pass=$pass_count fail=$fail_count"
 if (( fail_count > 0 )); then

--- a/tests/spawn-step.test.sh
+++ b/tests/spawn-step.test.sh
@@ -449,7 +449,21 @@ write_env_dump_cli() {
 set -euo pipefail
 attempt_dir=$2
 env | LC_ALL=C sort >"$attempt_dir/provider.env"
+printf '%s\n' "$0" "$@" >"$attempt_dir/provider.argv"
 printf '{"step_complete":true}\n' >"$attempt_dir/step-result.json"
+SH
+  chmod +x "$path"
+}
+
+write_probe_env_dump_cli() {
+  local path=$1
+  local env_file=$2
+  local argv_file=$3
+  cat >"$path" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+env | LC_ALL=C sort >"$env_file"
+printf '%s\n' "\$0" "\$@" >"$argv_file"
 SH
   chmod +x "$path"
 }
@@ -627,15 +641,22 @@ case_runner_rejects_nonexecutable_spawn_step() {
 
 case_provider_runs_with_reduced_environment() {
   local name=provider-runs-with-reduced-environment
-  local dir env_file expected_workspace expected_artifact_dir
+  local dir env_file probe_env_file provider_argv_file probe_argv_file expected_workspace expected_artifact_dir
   dir=$(make_case_dir)
   mkdir -p "$dir/tmp"
   expected_workspace=$(cd "$dir/ws" && pwd -P)
   expected_artifact_dir=$(cd "$dir/attempt/.." && cd .. && pwd)
   write_env_dump_cli "$dir/fake-hermes"
+  probe_env_file="$dir/attempt/probe.env"
+  probe_argv_file="$dir/attempt/probe.argv"
+  write_probe_env_dump_cli "$dir/fake-probe" "$probe_env_file" "$probe_argv_file"
   if LEAKED_SECRET_CANARY=sentinel \
     EXTRA_VISIBLE_CANARY=visible \
+    HTTPS_PROXY='https://proxy.example.invalid:8443' \
+    HTTP_PROXY='http://proxy.example.invalid:8080' \
+    ALL_PROXY='socks5://proxy.example.invalid:1080' \
     HERMES_STEP_CMD="$dir/fake-hermes" \
+    HERMES_PROBE_CMD="$dir/fake-probe" \
     HERMES_STEP_ENV_ALLOW='EXTRA_VISIBLE_CANARY' \
     HERMES_HTTP_TIMEOUT_S=31 \
     HERMES_STEP_TIMEOUT_S=40 \
@@ -645,12 +666,16 @@ case_provider_runs_with_reduced_environment() {
     TMPDIR="$dir/tmp" \
     run_adapter "$dir" >/dev/null 2>&1; then
     env_file="$dir/attempt/provider.env"
+    provider_argv_file="$dir/attempt/provider.argv"
     if [[ -f "$dir/attempt/step-result.json" ]] \
       && grep -Fqx "PATH=$PATH" "$env_file" \
       && grep -Fqx "HOME=$HOME" "$env_file" \
       && grep -Fqx "TMPDIR=$dir/tmp" "$env_file" \
       && grep -Fqx 'LANG=C' "$env_file" \
       && grep -Fqx 'LC_ALL=C' "$env_file" \
+      && grep -Fqx 'HTTPS_PROXY=https://proxy.example.invalid:8443' "$env_file" \
+      && grep -Fqx 'HTTP_PROXY=http://proxy.example.invalid:8080' "$env_file" \
+      && grep -Fqx 'ALL_PROXY=socks5://proxy.example.invalid:1080' "$env_file" \
       && grep -Fqx "TASK_FILE=$dir/task.md" "$env_file" \
       && grep -Fqx "ARTIFACT_DIR=$expected_artifact_dir" "$env_file" \
       && grep -Fqx "ATTEMPT_DIR=$dir/attempt" "$env_file" \
@@ -659,7 +684,18 @@ case_provider_runs_with_reduced_environment() {
       && grep -Fqx 'HERMES_STEP_TIMEOUT_S=40' "$env_file" \
       && grep -Fqx 'HERMES_STEP_GRACE_S=5' "$env_file" \
       && grep -Fqx 'EXTRA_VISIBLE_CANARY=visible' "$env_file" \
-      && ! grep -Fq 'LEAKED_SECRET_CANARY=sentinel' "$env_file"; then
+      && ! grep -Fq 'LEAKED_SECRET_CANARY=sentinel' "$env_file" \
+      && grep -Fqx "PATH=$PATH" "$probe_env_file" \
+      && grep -Fqx "HOME=$HOME" "$probe_env_file" \
+      && grep -Fqx "TMPDIR=$dir/tmp" "$probe_env_file" \
+      && grep -Fqx 'HTTPS_PROXY=https://proxy.example.invalid:8443' "$probe_env_file" \
+      && grep -Fqx "TASK_FILE=$dir/task.md" "$probe_env_file" \
+      && grep -Fqx "WORKSPACE=$expected_workspace" "$probe_env_file" \
+      && grep -Fqx 'HERMES_HTTP_TIMEOUT_S=31' "$probe_env_file" \
+      && grep -Fqx 'EXTRA_VISIBLE_CANARY=visible' "$probe_env_file" \
+      && ! grep -Fq 'LEAKED_SECRET_CANARY=sentinel' "$probe_env_file" \
+      && ! grep -Fq 'LEAKED_SECRET_CANARY' "$provider_argv_file" \
+      && ! grep -Fq 'LEAKED_SECRET_CANARY' "$probe_argv_file"; then
       pass "$name"
     else
       fail "$name" 'provider env contract check failed'
@@ -679,7 +715,7 @@ case_invalid_step_env_allow_fails_closed() {
   code=$?
   set -e
   if [[ "$code" -eq 111 ]] \
-    && grep -Fq 'HERMES_STEP_ENV_ALLOW contains an invalid variable name' <<<"$output" \
+    && grep -Fq 'HERMES_STEP_ENV_ALLOW contains an invalid variable name: GOOD-NAME' <<<"$output" \
     && [[ ! -e "$dir/attempt/provider.env" ]] \
     && [[ ! -e "$dir/attempt/step-result.json" ]]; then
     pass "$name"


### PR DESCRIPTION
Closes #243

SECRETS_ENV hygiene batch (5 adopted nightly findings, severity:high), hardened through a 5-seat blind review + 2 delta rounds:

1. **Fail-closed cron wrapper** — `templates/cron-wrapper.tmpl.sh` exits 3 with a cron-log diagnostic when `SECRETS_ENV` is set but the file is missing, non-regular, or unreadable (previously fell through to `exec "$TARGET"` with no credentials and no diagnostics). All existing symlink / NUL / identity-race checks preserved.
2. **`install.sh --check` parity** — missing, unreadable, symlink, dangling-symlink, and non-regular `SECRETS_ENV` are all `FAIL:` + non-zero exit (the check's fail-closed set now exactly matches the wrapper's).
3. **Quote-aware `$`-path audit** — strict whole-assignment grammar: unquoted / fully-double-quoted assignments resolve `$HOME`/`${HOME}` by bounded pure-string substitution (no eval; `$HOMELESS` boundary guarded); fully-single-quoted audits the literal path (runtime non-expansion semantics); mid-string quotes, mixed quotes, and backticks report `unauditable - manual check required` with a surfaced count. The template's own `SECRETS_ENV=${SECRETS_ENV:-}` default is skipped so pristine installs stay quiet and later operator assignments are audited. Comment stripping is quote-aware; pathological `HOME` values terminate (bounded forward scan); diagnostics state the checking-process-HOME assumption.
4. **Reduced hermes env, probe included, nothing on argv** — `adapters/hermes/spawn_step.sh` reduces its own exported environment in-process (`compgen -A export` + `unset -v` keep list: PATH/HOME/TMPDIR/LANG/LC_ALL + proxy trio + step-contract vars + validated `HERMES_STEP_ENV_ALLOW`), then launches BOTH the pre-flight probe and the provider under it. No `NAME=value` ever appears on a command line (the r1 `env -i` design was dropped for exactly that ps-visibility). A post-reduction sweep fails closed (exit 111, variable name only) if any non-kept export survives — e.g. `readonly -x` secrets, which `unset` cannot strip. Contract + upgrade migration note in `adapters/hermes/INSTALL.md`.
5. **O_NOFOLLOW residual race → accepted-risk record** — `docs/engineering.md` (+ ja mirror) with rationale and preconditions, referenced from the wrapper header. No code fix per the issue disposition.

## Files touched (= WIP declaration, 9 files)

- `templates/cron-wrapper.tmpl.sh`
- `install.sh`
- `adapters/hermes/spawn_step.sh`
- `adapters/hermes/INSTALL.md`
- `docs/engineering.md`
- `docs/engineering.ja.md`
- `tests/secrets-env-rules.test.sh`
- `tests/cron-wrapper-path.test.sh`
- `tests/spawn-step.test.sh`

`git diff --stat origin/main...28a02a7` = exactly these 9 files. No undeclared files.

## 完了記録 (L1-7)

**候補 commit SHA: `28a02a7`** (= PR head at review completion; `9c6698c` implementation + `5394db9` panel delta + `28a02a7` delta-2)

### Done when → PASS/FAIL

1. **Cron wrapper fails closed (non-zero exit + diagnostic) on missing/unreadable SECRETS_ENV — PASS.**
   Evidence (2026-09-01): `tests/secrets-env-rules.test.sh` fail-closed contract cases: missing → `wrapper_rc=3`, diagnostic `cron-wrapper infra error: SECRETS_ENV file not found: <path>`, canary target file absent (TARGET provably not exec'd); unreadable → `wrapper_rc=3`, canary absent. Orchestrator mutation (fail restored to fall-through, detached copy): `FAIL missing-file ... wrapper_rc=0 canary=present` → test suite red. Fail-broken direction (wrapper fails on healthy file): 3 tests red incl. valid-prediction-equivalence — the healthy path is also pinned.
2. **`install.sh --check` reports it as FAIL, not warning — PASS.**
   Evidence: same suite asserts `check_rc=1` + `FAIL:` lines for missing and unreadable; symlink/dangling/non-regular promoted to FAIL in the panel delta (4-seat convergence) and pinned by dedicated cases (17 PASS / 0 FAIL). Opus delta seat live-probed all three shapes → `check_rc=1` each, healthy 0600 file → `check_rc=0` (no false positive).
3. **`$`-parameterized assignments resolved-and-audited or explicitly unauditable (count surfaced, no silent clean) — PASS.**
   Evidence: `tests/cron-wrapper-path.test.sh` 15 PASS / 0 FAIL: `$HOME` and `${HOME}` fixtures resolved and audited (bad-permission decoy under fake HOME detected); `$SECRETS_DIR` and `$HOMELESS` fixtures → per-wrapper `unauditable - manual check required` + `unauditable count: 2`; quote-grammar fixtures (`"$HOME"/x` mid-quote, single-quote literal, backtick) per the Codex seat's live-probed decoy finding; pathological `HOME` terminates bounded. Codex delta seat re-probed all quote shapes at 5394db9: correct; GLM seat's adversarial probes (`$(reboot)`, `${XDG_HOME:-$HOME}`, backticks) → unauditable, nothing executed.
4. **Hermes `spawn_step` reduced environment + documented contract — PASS.**
   Evidence: `tests/spawn-step.test.sh` 24 PASS / 0 FAIL: `LEAKED_SECRET_CANARY` absent from provider env, probe env, and both argv dumps; contract vars + proxy trio present; invalid allowlist name → exit 111 naming the entry; glob fixture pins the `set -f` guard; `readonly -x` canary → exit 111 pre-probe (`environment reduction could not strip: <name>`), neither probe nor provider launched (Codex seat live-probed independently). INSTALL.md documents contract, probe parity, argv non-exposure, and the upgrade migration note.
5. **O_NOFOLLOW residual race recorded as accepted-risk, referenced from wrapper header — PASS.**
   Evidence: `docs/engineering.md#accepted-risk-cron-wrapper-secrets-env-race` (+ ja mirror, en/ja parity verified by 3 seats) states the residual window, rationale, and the local-attacker-with-filesystem-write precondition; `templates/cron-wrapper.tmpl.sh` header comment links the anchor. No code change for the race (issue disposition).
6. **Tests cover the three named paths — PASS.** (Evidence inline in items 1–4; every new test area is mutation-verified red-on-revert by the implementer, the orchestrator on detached copies, and 3 review seats independently.)
7. **Test suite green — PASS.**
   Evidence: local `make test` at 28a02a7 (2026-09-01): `Suite Summary: 43 PASS, 0 FAIL` (also green at 9c6698c and 5394db9); `make lint`: `bash32 ANSI-C lint: 89 shell files OK` / `lint: 89 shell files OK`; `shellcheck -x` on the three changed scripts: clean. CI on head 28a02a7: see CI 状態 below.

### 宣言ファイル集合と diff の照合

`git diff --stat origin/main...28a02a7` → exactly the 9 declared files above; nothing in the diff is outside the declaration (re-verified independently by the GLM, Grok, and Codex seats).

### 実装者 / レビュアー

- Implementer: Codex GPT-5.6 Sol (`--profile sol`; implementation + 2 delta resumes). Orchestration/adjudication/inspection: Alpha (Claude Fable 5, session 5403db73) — holds no review vote.
- 5-seat heterogeneous blind review (high-risk area: secret boundary → 5 seats per L1-11), fresh-context, read-only, on candidate 9c6698c, with delta verification to cumulative candidate 28a02a7:
  - **Opus 5** (requested opus / actual claude-opus-5): GO-WITH-CHANGES → delta: **CUMULATIVE GO**
  - **Codex GPT-5.6 Sol** (same-family-as-writer seat under the recorded correlated-seats exception, review_council 2026-08-12, 6-field record; fresh read-only sessions): NO-GO → delta: NO-GO (new live-probed MAJOR) → delta-2: **CUMULATIVE GO**
  - **Kimi K3** (requested/actual kimi-k3; fable-5 quota absence substitution per loom-seats): GO-WITH-CHANGES → delta: **CUMULATIVE GO**
  - **GLM 5.3** (requested/actual glm-5.3): **GO**
  - **Grok 4.6** (requested/actual grok-4.6): **GO**
- Adjudication & full round-by-round record: PR comment [5-seat review record](https://github.com/caty-ai/caty-agent-harness/pull/258#issuecomment-5489934046). Blocking findings adopted: 6 (r1, incl. 3- and 4-seat convergences) + 1 (delta round, 2-seat convergence readonly bypass). Recorded non-adoptions with reasons in the same record.

### CI 状態

Head `28a02a7` (2026-09-01): gitleaks PASS / history-check PASS / repo-state PASS / pr-size strip-size-exempt PASS / risk-review-gate detect-risk-paths + apply-visibility-labels PASS / test-lint lint PASS + test PASS (21m33s) + test-macos PASS (27m59s). Only red: `pr-size / pr-size` (464 lines > 250 — size-exempt label requested from the owner) and `risk-review-gate / risk-review-gate` (high-risk paths by design — `risk-reviewed` label pending the roster human). No unrelated red.

### release

- **release: v0.23.8** (annotated tag + GitHub Release via release-sync on tag push; ships user-visible behavior changes — wrapper fail-closed semantics, --check FAIL set, reduced hermes env)
- **previous release: v0.23.7** — 履行済み (https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.23.7 — verified existing before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
