### PR TITLE
security(#241): verifier-provider credential attachment restricted to an explicit host allowlist

### DIFF
--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -185,7 +185,10 @@ The rules there apply in addition to the Hermes-specific wiring below.
 
    For the API-backed shape, Anthropic remains the default: set an Anthropic key in
    `VERIFIER_API_KEY`, optionally set `VERIFIER_MODEL`, and leave
-   `VERIFIER_API_BASE` unset to use `https://api.anthropic.com`.
+   `VERIFIER_API_BASE` unset to use `https://api.anthropic.com`. Credential attachment
+   is restricted to an allowlist of hosts that defaults to `api.anthropic.com`; any
+   other base requires explicitly opting its host in through
+   `VERIFIER_API_ALLOWED_HOSTS`.
 
    **Z.ai GLM 5.2 configuration.** Set these values through the job's protected
    `SECRETS_ENV`:
@@ -194,7 +197,11 @@ The rules there apply in addition to the Hermes-specific wiring below.
    VERIFIER_API_KEY=<Z.ai member key>
    VERIFIER_MODEL=glm-5.2
    VERIFIER_API_BASE=https://api.z.ai/api/anthropic
+   VERIFIER_API_ALLOWED_HOSTS=api.z.ai
    ```
+
+   The allowlist line is the explicit opt-in that authorizes sending
+   `VERIFIER_API_KEY` to the non-default `api.z.ai` host.
 
    `SECRETS_ENV` is an additive overlay. When switching vendors, remove or overwrite
    the old key line: a leftover key for vendor A will be sent to vendor B. Prefer

--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -188,7 +188,10 @@ The rules there apply in addition to the Hermes-specific wiring below.
    `VERIFIER_API_BASE` unset to use `https://api.anthropic.com`. Credential attachment
    is restricted to an allowlist of hosts that defaults to `api.anthropic.com`; any
    other base requires explicitly opting its host in through
-   `VERIFIER_API_ALLOWED_HOSTS`.
+   `VERIFIER_API_ALLOWED_HOSTS`. The allowlist constrains only the host; the port and
+   path follow `VERIFIER_API_BASE`. Entries are bare lowercase hostnames. Setting
+   `VERIFIER_API_ALLOWED_HOSTS` replaces the default list, so include
+   `api.anthropic.com` if the Anthropic host is also needed.
 
    **Z.ai GLM 5.2 configuration.** Set these values through the job's protected
    `SECRETS_ENV`:
@@ -203,18 +206,20 @@ The rules there apply in addition to the Hermes-specific wiring below.
    The allowlist line is the explicit opt-in that authorizes sending
    `VERIFIER_API_KEY` to the non-default `api.z.ai` host.
 
-   `SECRETS_ENV` is an additive overlay. When switching vendors, remove or overwrite
-   the old key line: a leftover key for vendor A will be sent to vendor B. Prefer
+   `SECRETS_ENV` is an additive overlay. When switching vendors, update or remove
+   `VERIFIER_API_BASE` and `VERIFIER_API_ALLOWED_HOSTS` together with the old key line.
+   A leftover key for vendor A will be sent to vendor B; a leftover allowlist for vendor
+   A hard-stops vendor B. That failure is fail-closed, but avoidable. Prefer
    `VERIFIER_API_KEY` for both vendors; `ANTHROPIC_API_KEY` is accepted only as a
    backward-compatible fallback when the preferred variable is unset or empty.
 
    The conformance gate pins the staged wrapper, provider, and probe files by SHA-256,
    plus the TTL and recorded behavioral flags. It does not pin the API key,
-   `VERIFIER_API_BASE`, or live `VERIFIER_MODEL`; `provider_version` is only the model
-   label present at attestation time, not the model actually served. Re-attesting after
-   a vendor, model, or endpoint change is therefore an operator duty the gate cannot
-   enforce today; a follow-up issue tracks gating the endpoint and served model in the
-   evidence record.
+   `VERIFIER_API_BASE`, `VERIFIER_API_ALLOWED_HOSTS`, or live `VERIFIER_MODEL`;
+   `provider_version` is only the model label present at attestation time, not the model
+   actually served. Re-attesting after a vendor, model, or endpoint change is therefore
+   an operator duty the gate cannot enforce today; a follow-up issue tracks gating the
+   endpoint and served model in the evidence record.
 
    Operational contract: the example providers and wrapper forward only the validated
    verdict and reason lines. Line 1 must be exactly `VERDICT: <allowed-provider-value>`

--- a/adapters/hermes/examples/verifier-provider.py
+++ b/adapters/hermes/examples/verifier-provider.py
@@ -85,6 +85,28 @@ api_base = (
     f"{parsed_api_base.scheme}://{parsed_api_base.netloc}{parsed_api_base.path}"
 ).rstrip("/")
 
+allowed_hosts_value = os.environ.get("VERIFIER_API_ALLOWED_HOSTS")
+if allowed_hosts_value is None or allowed_hosts_value == "":
+    allowed_hosts = ["api.anthropic.com"]
+else:
+    allowed_hosts = []
+    for allowed_host_value in allowed_hosts_value.split(","):
+        allowed_host = allowed_host_value.strip(" \t")
+        allowed_host_valid = (
+            bool(allowed_host)
+            and allowed_host.isascii()
+            and not any(
+                character.isspace() or unicodedata.category(character) == "Cc"
+                for character in allowed_host
+            )
+            and not any(character in allowed_host for character in "/:@")
+        )
+        if not allowed_host_valid:
+            fail("provider host allowlist is invalid")
+        allowed_hosts.append(allowed_host.lower())
+if parsed_api_base.hostname.lower() not in allowed_hosts:
+    fail("provider API base host is not allowlisted")
+
 model = os.environ.get("VERIFIER_MODEL", "claude-sonnet-5")
 try:
     timeout_seconds = float(os.environ.get("VERIFIER_HTTP_TIMEOUT_S", "120"))

--- a/adapters/hermes/examples/verifier-provider.py
+++ b/adapters/hermes/examples/verifier-provider.py
@@ -92,18 +92,15 @@ else:
     allowed_hosts = []
     for allowed_host_value in allowed_hosts_value.split(","):
         allowed_host = allowed_host_value.strip(" \t")
-        allowed_host_valid = (
-            bool(allowed_host)
-            and allowed_host.isascii()
-            and not any(
-                character.isspace() or unicodedata.category(character) == "Cc"
-                for character in allowed_host
-            )
-            and not any(character in allowed_host for character in "/:@")
-        )
-        if not allowed_host_valid:
+        if not allowed_host:
             fail("provider host allowlist is invalid")
-        allowed_hosts.append(allowed_host.lower())
+        allowed_host = allowed_host.lower()
+        if re.fullmatch(
+            r"[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*",
+            allowed_host,
+        ) is None:
+            fail("provider host allowlist is invalid")
+        allowed_hosts.append(allowed_host)
 if parsed_api_base.hostname.lower() not in allowed_hosts:
     fail("provider API base host is not allowlisted")
 

--- a/tests/hermes-verifier-examples.test.sh
+++ b/tests/hermes-verifier-examples.test.sh
@@ -299,6 +299,7 @@ if grep -Fq '"$FABLE_CONFORMING_PROVIDER_PATH" "$bundle"' "$CANONICAL_WRAPPER" \
   && grep -Fq 'os.environ.get("ANTHROPIC_API_KEY"' "$PROVIDER" \
   && grep -Fq 'os.environ.get("VERIFIER_MODEL", "claude-sonnet-5")' "$PROVIDER" \
   && grep -Fq 'os.environ.get("VERIFIER_API_BASE"' "$PROVIDER" \
+  && grep -Fq 'VERIFIER_API_ALLOWED_HOSTS' "$PROVIDER" \
   && grep -Fq 'f"{api_base}/v1/messages"' "$PROVIDER" \
   && grep -Fq 'urllib.parse.urlsplit(api_base)' "$PROVIDER" \
   && grep -Fq 'urllib.request.build_opener(NoRedirectHandler())' "$PROVIDER" \
@@ -648,6 +649,7 @@ zai_base=https://api.z.ai/api/anthropic
 rm -f "$request_url_marker"
 set +e
 zai_base_output=$(VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$zai_base" \
+  VERIFIER_API_ALLOWED_HOSTS=api.z.ai \
   REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
   REQUEST_COUNT_MARKER="$request_count_marker" \
   python3 "$opener_stub" "$PROVIDER" "$bundle")
@@ -664,6 +666,7 @@ fi
 rm -f "$request_url_marker"
 set +e
 trailing_slash_output=$(VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$zai_base/" \
+  VERIFIER_API_ALLOWED_HOSTS=api.z.ai \
   REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
   REQUEST_COUNT_MARKER="$request_count_marker" \
   python3 "$opener_stub" "$PROVIDER" "$bundle")
@@ -680,6 +683,7 @@ fi
 rm -f "$request_url_marker"
 set +e
 double_slash_output=$(VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$zai_base//" \
+  VERIFIER_API_ALLOWED_HOSTS=api.z.ai \
   REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
   REQUEST_COUNT_MARKER="$request_count_marker" \
   python3 "$opener_stub" "$PROVIDER" "$bundle")
@@ -699,6 +703,7 @@ for bare_delimiter in '#' '?'; do
   set +e
   bare_delimiter_output=$(VERIFIER_API_KEY=fixture \
     VERIFIER_API_BASE="$zai_base$bare_delimiter" \
+    VERIFIER_API_ALLOWED_HOSTS=api.z.ai \
     REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
     REQUEST_COUNT_MARKER="$request_count_marker" \
     python3 "$opener_stub" "$PROVIDER" "$bundle")
@@ -742,6 +747,7 @@ fi
 
 set +e
 redirect_output=$(VERIFIER_API_KEY=redirect-secret VERIFIER_API_BASE="$zai_base" \
+  VERIFIER_API_ALLOWED_HOSTS=api.z.ai \
   STUB_RESPONSE_MODE=redirect REQUEST_URL_MARKER="$request_url_marker" \
   REQUEST_KEY_MARKER="$request_key_marker" REQUEST_COUNT_MARKER="$request_count_marker" \
   python3 "$opener_stub" "$PROVIDER" "$bundle" 2>"$TMP_ROOT/redirect.err")
@@ -804,6 +810,99 @@ if [ "$credential_guard_ok" -eq 1 ]; then
 else
   fail_case '[17] provider prefers VERIFIER_API_KEY, preserves the legacy fallback, and fails without either key' \
     "both=$both_keys_rc legacy=$legacy_key_rc missing=$missing_key_rc"
+fi
+
+host_rejection_guard_ok=1
+for host_rejection_case in \
+  'default-rejects-attacker||https://attacker.example.test' \
+  'explicit-replaces-default|api.z.ai|https://api.anthropic.com'; do
+  host_rejection_name=${host_rejection_case%%|*}
+  host_rejection_rest=${host_rejection_case#*|}
+  host_rejection_allowlist=${host_rejection_rest%%|*}
+  host_rejection_base=${host_rejection_rest#*|}
+  rm -f "$request_count_marker"
+  set +e
+  if [ -n "$host_rejection_allowlist" ]; then
+    host_rejection_output=$(VERIFIER_API_KEY=fixture \
+      VERIFIER_API_BASE="$host_rejection_base" \
+      VERIFIER_API_ALLOWED_HOSTS="$host_rejection_allowlist" \
+      REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+      REQUEST_COUNT_MARKER="$request_count_marker" \
+      python3 "$opener_stub" "$PROVIDER" "$bundle" \
+      2>"$TMP_ROOT/host-rejection-$host_rejection_name.err")
+  else
+    host_rejection_output=$(env -u VERIFIER_API_ALLOWED_HOSTS \
+      VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$host_rejection_base" \
+      REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+      REQUEST_COUNT_MARKER="$request_count_marker" \
+      python3 "$opener_stub" "$PROVIDER" "$bundle" \
+      2>"$TMP_ROOT/host-rejection-$host_rejection_name.err")
+  fi
+  host_rejection_rc=$?
+  set -e
+  if [ "$host_rejection_rc" -ne 1 ] || [ -n "$host_rejection_output" ] \
+    || ! grep -Fqx 'provider API base host is not allowlisted' \
+      "$TMP_ROOT/host-rejection-$host_rejection_name.err" \
+    || [ -e "$request_count_marker" ]; then
+    host_rejection_guard_ok=0
+  fi
+done
+if [ "$host_rejection_guard_ok" -eq 1 ]; then
+  pass '[18] provider rejects non-allowlisted hosts before attempting a credentialed request'
+else
+  fail_case '[18] provider rejects non-allowlisted hosts before attempting a credentialed request' \
+    'a default or explicitly excluded host reached the request path'
+fi
+
+allowlist_validation_guard_ok=1
+for invalid_allowlist in \
+  '   ' \
+  'https://api.z.ai' \
+  'api.z.ai/' \
+  'api.z.ai,,' \
+  'api.z.ai:443'; do
+  rm -f "$request_count_marker"
+  set +e
+  invalid_allowlist_output=$(VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$zai_base" \
+    VERIFIER_API_ALLOWED_HOSTS="$invalid_allowlist" \
+    REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+    REQUEST_COUNT_MARKER="$request_count_marker" \
+    python3 "$opener_stub" "$PROVIDER" "$bundle" \
+    2>"$TMP_ROOT/invalid-allowlist.err")
+  invalid_allowlist_rc=$?
+  set -e
+  if [ "$invalid_allowlist_rc" -ne 1 ] || [ -n "$invalid_allowlist_output" ] \
+    || ! grep -Fqx 'provider host allowlist is invalid' \
+      "$TMP_ROOT/invalid-allowlist.err" \
+    || [ -e "$request_count_marker" ]; then
+    allowlist_validation_guard_ok=0
+  fi
+done
+if [ "$allowlist_validation_guard_ok" -eq 1 ]; then
+  pass '[19] provider fails closed on malformed or empty host allowlist entries before request I/O'
+else
+  fail_case '[19] provider fails closed on malformed or empty host allowlist entries before request I/O' \
+    'one or more invalid allowlists escaped validation or reached the request path'
+fi
+
+rm -f "$request_url_marker" "$request_count_marker"
+set +e
+case_insensitive_output=$(VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$zai_base" \
+  VERIFIER_API_ALLOWED_HOSTS=API.Z.AI \
+  REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+  REQUEST_COUNT_MARKER="$request_count_marker" \
+  python3 "$opener_stub" "$PROVIDER" "$bundle")
+case_insensitive_rc=$?
+set -e
+if [ "$case_insensitive_rc" -eq 0 ] \
+  && [ "$case_insensitive_output" = 'VERDICT: pass
+stub accepted the request URL' ] \
+  && [ "$(cat "$request_url_marker")" = "$zai_base/v1/messages" ] \
+  && [ "$(cat "$request_count_marker")" -eq 1 ]; then
+  pass '[20] provider matches explicitly allowed API hostnames case-insensitively'
+else
+  fail_case '[20] provider matches explicitly allowed API hostnames case-insensitively' \
+    "rc=$case_insensitive_rc output=$case_insensitive_output"
 fi
 
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"

--- a/tests/hermes-verifier-examples.test.sh
+++ b/tests/hermes-verifier-examples.test.sh
@@ -17,6 +17,9 @@ cleanup() {
 trap cleanup EXIT HUP INT TERM
 mkdir -p "$TMP_ROOT"
 
+# Prevent ambient operator configuration from leaking into test cases.
+unset VERIFIER_API_BASE VERIFIER_API_ALLOWED_HOSTS
+
 pass() {
   PASS_COUNT=$((PASS_COUNT + 1))
   printf 'PASS %s\n' "$1"
@@ -815,6 +818,7 @@ fi
 host_rejection_guard_ok=1
 for host_rejection_case in \
   'default-rejects-attacker||https://attacker.example.test' \
+  'set-empty-rejects-attacker|@EMPTY@|https://attacker.example.test' \
   'explicit-replaces-default|api.z.ai|https://api.anthropic.com'; do
   host_rejection_name=${host_rejection_case%%|*}
   host_rejection_rest=${host_rejection_case#*|}
@@ -822,7 +826,15 @@ for host_rejection_case in \
   host_rejection_base=${host_rejection_rest#*|}
   rm -f "$request_count_marker"
   set +e
-  if [ -n "$host_rejection_allowlist" ]; then
+  if [ "$host_rejection_allowlist" = '@EMPTY@' ]; then
+    host_rejection_output=$(VERIFIER_API_KEY=fixture \
+      VERIFIER_API_BASE="$host_rejection_base" \
+      VERIFIER_API_ALLOWED_HOSTS= \
+      REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+      REQUEST_COUNT_MARKER="$request_count_marker" \
+      python3 "$opener_stub" "$PROVIDER" "$bundle" \
+      2>"$TMP_ROOT/host-rejection-$host_rejection_name.err")
+  elif [ -n "$host_rejection_allowlist" ]; then
     host_rejection_output=$(VERIFIER_API_KEY=fixture \
       VERIFIER_API_BASE="$host_rejection_base" \
       VERIFIER_API_ALLOWED_HOSTS="$host_rejection_allowlist" \
@@ -860,7 +872,9 @@ for invalid_allowlist in \
   'https://api.z.ai' \
   'api.z.ai/' \
   'api.z.ai,,' \
-  'api.z.ai:443'; do
+  'api.z.ai:443' \
+  'api.z%2e.ai' \
+  '*'; do
   rm -f "$request_count_marker"
   set +e
   invalid_allowlist_output=$(VERIFIER_API_KEY=fixture VERIFIER_API_BASE="$zai_base" \


### PR DESCRIPTION
# security(#241): verifier-provider credential attachment restricted to an explicit host allowlist

Closes #241.

## What

`adapters/hermes/examples/verifier-provider.py` previously accepted any HTTPS host in `VERIFIER_API_BASE` and attached `VERIFIER_API_KEY` / `ANTHROPIC_API_KEY` as `x-api-key` to it (adopted nightly finding `rv-security-codex-6780fb46b4f2-519fbada`). The provider now refuses, before any I/O, any base whose hostname is not on an explicit allowlist:

- default allowlist = `api.anthropic.com` only
- overrides require the new `VERIFIER_API_ALLOWED_HOSTS` env (comma-separated bare lowercase LDH hostnames, strict fail-closed parse; explicit list **replaces** the default)
- the documented z.ai flow opts in via `VERIFIER_API_ALLOWED_HOSTS=api.z.ai` (INSTALL.md updated; vendor-switch guidance covers base+allowlist+key together)
- the sibling finding `rv-security-codex-6780fb46b4f2-ea0109e5` (review-labels outbound declaration gap) was **already resolved on main by #136** — verified by all 5 seats on this branch; no change needed (file untouched)

## Files touched (WIP declaration vs diff)

Declared (issue #241 WIP comment): `adapters/hermes/examples/verifier-provider.py`, `tests/hermes-verifier-examples.test.sh`, `adapters/hermes/INSTALL.md`, `.github/workflows/review-labels.yml` (verification-only expected).
Actual diff (`git diff --stat origin/main...06ecebd`):

```
 adapters/hermes/INSTALL.md                    |  28 +++++--
 adapters/hermes/examples/verifier-provider.py |  19 +++++
 tests/hermes-verifier-examples.test.sh        | 113 ++++++++++++++++++++++++++
 3 files changed, 152 insertions(+), 8 deletions(-)
```

Match: 3 of 4 declared files in diff; `review-labels.yml` intentionally untouched (declared as verification-only; verified correct as-is). No undeclared files in the diff.

## Completion record (L1-7)

Candidate SHA: `06ecebd` (= PR head at review time)
Implementer: Codex GPT-5.6 Sol (writer, `--profile sol`; commits authored by shojikumaru local orchestration, Alpha session 44fc0283)
Reviewers: 5-seat heterogeneous panel — see review record comment (r1 blind + delta cumulative; requested/actual per seat; codex-sol same-family seat under seat-decree 2026-08-12 exception, recorded)

### Done when → evidence

1. **Provider refuses to attach credentials outside an explicit allowlist (default: Anthropic; documented opt-in override)** — PASS
   Evidence (2026-09-02, worktree wt/241): `VERIFIER_API_KEY=x VERIFIER_API_BASE=https://evil.example python3 -B adapters/hermes/examples/verifier-provider.py b` → rc=1, stderr `provider API base host is not allowlisted`, no request constructed (enforcement precedes `urllib.request.Request` creation; verified by 5 seats with opener-stub request markers — zero credentialed requests in every rejection probe). Opt-in documented in INSTALL.md z.ai block (`VERIFIER_API_ALLOWED_HOSTS=api.z.ai`).
2. **Test exercises the rejection path** — PASS
   Test `[18] provider rejects non-allowlisted hosts before attempting a credentialed request` (3 modes: default/attacker, set-but-empty/attacker, explicit-list/non-member) asserts rc=1 + exact stderr + request-count marker absent. Mutation-verified by 4 seats independently (membership check neutralized ⇒ [18] red on rc, stderr and marker; Opus 5-mutant sweep: all 5 killed post-delta).
3. **review-labels.yml outbound declaration covers the file** — PASS (already true on main)
   `.github/workflows/review-labels.yml:19-20` declares `adapters/hermes/examples/verifier-provider.py` under `risk_paths_outbound` (since #136). Verified on this branch by all 5 seats; `git diff origin/main...06ecebd -- .github/workflows/review-labels.yml` is empty (2026-09-02).
4. **Test suite green** — PASS
   `bash tests/hermes-verifier-examples.test.sh` → `Summary: 30 PASS, 0 FAIL`; `make test` → `Suite Summary: 43 PASS, 0 FAIL`; `make lint` → `lint: 89 shell files OK` (2026-09-02, wt/241 at 06ecebd; Opus seat independently reproduced make test 43/43).

### CI status

At head `06ecebd` (2026-09-02): `test-lint / test` **pass** (22m0s, run 33550339392) / `test-lint / test-macos` **pass** (29m15s, same run — note: near the 30-min ceiling tracked in #261) / `test-lint / lint` pass / gitleaks pass / history-check pass / pr-size pass / repo-state pass / watch pass / `risk-review-gate / detect-risk-paths` pass. The only non-green check is `risk-review-gate / risk-review-gate` = fail-by-design until the human `risk-reviewed` label is applied (this PR touches the declared outbound risk path, so the gate correctly fired).

### release

`release: v0.24.0` — shipping-relevant (changes the behavior of a distributed example adapter + operator-facing docs/norms). Tag to be cut on the main merge commit; MERGED declaration only after the GitHub Release exists (T-5).

### previous release

Previous shipping merge in this repo: #242 lane → `v0.23.9` — fulfilled (annotated tag + GitHub Release exist: https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.23.9).

## Review

- r1 (blind, 5 seats): Kimi GO / Codex GO-W-MINOR / GLM GO / Grok GO / Opus GO-W-MINOR — CRITICAL/MAJOR: none. Adjudication adopted 5 findings (delta commit `06ecebd`), recorded 3 as non-blocking by convergence (port-not-pinned: 4 seats; padding tolerance; empty-env=default now test-pinned).
- delta (cumulative): 5/5 cumulative GO at 06ecebd (Kimi / Codex / GLM / Grok / Opus), all 5 adopted findings independently verified RESOLVED, zero new findings. Opus re-ran its surviving mutant M5 → now KILLED by the new test [18] set-empty case; Grok re-ran its r1 percent-entry probe → now fail-closed.
- Full review record with requested/actual models and evidence: review record comment on this PR (posted after opening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
