### PR TITLE
fix(raw-review): canonicalize the date-led provenance stamp in citations (#274)

### DIFF
--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -82,10 +82,19 @@ fail-closed）のいずれかです。
 THEME block 間の空行は許容しますが、block 内の空行は不正です。各 member citation は
 比較時に先頭の indentation、1 個の bullet marker、ISO date prefix、`[session-806]` /
 `[2026-07-20]` のように内部 whitespace を含まず、ASCII digit または `-` を少なくとも 1 つ含み、
-閉じ `]` の直後に space または tab が続く保守的な machine tag、`**bold**` / word-adjacent な
+閉じ `]` の直後に space または tab が続く保守的な machine tag、最大 1 個の日付で始まる
+provenance stamp（`(YYYY-MM-DD)` または数字を含む job id を伴う `(YYYY-MM-DD, job-id)`、
+例: `(2026-09-04, ev007b-C-r1j1)`）、`**bold**` / word-adjacent な
 `*bold*` のような paired emphasis marker を除いたうえで、正規化後 8〜200 文字で、
 正規化済み source line の先頭に一致する必要があります。
 `[IMPORTANT]` / `[NEVER]` のような human warning tag と、意味を持つ lone/glob `*` token は保持されます。
+stamp を引用に含めても常に構いません。stamp の区切りは `,` または `;`、その直後の space/tab は任意で、
+job id は `[A-Za-z0-9][A-Za-z0-9._-]{0,59}` に一致する 1〜60 文字の ASCII task id かつ
+ASCII 数字を含むものに限ります。それ以外の括弧内 whitespace は認めず、`)` の直後には space/tab が必要です。
+source と quote の両方で除去順序は bullet → date → 最大 2 個の tags → stamp → emphasis に固定され、
+`(date, id) [tag]` の tag は保持されます。他の括弧書き（例: `(IMPORTANT)`、`(DO-NOT-DELETE)`、
+`(Rule 1)`、`(2026-09-04, unverified)`、日付の後の単独の `(job-id)`）は内容なので省略しないでください。
+引用は 200 文字以内にしてください。
 短すぎる citation、行途中だけの一致、fabrication は block 全体を reject します。fabricated block 数が
 `max(fabricated_floor, ceil(block 数の fabricated_pct%))` に達すると reviewer call 全体を fail にします。
 `fabricated_pct` の既定値は 50、許容範囲は 1〜100 です。`loop/review.conf` の数値は 10 進として解釈するため、

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -83,9 +83,18 @@ THEME blocks may be separated by blank lines, but blank lines inside a block are
 Each member citation must normalize to 8–200 characters and match the start of a normalized
 source line after leading indentation, one bullet marker, an ISO date prefix, conservative
 machine tags with no internal whitespace that contain at least one ASCII digit or `-` and are
-followed by space or tab, and paired emphasis markers such as `**bold**` / word-adjacent
+followed by space or tab, at most one date-led provenance stamp of the form `(YYYY-MM-DD)`
+or `(YYYY-MM-DD, job-id)` where the job id contains a digit — e.g. `(2026-09-04, ev007b-C-r1j1)` —
+and paired emphasis markers such as `**bold**` / word-adjacent
 `*bold*` are stripped for comparison. Human warning tags such as `[IMPORTANT]` or `[NEVER]`,
-and meaningful lone/glob `*` tokens, remain significant. Shorter, mid-line-only,
+and meaningful lone/glob `*` tokens, remain significant. Quoting the stamp as part of the citation
+is always acceptable. The stamp permits `,` or `;`, optional space/tab after the separator, and
+a 1–60 character ASCII task id matching `[A-Za-z0-9][A-Za-z0-9._-]{0,59}` with an ASCII digit;
+no other internal whitespace is allowed, and `)` must be followed by space/tab.
+The fixed order on both source and quote is bullet → date → up to two tags → stamp → emphasis;
+`(date, id) [tag]` keeps the tag. Do not omit any other parenthetical (for example `(IMPORTANT)`,
+`(DO-NOT-DELETE)`, `(Rule 1)`, `(2026-09-04, unverified)`, or a bare `(job-id)` after a date);
+they are content. Keep the quote at 200 characters or fewer. Shorter, mid-line-only,
 or fabricated citations reject the complete block. The whole reviewer call fails when fabricated
 blocks reach `max(fabricated_floor, ceil(fabricated_pct% of blocks))`; `fabricated_pct`
 defaults to 50 and accepts values from 1 through 100. Numeric `loop/review.conf` values are

--- a/scripts/raw-review.sh
+++ b/scripts/raw-review.sh
@@ -429,6 +429,11 @@ def canonicalize(value):
         if not re.search(r"[0-9-]", match.group(1)):
             break
         value = value[match.end():]
+    # The identifier charset mirrors is_safe_id in scripts/tr-enqueue, bounded
+    # here to 60 characters; digit-free parentheticals remain content.
+    stamp = re.match(r"^\(([0-9]{4}-[0-9]{2}-[0-9]{2})(?:[,;][ \t]*([A-Za-z0-9][A-Za-z0-9._-]{0,59}))?\)[ \t]+", value)
+    if stamp and (stamp.group(2) is None or re.search(r"[0-9]", stamp.group(2))):
+        value = value[stamp.end():]
     previous = None
     while value != previous:
         previous = value

--- a/templates/review-prompt.md
+++ b/templates/review-prompt.md
@@ -31,8 +31,8 @@ optional space/tab after the separator, and a 1–60 character ASCII task id mat
 `[A-Za-z0-9][A-Za-z0-9._-]{0,59}` with an ASCII digit; no other internal whitespace is allowed,
 and `)` must be followed by space/tab. At most one stamp is stripped. The fixed order is
 bullet → date → up to two tags → stamp → emphasis; `(date, id) [tag]` keeps the tag.
-The same rule applies to source and quote. Paired emphasis markers such as `**bold**` or
-word-adjacent `*bold*` are also stripped for comparison.
+The same rule applies to source and quote; for comparison, paired emphasis markers such as
+`**bold**` or word-adjacent `*bold*` are also stripped.
 Do not skip human warning tags such as `[IMPORTANT]` / `[NEVER]`, and do not
 omit a meaningful lone `*` token. Do not omit any other parenthetical (for example
 `(IMPORTANT)`, `(DO-NOT-DELETE)`, `(Rule 1)`, `(2026-09-04, unverified)`, or a bare

--- a/templates/review-prompt.md
+++ b/templates/review-prompt.md
@@ -24,9 +24,19 @@ a block. Include at most five MEMBERS citations per theme, choosing the clearest
 Keep EVIDENCE to one to three lines. Quote each member verbatim from the start of the
 lesson content after any leading indentation, bullet, ISO date, conservative machine tags
 with no internal whitespace that contain at least one ASCII digit or `-` and are followed by
-space or tab, and paired emphasis markers such as `**bold**` or word-adjacent `*bold*`.
+space or tab, and a date-led provenance stamp of the form `(YYYY-MM-DD)` or
+`(YYYY-MM-DD, job-id)` where the job id contains a digit — e.g. `(2026-09-04, ev007b-C-r1j1)`.
+Quoting the stamp as part of the citation is always acceptable. The stamp permits `,` or `;`,
+optional space/tab after the separator, and a 1–60 character ASCII task id matching
+`[A-Za-z0-9][A-Za-z0-9._-]{0,59}` with an ASCII digit; no other internal whitespace is allowed,
+and `)` must be followed by space/tab. At most one stamp is stripped. The fixed order is
+bullet → date → up to two tags → stamp → emphasis; `(date, id) [tag]` keeps the tag.
+The same rule applies to source and quote,
+and paired emphasis markers such as `**bold**` or word-adjacent `*bold*` are stripped for comparison.
 Do not skip human warning tags such as `[IMPORTANT]` / `[NEVER]`, and do not
-omit a meaningful lone `*` token. Keep the quote at 200 characters or fewer.
+omit a meaningful lone `*` token. Do not omit any other parenthetical (for example
+`(IMPORTANT)`, `(DO-NOT-DELETE)`, `(Rule 1)`, `(2026-09-04, unverified)`, or a bare
+`(job-id)` after a date); they are content. Keep the quote at 200 characters or fewer.
 When there are no groups, write
 `NO_GROUPS:` inside the markers and no THEME block. Put no extra prose beyond this
 grammar inside the markers, and put none outside them. Citation authenticity is checked

--- a/templates/review-prompt.md
+++ b/templates/review-prompt.md
@@ -31,8 +31,8 @@ optional space/tab after the separator, and a 1–60 character ASCII task id mat
 `[A-Za-z0-9][A-Za-z0-9._-]{0,59}` with an ASCII digit; no other internal whitespace is allowed,
 and `)` must be followed by space/tab. At most one stamp is stripped. The fixed order is
 bullet → date → up to two tags → stamp → emphasis; `(date, id) [tag]` keeps the tag.
-The same rule applies to source and quote,
-and paired emphasis markers such as `**bold**` or word-adjacent `*bold*` are stripped for comparison.
+The same rule applies to source and quote. Paired emphasis markers such as `**bold**` or
+word-adjacent `*bold*` are also stripped for comparison.
 Do not skip human warning tags such as `[IMPORTANT]` / `[NEVER]`, and do not
 omit a meaningful lone `*` token. Do not omit any other parenthetical (for example
 `(IMPORTANT)`, `(DO-NOT-DELETE)`, `(Rule 1)`, `(2026-09-04, unverified)`, or a bare

--- a/tests/raw-review.test.sh
+++ b/tests/raw-review.test.sh
@@ -691,6 +691,314 @@ else
   fail_case '[R3-3] tag-only quotes still die after bracket stripping empties the canonicalized citation' "rc=$bracket_tags_empty_rc receipt=$(tail -n 1 "$ws_bracket_tags_empty/loop/promotions/runs.log") stderr=$(cat "$TMP_ROOT/bracket-tags-empty.err")"
 fi
 
+# Run one #274 citation against one provenance-stamped source line. The
+# production-shaped flush header keeps session attribution in the fixture.
+CASE_274_RESULTS=
+CASE_274_WS=
+CASE_274_CANDIDATE=
+CASE_274_REJECTS=
+run_274_single() {
+  local name=$1 source_line=$2 quote=$3 expected=$4
+  local reviewer output ws rc receipt candidate rejects matched=0
+  reviewer=$TMP_ROOT/274-$name-reviewer
+  output=$TMP_ROOT/274-$name-output
+  write_reviewer "$reviewer" 'cat >/dev/null
+cat "$1"'
+  {
+    printf '%s\n' RAW-REVIEW-OUTPUT-BEGIN
+    printf 'THEME: provenance fixture %s\n' "$name"
+    printf '%s\n' 'CLASS: rule' 'MEMBERS:'
+    printf -- '- flush-2026-09-04.md:%s\n' "$quote"
+    printf '%s\n' 'WEEKS: 2026-W36' 'EVIDENCE: The citation result pins the bounded provenance grammar.' 'PROMOTE: not-yet' RAW-REVIEW-OUTPUT-END
+  } >"$output"
+  ws=$(new_ws "274-$name")
+  printf '%s\n' \
+    "<!-- flush origin=stop-hook-demand session=session-$name ts=2026-09-04T01:00:00Z outcome=ok unverified=true -->" \
+    "$source_line" >"$ws/loop/archive/flush-2026-09-04.md"
+  write_conf "$ws" producer-model "fixture-$name $reviewer $output"
+  "$RAW_REVIEW" --workspace "$ws" --week 2026-W36 >/dev/null 2>"$TMP_ROOT/274-$name.err"
+  rc=$?
+  receipt=$(tail -n 1 "$ws/loop/promotions/runs.log")
+  candidate=$(latest_candidate "$ws")
+  rejects=$(find "$ws/loop/promotions" -type f -name 'candidates-*.rejects.md' | LC_ALL=C sort | tail -n 1)
+  CASE_274_RESULTS="$CASE_274_RESULTS$name:$receipt|"
+  CASE_274_WS=$ws
+  CASE_274_CANDIDATE=$candidate
+  CASE_274_REJECTS=$rejects
+  if [[ "$expected" == accepted ]]; then
+    if [[ "$rc" -eq 0 && "$receipt" == *' fabricated=0 '* && "$receipt" == *' candidates=1 '* \
+      && -f "$candidate" ]] && grep -Fq -- "- flush-2026-09-04.md:$quote" "$candidate"; then
+      matched=1
+    fi
+  elif [[ "$rc" -eq 1 && "$receipt" == *' fabricated=1 '* \
+    && "$receipt" == *' candidates=0 '* && "$receipt" == *' error=chain-exhausted' \
+    && -f "$rejects" ]] && grep -Fq -- "- flush-2026-09-04.md:$quote" "$rejects"; then
+    matched=1
+  fi
+  [[ "$matched" -eq 1 ]]
+}
+
+CASE_274_RESULTS=
+p1_ok=1
+run_274_single p1-comma \
+  '- (2026-09-04, ev007b-C-r1j1) Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows.' \
+  'Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows.' accepted || p1_ok=0
+run_274_single p1-semicolon \
+  '- (2026-09-04;r1j1) Semicolon provenance stamps use the same bounded task identifier grammar.' \
+  'Semicolon provenance stamps use the same bounded task identifier grammar.' accepted || p1_ok=0
+run_274_single p1-after-tag \
+  '- [tag-1] (2026-09-04, r1j1) Machine tags precede provenance stamps in the fixed canonicalization order.' \
+  'Machine tags precede provenance stamps in the fixed canonicalization order.' accepted || p1_ok=0
+if [[ "$p1_ok" -eq 1 ]]; then
+  pass '[274-P1] date-led provenance stamps authenticate content-only prefixes'
+else
+  fail_case '[274-P1] date-led provenance stamps authenticate content-only prefixes' "$CASE_274_RESULTS"
+fi
+
+CASE_274_RESULTS=
+if run_274_single p5-date-only \
+  '- (2026-09-04) Date-only provenance stamps are a deliberate supported extension.' \
+  'Date-only provenance stamps are a deliberate supported extension.' accepted; then
+  pass '[274-P5] date-only provenance stamps authenticate content-only prefixes'
+else
+  fail_case '[274-P5] date-only provenance stamps authenticate content-only prefixes' "$CASE_274_RESULTS"
+fi
+
+CASE_274_RESULTS=
+if run_274_single p3-inclusive \
+  '- (2026-09-04, ev007b-C-r1j1) Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows.' \
+  '(2026-09-04, ev007b-C-r1j1) Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows.' accepted; then
+  pass '[274-P3] a quote that includes the provenance stamp remains accepted symmetrically'
+else
+  fail_case '[274-P3] a quote that includes the provenance stamp remains accepted symmetrically' "$CASE_274_RESULTS"
+fi
+
+REPLAY_274=$TMP_ROOT/274-p4-replay-reviewer
+write_reviewer "$REPLAY_274" 'cat >/dev/null
+cat <<"OUT"
+RAW-REVIEW-OUTPUT-BEGIN
+THEME: exact-substring CSV extraction fidelity
+CLASS: rule
+MEMBERS:
+- flush-2026-09-04.md:Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows; the donecheck validation confirms this contract via substring matching
+- flush-2026-09-04.md:CSV ledger files contain multiple entries for same txn_id across different rows (e.g., TXN-04001 in 094-ledger-log.csv appears on line 3 with status PENDING and again on line 39 with status FAILED
+WEEKS: 2026-W36
+EVIDENCE: Two sessions independently require extraction fidelity to source CSV ledger rows: character-for-character substrings enforced by donecheck validation, plus inclusion of every row matching a txn_id because transactions recur with status updates.
+PROMOTE: not-yet
+
+THEME: non-overlapping corpus chunk partitioning
+CLASS: capability-fact
+MEMBERS:
+- flush-2026-09-04.md:Each corpus chunk step processes only its listed files; no overlap or file re-reading between steps. Step planning pre-partitions the 52 total ledger files into 4 fixed chunks of 13 files each,
+WEEKS: 2026-W36
+EVIDENCE: Step planning pre-partitions the 52 ledger files into 4 fixed chunks of 13; each step reads only its listed files so nothing is processed twice.
+PROMOTE: not-yet
+
+THEME: Faithful extraction of CSV source rows for validation
+CLASS: skill
+MEMBERS:
+- flush-2026-09-04.md:Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows; the donecheck validation confirms this contract via substring matching, so truncation or refo
+- flush-2026-09-04.md:CSV ledger files contain multiple entries for same txn_id across different rows (e.g., TXN-04001 in 094-ledger-log.csv appears on line 3 with status PENDING and again on line 39 with status FAILED as a status update)
+WEEKS: 2026-W36
+EVIDENCE: Both lessons demand extraction that mirrors the source rows exactly — character-for-character substrings to pass substring-match validation, and inclusion of every matching row (status updates) so output reflects the data as recorded.
+PROMOTE: not-yet
+
+THEME: Pre-partition corpus chunks to avoid duplicate processing
+CLASS: rule
+MEMBERS:
+- flush-2026-09-04.md:Each corpus chunk step processes only its listed files; no overlap or file re-reading between steps. Step planning pre-partitions the 52 total ledger files into 4 fixed chunks of 13 files each, avoiding duplicate processing.
+WEEKS: 2026-W36
+EVIDENCE: Single lesson stating that step planning must pre-partition files into fixed disjoint chunks so no file is read twice.
+PROMOTE: not-yet
+RAW-REVIEW-OUTPUT-END
+OUT'
+ws_274_replay=$(new_ws 274-p4-replay)
+cat <<'EOF_RAW' >"$ws_274_replay/loop/archive/flush-2026-09-04.md"
+<!-- flush origin=stop-hook-demand session=ev007b-C-r1j1 ts=2026-09-04T01:00:00Z outcome=ok unverified=true -->
+- (2026-09-04, ev007b-C-r1j1) Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows; the donecheck validation confirms this contract via substring matching, so truncation or reformatting will fail validation even if the semantic content is correct.
+- (2026-09-04, ev007b-C-r1j1) Each corpus chunk step processes only its listed files; no overlap or file re-reading between steps. Step planning pre-partitions the 52 total ledger files into 4 fixed chunks of 13 files each, avoiding duplicate processing.
+<!-- flush origin=stop-hook-demand session=ev007b-C-r1j2 ts=2026-09-04T02:00:00Z outcome=ok unverified=true -->
+- (2026-09-04, ev007b-C-r1j2) CSV ledger files contain multiple entries for same txn_id across different rows (e.g., TXN-04001 in 094-ledger-log.csv appears on line 3 with status PENDING and again on line 39 with status FAILED as a status update). Query extraction must include all matching rows to accurately reflect the data as recorded in source files.
+<!-- flush origin=stop-hook-demand session=ev007b-C-r2j2 ts=2026-09-04T03:00:00Z outcome=ok unverified=true -->
+- 2026-09-04 (ev007b-C-r2j2) Step 1 executed successfully: read all 13 specified corpus files (001, 002, 003, 005, 008, 010, 012, 013, 015, 018, 019, 020, 023-ledger-log.csv), extracted 26 transaction IDs across Q01-Q05 (6 + 7 + 7 + 6 + 6 txn_ids respectively).
+EOF_RAW
+{
+  printf '%s\n' 'producer=producer-model' "reviewer replay $REPLAY_274" \
+    'review_window_weeks=2' 'reviewer_timeout_s=10' \
+    'fabricated_floor=4' 'zero_streak_threshold=2' 'prompt_max_bytes=2000000'
+} >"$ws_274_replay/loop/review.conf"
+# Production uses fabricated_floor=4; with 4 blocks, max(4, ceil(4*50/100)) is 4.
+"$RAW_REVIEW" --workspace "$ws_274_replay" --week 2026-W36 >/dev/null 2>"$TMP_ROOT/274-p4-replay.err"
+replay_274_rc=$?
+replay_274_receipt=$(tail -n 1 "$ws_274_replay/loop/promotions/runs.log")
+replay_274_candidate=$(latest_candidate "$ws_274_replay")
+replay_274_rejects=$(find "$ws_274_replay/loop/promotions" -type f -name 'candidates-*.rejects.md' | LC_ALL=C sort | tail -n 1)
+if [[ "$replay_274_rc" -eq 0 && "$replay_274_receipt" == *' blocks=4 '* \
+  && "$replay_274_receipt" == *' fabricated=2 '* && "$replay_274_receipt" == *' candidates=2 '* \
+  && -f "$replay_274_candidate" && -f "$replay_274_rejects" \
+  && "$(grep -c '^- flush-2026-09-04.md:' "$replay_274_candidate")" -eq 3 ]] \
+  && grep -Fq 'flush-2026-09-04.md:Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows; the donecheck validation confirms this contract via substring matching' "$replay_274_candidate" \
+  && grep -Fq 'flush-2026-09-04.md:CSV ledger files contain multiple entries for same txn_id across different rows (e.g., TXN-04001 in 094-ledger-log.csv appears on line 3 with status PENDING and again on line 39 with status FAILED' "$replay_274_candidate" \
+  && grep -Fq 'flush-2026-09-04.md:Each corpus chunk step processes only its listed files; no overlap or file re-reading between steps. Step planning pre-partitions the 52 total ledger files into 4 fixed chunks of 13 files each,' "$replay_274_candidate" \
+  && grep -Fq 'THEME: Faithful extraction of CSV source rows for validation' "$replay_274_rejects" \
+  && grep -Fq 'THEME: Pre-partition corpus chunks to avoid duplicate processing' "$replay_274_rejects"; then
+  pass '[274-P4-replay] real EV-007b data accepts exactly the three citations at or below 200 characters'
+else
+  fail_case '[274-P4-replay] real EV-007b data accepts exactly the three citations at or below 200 characters' "rc=$replay_274_rc receipt=$replay_274_receipt candidate=$(cat "$replay_274_candidate" 2>/dev/null)"
+fi
+
+I1_274=$TMP_ROOT/274-i1-reviewer
+write_reviewer "$I1_274" 'cat >/dev/null
+cat <<"OUT"
+RAW-REVIEW-OUTPUT-BEGIN
+THEME: duplicate spellings do not inflate recurrence
+CLASS: rule
+MEMBERS:
+- flush-2026-09-04.md:Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows.
+- flush-2026-09-04.md:(2026-09-04, ev007b-C-r1j1) Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows.
+WEEKS: 2026-W36
+EVIDENCE: Both spellings resolve to one source session.
+PROMOTE: not-yet
+RAW-REVIEW-OUTPUT-END
+OUT'
+ws_274_i1=$(new_ws 274-i1)
+printf '%s\n' \
+  '<!-- flush origin=stop-hook-demand session=ev007b-C-r1j1 ts=2026-09-04T01:00:00Z outcome=ok unverified=true -->' \
+  '- (2026-09-04, ev007b-C-r1j1) Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows.' \
+  >"$ws_274_i1/loop/archive/flush-2026-09-04.md"
+write_conf "$ws_274_i1" producer-model "i1 $I1_274"
+"$RAW_REVIEW" --workspace "$ws_274_i1" --week 2026-W36 >/dev/null 2>"$TMP_ROOT/274-i1.err"
+i1_274_rc=$?
+i1_274_receipt=$(tail -n 1 "$ws_274_i1/loop/promotions/runs.log")
+i1_274_candidate=$(latest_candidate "$ws_274_i1")
+if [[ "$i1_274_rc" -eq 0 && "$i1_274_receipt" == *' fabricated=0 '* \
+  && "$i1_274_receipt" == *' candidates=1 '* && -f "$i1_274_candidate" \
+  && "$(grep -c '^run-k: 1$' "$i1_274_candidate")" -eq 1 \
+  && "$(grep -c '^run-sessions: 1$' "$ws_274_i1/loop/promotions/ledger.md")" -eq 1 ]]; then
+  pass '[274-I1] two citation spellings of one source line receive exactly one session of recurrence credit'
+else
+  fail_case '[274-I1] two citation spellings of one source line receive exactly one session of recurrence credit' "rc=$i1_274_rc receipt=$i1_274_receipt candidate=$(cat "$i1_274_candidate" 2>/dev/null)"
+fi
+
+# `(date, X)` is the STATE.md provenance slot and X is a valid task id under
+# is_safe_id; a digit-bearing X cannot be separated from a job id by grammar —
+# recorded equivalence, #274 design round 3 (one seat dissented; promotion
+# writes the THEME, never the member quote).
+CASE_274_RESULTS=
+c1_ok=1
+run_274_single c1-rule-content '- (2026-09-04, Rule-1) Do not push unreviewed migrations' \
+  'Do not push unreviewed migrations' accepted || c1_ok=0
+run_274_single c1-rule-inclusive '- (2026-09-04, Rule-1) Do not push unreviewed migrations' \
+  '(2026-09-04, Rule-1) Do not push unreviewed migrations' accepted || c1_ok=0
+run_274_single c1-unsafe-content '- (2026-09-04, unsafe-1) safe to deploy' \
+  'safe to deploy' accepted || c1_ok=0
+run_274_single c1-unsafe-inclusive '- (2026-09-04, unsafe-1) safe to deploy' \
+  '(2026-09-04, unsafe-1) safe to deploy' accepted || c1_ok=0
+if [[ "$c1_ok" -eq 1 ]]; then
+  pass '[274-C1] digit-bearing task ids in the date-led provenance slot share the recorded equivalence'
+else
+  fail_case '[274-C1] digit-bearing task ids in the date-led provenance slot share the recorded equivalence' "$CASE_274_RESULTS"
+fi
+
+CASE_274_RESULTS=
+if run_274_single n1-absent \
+  '- (2026-09-04, ev007b-C-r1j1) Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows.' \
+  'This plausible provenance citation does not exist in the selected source file.' rejected; then
+  pass '[274-N1] a plausible provenance stamp cannot authenticate a line that does not exist'
+else
+  fail_case '[274-N1] a plausible provenance stamp cannot authenticate a line that does not exist' "$CASE_274_RESULTS"
+fi
+
+CASE_274_RESULTS=
+if run_274_single n2-midline \
+  '- (2026-09-04, ev007b-C-r1j1) Quote extraction for answer verification must use exact character-for-character substrings from source CSV rows.' \
+  'must use exact character-for-character substrings from source CSV rows.' rejected; then
+  pass '[274-N2] provenance stripping does not relax prefix anchoring for mid-line fragments'
+else
+  fail_case '[274-N2] provenance stripping does not relax prefix anchoring for mid-line fragments' "$CASE_274_RESULTS"
+fi
+
+CASE_274_RESULTS=
+if run_274_single n3-over-cap \
+  '- (2026-09-04, ev007b-C-r1j2) CSV ledger files contain multiple entries for same txn_id across different rows (e.g., TXN-04001 in 094-ledger-log.csv appears on line 3 with status PENDING and again on line 39 with status FAILED as a status update). Query extraction must include all matching rows to accurately reflect the data as recorded in source files.' \
+  'CSV ledger files contain multiple entries for same txn_id across different rows (e.g., TXN-04001 in 094-ledger-log.csv appears on line 3 with status PENDING and again on line 39 with status FAILED as a status update)' rejected; then
+  pass '[274-N3] the real 216-character citation remains rejected by the unchanged cap'
+else
+  fail_case '[274-N3] the real 216-character citation remains rejected by the unchanged cap' "$CASE_274_RESULTS"
+fi
+
+CASE_274_RESULTS=
+n4_ok=1
+run_274_single n4-unverified-content '- (2026-09-04, unverified) safe to deploy' 'safe to deploy' rejected || n4_ok=0
+run_274_single n4-unverified-inclusive '- (2026-09-04, unverified) safe to deploy' '(2026-09-04, unverified) safe to deploy' accepted || n4_ok=0
+run_274_single n4-date-delete-content '- (2026-09-04, DO-NOT-DELETE) keep the warm spare out of rotation' 'keep the warm spare out of rotation' rejected || n4_ok=0
+run_274_single n4-date-delete-inclusive '- (2026-09-04, DO-NOT-DELETE) keep the warm spare out of rotation' '(2026-09-04, DO-NOT-DELETE) keep the warm spare out of rotation' accepted || n4_ok=0
+run_274_single n4-date-important-content '- (2026-09-04, IMPORTANT) preserve the operator warning' 'preserve the operator warning' rejected || n4_ok=0
+run_274_single n4-date-important-inclusive '- (2026-09-04, IMPORTANT) preserve the operator warning' '(2026-09-04, IMPORTANT) preserve the operator warning' accepted || n4_ok=0
+run_274_single n4-delete-content '- (DO-NOT-DELETE) retain this exception file' 'retain this exception file' rejected || n4_ok=0
+run_274_single n4-delete-inclusive '- (DO-NOT-DELETE) retain this exception file' '(DO-NOT-DELETE) retain this exception file' accepted || n4_ok=0
+run_274_single n4-rule-content '- (Rule 1) never rewrite sealed records' 'never rewrite sealed records' rejected || n4_ok=0
+run_274_single n4-rule-inclusive '- (Rule 1) never rewrite sealed records' '(Rule 1) never rewrite sealed records' accepted || n4_ok=0
+run_274_single n4-priority-content '- (high-priority) flush memtable on exit' 'flush memtable on exit' rejected || n4_ok=0
+run_274_single n4-priority-inclusive '- (high-priority) flush memtable on exit' '(high-priority) flush memtable on exit' accepted || n4_ok=0
+run_274_single n4-v2-content '- (v2) preserve the version qualifier' 'preserve the version qualifier' rejected || n4_ok=0
+run_274_single n4-v2-inclusive '- (v2) preserve the version qualifier' '(v2) preserve the version qualifier' accepted || n4_ok=0
+run_274_single n4-cve-content '- (CVE-2024-1111) buffer overflow in parser' 'buffer overflow in parser' rejected || n4_ok=0
+run_274_single n4-cve-inclusive '- (CVE-2024-1111) buffer overflow in parser' '(CVE-2024-1111) buffer overflow in parser' accepted || n4_ok=0
+run_274_single n4-dated-cve-content '- 2026-09-04 (CVE-2024-1111) rotated the exposed API token' 'rotated the exposed API token' rejected || n4_ok=0
+run_274_single n4-dated-cve-inclusive '- 2026-09-04 (CVE-2024-1111) rotated the exposed API token' '(CVE-2024-1111) rotated the exposed API token' accepted || n4_ok=0
+run_274_single n4-cve-mismatch '- (CVE-2024-1111) buffer overflow in parser' '(CVE-2024-2222) buffer overflow in parser' rejected || n4_ok=0
+run_274_single n4-dated-cve-mismatch '- 2026-09-04 (CVE-2024-1111) rotated the exposed API token' '2026-09-04 (CVE-2024-2222) rotated the exposed API token' rejected || n4_ok=0
+if [[ "$n4_ok" -eq 1 ]]; then
+  pass '[274-N4] content parentheticals remain significant, including dated warnings and CVEs'
+else
+  fail_case '[274-N4] content parentheticals remain significant, including dated warnings and CVEs' "$CASE_274_RESULTS"
+fi
+
+identifier_61=a123456789012345678901234567890123456789012345678901234567890
+CASE_274_RESULTS=
+n5_ok=1
+run_274_single n5-words-content '- (2026-09-04, two words) bounded grammar text' 'bounded grammar text' rejected || n5_ok=0
+run_274_single n5-words-inclusive '- (2026-09-04, two words) bounded grammar text' '(2026-09-04, two words) bounded grammar text' accepted || n5_ok=0
+run_274_single n5-nested-content '- ((2026-09-04) id) nested grammar text' 'nested grammar text' rejected || n5_ok=0
+run_274_single n5-nested-inclusive '- ((2026-09-04) id) nested grammar text' '((2026-09-04) id) nested grammar text' accepted || n5_ok=0
+run_274_single n5-long-content "- (2026-09-04, $identifier_61) overlong identifier text" 'overlong identifier text' rejected || n5_ok=0
+run_274_single n5-long-inclusive "- (2026-09-04, $identifier_61) overlong identifier text" "(2026-09-04, $identifier_61) overlong identifier text" accepted || n5_ok=0
+run_274_single n5-colon-content '- (2026-09-04, job:7) colon identifier text' 'colon identifier text' rejected || n5_ok=0
+run_274_single n5-colon-inclusive '- (2026-09-04, job:7) colon identifier text' '(2026-09-04, job:7) colon identifier text' accepted || n5_ok=0
+run_274_single n5-slash-content '- (2026-09-04, job/7) slash identifier text' 'slash identifier text' rejected || n5_ok=0
+run_274_single n5-slash-inclusive '- (2026-09-04, job/7) slash identifier text' '(2026-09-04, job/7) slash identifier text' accepted || n5_ok=0
+run_274_single n5-fused-content '- (2026-09-04, r1j1)text without delimiter' 'text without delimiter' rejected || n5_ok=0
+run_274_single n5-fused-inclusive '- (2026-09-04, r1j1)text without delimiter' '(2026-09-04, r1j1)text without delimiter' accepted || n5_ok=0
+run_274_single n5-emphasis-content '- **(2026-09-04, r1j1)** emphasized stamp text' 'emphasized stamp text' rejected || n5_ok=0
+run_274_single n5-emphasis-inclusive '- **(2026-09-04, r1j1)** emphasized stamp text' '**(2026-09-04, r1j1)** emphasized stamp text' accepted || n5_ok=0
+run_274_single n5-second-content '- (2026-09-04, r1j1) (2026-09-04, r2j2) second stamp text' 'second stamp text' rejected || n5_ok=0
+run_274_single n5-second-inclusive '- (2026-09-04, r1j1) (2026-09-04, r2j2) second stamp text' '(2026-09-04, r1j1) (2026-09-04, r2j2) second stamp text' accepted || n5_ok=0
+if [[ "$n5_ok" -eq 1 && "${#identifier_61}" -eq 61 ]]; then
+  pass '[274-N5] provenance grammar stays bounded and strips at most one stamp before emphasis'
+else
+  fail_case '[274-N5] provenance grammar stays bounded and strips at most one stamp before emphasis' "id_len=${#identifier_61} $CASE_274_RESULTS"
+fi
+
+CASE_274_RESULTS=
+n6_ok=1
+run_274_single n6-bare-content '- (id-7) [tag-9] text remains ordered' 'text remains ordered' rejected || n6_ok=0
+run_274_single n6-bare-tag '- (id-7) [tag-9] text remains ordered' '[tag-9] text remains ordered' rejected || n6_ok=0
+run_274_single n6-bare-inclusive '- (id-7) [tag-9] text remains ordered' '(id-7) [tag-9] text remains ordered' accepted || n6_ok=0
+run_274_single n6-stamp-content '- (2026-09-04, id-7) [tag-9] text remains ordered' 'text remains ordered' rejected || n6_ok=0
+# Fixed-order characterization: the source keeps [tag-9] after stripping the
+# stamp, while a quote beginning at [tag-9] has that tag stripped by step 3.
+# The context-free canonicalizer therefore rejects it fail-closed.
+run_274_single n6-stamp-tag '- (2026-09-04, id-7) [tag-9] text remains ordered' '[tag-9] text remains ordered' rejected || n6_ok=0
+run_274_single n6-stamp-inclusive '- (2026-09-04, id-7) [tag-9] text remains ordered' '(2026-09-04, id-7) [tag-9] text remains ordered' accepted || n6_ok=0
+run_274_single n6-form-b-content '- 2026-09-04 (ev007b-C-r2j2) Step 1 executed successfully with all corpus files.' 'Step 1 executed successfully with all corpus files.' rejected || n6_ok=0
+run_274_single n6-form-b-inclusive '- 2026-09-04 (ev007b-C-r2j2) Step 1 executed successfully with all corpus files.' '(ev007b-C-r2j2) Step 1 executed successfully with all corpus files.' accepted || n6_ok=0
+if [[ "$n6_ok" -eq 1 ]]; then
+  pass '[274-N6] fixed order preserves bare ids, post-stamp tags, and removed form B fail-closed'
+else
+  fail_case '[274-N6] fixed order preserves bare ids, post-stamp tags, and removed form B fail-closed' "$CASE_274_RESULTS"
+fi
+
 CANONICAL_RESIDUE=$TMP_ROOT/canonical-residue-reviewer
 write_reviewer "$CANONICAL_RESIDUE" 'cat >/dev/null
 cat <<"OUT"


### PR DESCRIPTION
Closes #274.

## Summary

`scripts/raw-review.sh` rejected every reviewer citation whenever flush bullets carried the STATE.md provenance-stamp convention `- (2026-09-04, ev007b-C-r1j1) text`: the canonicalization stripped bullet / ISO date / `[machine-tag]`s but not the parenthesized stamp, the reviewer (per `templates/review-prompt.md`) quoted the content after it, the prefix check failed, and with `blocks>0 && candidates==0` the whole reviewer call failed closed — EV-007b: 6/6 reviewer calls, 0 candidates, outcome row 4 (REPORT-B §5 / §9(a), `docs/benchmark.md#ev-007`).

This PR makes `citation_canonicalize_stream` strip **at most one date-led provenance stamp** on both sides — `(YYYY-MM-DD)` or `(YYYY-MM-DD, job-id)` where the job id is a whitespace-free token in the product task-id charset (`is_safe_id`: `[A-Za-z0-9][A-Za-z0-9._-]{0,59}`) containing at least one digit — after the bullet / date / tag strips and before the emphasis strip (5 inserted lines). A bare `(job-id)` after a date is not stripped; content parentheticals (`(IMPORTANT)`, `(DO-NOT-DELETE)`, `(Rule 1)`, `(2026-09-04, unverified)`) stay significant. Prefix anchoring, the 8–200 character bounds, the `*`-suffix rule, the truncation branch, `fabricated_floor` / `fabricated_pct` and the `blocks>0 && candidates==0` fail-close are unchanged. `templates/review-prompt.md`, `docs/reference.md` and `docs/reference.ja.md` state the same rule (fixed order bullet → date → tags → stamp → emphasis; stamp-inclusive quotes always acceptable).

Design: 3 heterogeneous blind seats × 3 rounds on #274 (Gemini GO / GLM GO / Codex NO-GO adjudicated with receipt — the product task-id grammar is free-form, so a job-id-shaped regex over-fits; residual equivalence `(date, digit-bearing-X)` recorded and pinned by `[274-C1]` with the dissent quoted). Writer: Codex gpt-5.6-sol (the astra run was cut by the account usage limit after the docs edits; the owner switched accounts). Merge review: 3 heterogeneous blind seats, 2 rounds (below).

Recorded amendment (L1-8, on #274): the identifier charset is the task-id charset, not the v3 §2 sketch `[A-Za-z0-9_.:/-]{1,60}` — narrower, fail-closed, pinned by `[274-N5]` (colon / slash ids stay content). Done-when P2 and the N5 "80 chars" bound are superseded by design v3 (form B removed; bound = 60).

## 完了記録 (Completion record)

candidate SHA: cca5755e2b08bc1881ff27ec04d9938f81cb2e22 (L1-8 superseding record: `935c143` was reviewed by the merge seats; `cca5755` adds one wording-only line in `templates/review-prompt.md` — the seats' round-1/2 wording fix had capitalised the pinned phrase `paired emphasis markers`, which raw-review test [2] greps case-sensitively, so CI went red on `935c143`; the phrase is lowercase again, the rule text is unchanged, local `bash tests/raw-review.test.sh` = `64 PASS, 0 FAIL`)
implementer: Codex gpt-5.6-sol via `codex exec --profile sol` (brief = design v3); orchestration, adjudication and commits by alpha (Claude Fable 5.1, session d319e48f)
reviewer: Gemini 3.8 Flash (agy, no tools) · Grok 4.5 · GLM-5.3 — blind, fresh context, full diff inline; design seats Gemini / GLM / Codex sol
identity check: 別モデル — writer = OpenAI gpt-5.6-sol; no merge seat is an OpenAI model (Gemini / Grok / GLM); the orchestrator (Claude) is not counted as a seat
CI: `935c143` red (raw-review test [2], casing of a pinned phrase introduced by the wording fix — my error); `cca5755` pending at record time; final state recorded in the MERGED comment on #264/#274. pr-size red until the owner re-applies `size-exempt` (the push strips it)
release: v0.25.0
previous release: v0.24.3 → https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.24.3 (fulfilled: annotated tag on `4e2c7f8` + GitHub Release published 2026-09-05T11:18:59Z)

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| Regression tests red before / green after: P1, P4-replay, P5 (+ I1, C1 measured red before) | PASS | new suite vs `origin/main` `scripts/raw-review.sh` (temp tree, 2026-09-05): `Summary: 59 PASS, 5 FAIL` = `[274-P1] [274-P5] [274-P4-replay] [274-I1] [274-C1]`; on the candidate: `bash tests/raw-review.test.sh` → `Summary: 64 PASS, 0 FAIL` |
| P2 (form B content-only accepted) | N/A (superseded by design v3 — form B removed; `[274-N6]` pins content-only rejected / parenthetical-inclusive accepted) | `[274-N6] fixed order preserves bare ids, post-stamp tags, and removed form B fail-closed` → PASS, 2026-09-05 |
| P3 symmetry pin (stamp-inclusive quote accepted) | PASS | `[274-P3]` green before and after (measured) |
| P4 real-data replay | PASS | `[274-P4-replay]`: before `blocks=4 fabricated=4 candidates=0 error=chain-exhausted` rc 1; after rc 0 `blocks=4 fabricated=2 candidates=2`, candidate file holds exactly the 183/196/193-char members, rejects hold blocks 3 and 4 (206/216, 224 chars > cap) |
| Negative controls N1–N6 stay red | PASS | `[274-N1]`…`[274-N6]` PASS on the candidate; N4 covers `(2026-09-04, unverified)`, `(2026-09-04, DO-NOT-DELETE)`, `(DO-NOT-DELETE)`, `(Rule 1)`, `(high-priority)`, `(CVE-2024-1111)` undated and dated, CVE mismatch; N5 covers whitespace, nested, 61-char, `:`/`/`, no-whitespace-after, emphasis-wrapped (N5 "80" bound superseded → 60) |
| Mutation check recorded by a seat (source-side / quote-side) | PASS | writer: source-side disabled `56 PASS, 8 FAIL` (P1/P4/P5/C1-content red, also P3/I1 by asymmetry; every N-subcheck still rejected), quote-side disabled `59 PASS, 5 FAIL` (P3/I1/C1-inclusive red); switch removed (`grep RAW_REVIEW_SKIP_PROVENANCE_STAMP` = 0). All three merge seats reasoned the same red sets from the diff (F3) |
| review-prompt.md, reference.md, reference.ja.md describe the same rule as the code | PASS | all three seats F5 PASS (sentences quoted in their outputs); Grok's splice MINOR fixed in `935c143`; pinned-phrase casing restored in `cca5755` |
| `make test` green locally and on CI | PASS (local) / CI pending | local (writer): `Suite Summary: 43 PASS, 0 FAIL`, `make lint` 89 files OK; CI: see the CI field |
| 3 blind design seats GO before implementation; 3 merge seats GO; L1-7 on the PR | PASS | design r1–r3 and merge r1–r2 records on #274 (comments 5552145973 / 5552171026 / 5552192396 / 5552644545 + r2); this record |
| `release: v0.25.0` + previous v0.24.3 fulfilled | declared | tag + Release after merge (T-5); previous fulfilled (link above) |
| EV-007b pin moved to v0.25.0 and the sealed series re-run under #264 | N/A (separate lane; #264 owns it) | PREREGISTRATION-C.md v0.4.2 panel-approved on #264; pin move + wiring re-check start after the Release |

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...cca5755:
```
 docs/reference.ja.md       |  11 +-
 docs/reference.md          |  13 +-
 scripts/raw-review.sh      |   5 +
 templates/review-prompt.md |  14 ++-
 tests/raw-review.test.sh   | 308 ++++++++++++++++++++++++++++++++++++++++++++
 5 files changed, 346 insertions(+), 5 deletions(-)
```
宣言ファイル集合との差分: なし（WIP comment on #274 declared exactly these five files）

### Panel record

- Design r1: Gemini GO-W-C / Codex NO-GO / GLM GO-W-C → r2 (forms A+B): Gemini GO-W-C / Codex NO-GO / GLM GO-W-C → r3 (form A only, digit id): **Gemini GO / GLM GO / Codex NO-GO** (dissent adjudicated with receipt: `is_safe_id` free-form; `r<n>j<m>` regex over-fits; promotion writes the THEME label not the member quote; pinned by `[274-C1]`).
- Merge r1 (`74d1f33`): **Gemini GO / Grok GO / GLM GO-W-CHANGES** (charset amendment to be recorded → recorded above; Done-when supersessions → recorded; pre-fix red set → measured 5). r2 (GLM delta, `935c143`): **GLM GO** (all three findings RESOLVED; cumulative GO ×3). `cca5755` = one wording line (casing of a pinned phrase), no rule change — recorded, not re-reviewed.
- Full seat outputs: 9 design + 3 merge (+ delta) files kept in the lane's panel record (`_handoffs`, attached to the #264 successor lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
