### PR TITLE
chore(#233): ignore __pycache__/ and *.pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .omx/
 .omc/
+# Ignore Python bytecode (#233).
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary

Adds `__pycache__/` and `*.pyc` to `.gitignore` so python bytecode can never be swept into a commit again (recurrence guard from the #217 review panel, which found two `__pycache__/*.cpython-314.pyc` blobs committed by a blanket `git add`).

Closes #233

## Files touched (L0-6)

- `.gitignore` (+3 lines; existing `.omx/` / `.omc/` rules untouched)

## 完了記録 (Completion record)

candidate SHA: 5eca6b8aa79fc14d9c03a0c888a64946119d3d4d
implementer: Codex gpt-6-astra (medium) via `codex exec`, commit by alpha (Claude Code)
reviewer: 3 heterogeneous seats — Grok 4.6 (CLI), Opus 5 (Claude Code Agent code-reviewer), Kimi K3 (CLI); seat decision by `loom-seats --size S --absent glm-5.3` (GLM 5.3 absent: 429 weekly/monthly limit until 2026-09-10, observed 2026-09-07)
identity check: 別モデル（writer = Codex; seats = Grok / Opus / Kimi）
CI: green — test-lint run 34058941387 @ 5eca6b8: lint pass, test pass (17m54s), test-macos pass; gitleaks / history-check / pr-size / risk-review-gate / repo-state / watch all pass (2026-09-07)
release: N/A（③ CI・開発環境の配線のみ — an ignore rule changes no runtime behavior, public API, or distributed file）
previous release: v0.26.0 → https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.26.0（Release 実在確認 2026-09-07: `gh release list` に Latest として表示）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| `.gitignore` ignores `__pycache__/` and `*.pyc` | PASS | `git diff`: `+__pycache__/` `+*.pyc` appended after existing rules (2026-09-07) |
| `git check-ignore -v scripts/__pycache__/x.pyc` resolves to the new rule | PASS | output `.gitignore:4:__pycache__/	scripts/__pycache__/x.pyc`; also `.gitignore:5:*.pyc	scripts/x.pyc` (2026-09-07) |
| `git ls-files \| grep -c 'pyc$'` remains 0 | PASS | printed `0`; additionally `git ls-files -ci --exclude-standard \| wc -l` = 0 (no tracked file newly ignored) (2026-09-07) |
| テスト / lint green | PASS | `make lint` → `lint: 89 shell files OK`; `make test` → `Suite Summary: 43 PASS, 0 FAIL` (2026-09-07, writer run + alpha re-run) |

Tests added: none — T-3 reason 2 (no test target: ignore rule only).

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...5eca6b8aa79fc14d9c03a0c888a64946119d3d4d: ` .gitignore | 3 +++`
宣言ファイル集合との差分: なし

### Review record

Panel: 3 heterogeneous seats, blind (identical packet, no cross-visibility), all read-only against candidate 5eca6b8. Alpha (orchestrator) is not counted as a seat. GLM 5.3 absent (429 weekly/monthly limit, reset 2026-09-10 10:00); decision `loom-seats --size S --absent glm-5.3` → Grok 4.6 substitutes.

| seat | requested → actual | verdict | blocking | F1..F5 | evidence highlights |
|---|---|---|---|---|---|
| Grok 4.6 (CLI `grok`, effort high) | grok-4.6 → grok-4.6 | GO | 0 | PASS PASS PASS N/A PASS | check-ignore on 8 paths incl. `.cpython-314.pyc`, `git ls-files -ci --exclude-standard` empty, `make lint` 89 OK, `PYTHONDONTWRITEBYTECODE=1 make test` → 43 PASS 0 FAIL. `Killed: 9` lines traced to apply-promotions crash-injection, not this diff. NIT-1: no CI pin for the two lines |
| Opus 5 (Claude Code Agent code-reviewer) | opus-5 → claude-opus-5[1m] | GO | 0 | PASS ×5 | 13 constructed paths (near-misses correctly not ignored), pure-addition proof (no `-` lines), base-red proof in scratch repo, F3: tests/cli-conventions.test.sh leak detection is find-based (line 42) and stays green 8/8, no `git clean` consumer; `make test` 43 PASS 0 FAIL, post-suite no `__pycache__` created. MINOR-1: guard unpinned by any test; NIT: `*.py[cod]` convention, dir-only trailing slash |
| Kimi K3 (CLI `kimi -p`) | kimi-code/k3 → k3-class (checkpoint undisclosed) | GO | 0 | PASS N/A N/A N/A PASS | check-ignore ×5, ls-files pyc 0, base .gitignore compared, `make lint`, `make test` 43 PASS 0 FAIL. NIT: no automated test pins the rule |

Adjudication (alpha): 3/3 GO, zero blocking. The one convergent non-blocking finding (no automated pin for the recurrence guard) is out of this Issue's Done-when and is filed as a follow-up Issue after merge rather than widening this S lane. Seat files: session scratchpad `seats-233/{grok,opus,kimi}.md`.
