### PR TITLE
ci(repo-state): adopt family-os v0.19.0 (workflow_run after release-sync) (family-os#165)

### DIFF
--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_run:
+    workflows: [release-sync]
+    types: [completed]
   pull_request:
 
 permissions:
@@ -17,7 +20,7 @@ concurrency:
 
 jobs:
   repo-state:
-    uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.18.0
+    uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.19.0
     secrets: inherit
     with:
-      generator_ref: v0.18.0
+      generator_ref: v0.19.0


### PR DESCRIPTION
## Why

Follow-up to caty-ai/family-os#165 (fix merged as family-os PR #170, released as [v0.19.0](https://github.com/caty-ai/family-os/releases/tag/v0.19.0)). With v0.18.0 the stamp refreshes on every `update` run, but a Release created by release-sync with `GITHUB_TOKEN` fires no `release` event, so a repo that releases and then goes quiet keeps the previous `latest_tag` until its next unrelated push. v0.19.0 adds a `workflow_run` path: when this repo's `release-sync` workflow completes successfully, the reusable `update` job checks out the default branch and refreshes the stamp.

## What (mechanical diff)

`.github/workflows/repo-state.yml`:
- `on:` gains `workflow_run: workflows: [release-sync], types: [completed]` (this repo's carrier is named `release-sync`)
- `uses: …/repo-state.yml@v0.19.0` + `generator_ref: v0.19.0` (refs move together per the caller contract)

Nothing else changes. Generator unchanged since v0.12.1.

Behaviour after merge: one extra `update` run per release (after release-sync completes; failed/cancelled carrier runs do not trigger it), which regenerates and pushes a stamp commit only if `latest_tag` changed. Details: family-os `docs/repo-state/spec.md` §4.

## Review

Batch of 13 caller adoptions, one heterogeneous delta seat over the whole batch diff (the family-os#127 owner-approved lighter scheme for mechanical copies, as used for the v0.18.0 bump on #163). Seat record on caty-ai/family-os#165.

## 完了記録 (Completion record)

candidate SHA: 766850d538b79777a06f08390d05ab3a591f3de2
implementer: Alpha (Claude Fable 5.1) — mechanical yml edit (3-line trigger + 2 pin lines)
reviewer: BATCH_SEAT
identity check: 別モデル
CI: see PR checks at merge time (recorded on family-os#165 per repo)
release: N/A ③ (CI wiring only — the caller trigger and pin; no behaviour, API or artifact of this repository changes)
previous release: unchanged by this PR (no ship-equivalent change here); ledger continues on this repo's next ship-equivalent lane

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| Caller declares `workflow_run` on `release-sync` and pins `@v0.19.0` / `generator_ref: v0.19.0` | PASS | this diff, 2026-09-05 |
| After this repo's next release-sync Release, `latest_tag` refreshes without a further push | recorded on family-os#165 at the next release | `workflow_run` run + stamp commit |

Tracked in caty-ai/family-os#165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
