### PR TITLE
fix(#98): sanitize session_id before building the checkpoint guard path

### DIFF
--- a/adapters/claude-code/checkpoint-stop-hook.sh
+++ b/adapters/claude-code/checkpoint-stop-hook.sh
@@ -32,6 +32,7 @@ case "$(json_get stop_hook_active)" in
 esac
 
 session_id=$(json_get session_id)
+session_id=$(printf '%s' "$session_id" | tr -cd 'A-Za-z0-9._-')
 cwd=$(json_get cwd)
 [[ -n "$cwd" && -d "$cwd" ]] || exit 0
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
@@ -68,8 +69,7 @@ touch "$guard" 2>/dev/null || exit 0
 mkdir -p "$cwd/loop/pending" 2>/dev/null || true
 flush_file="$cwd/loop/pending/flush-$(date -u +%F).md"
 flush_stamp_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-stamp_sid=$(printf '%s' "$session_id" | tr -cd 'A-Za-z0-9._-')
-[[ -n "$stamp_sid" ]] || stamp_sid="cwd-$(printf '%s' "$cwd" | cksum | cut -d' ' -f1)"
+stamp_sid=$session_id
 cat >&2 <<EOF
 caty-agent-harness CHECKPOINT: workspace files changed after STATE.md was last written (e.g. ${newer#"$cwd"/}).
 Before ending the session, write 'loop/handoffs/<UTC-date>-<task-slug>.md'; insert a new entry 1 under '## Last session' with the UTC date, task id, next action, blockers, last verified artifact path, and handoff pointer; push every previous entry down verbatim; never delete, summarize, or collapse existing entries. Fold any new observations into the right sections. If this turn genuinely produced nothing checkpoint-worthy, state that explicitly and continue — this reminder fires at most once per session.

--- a/tests/claude-code-checkpoint-hook.test.sh
+++ b/tests/claude-code-checkpoint-hook.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/caty-claude-checkpoint-test.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+failures=0
+
+pass() { printf 'ok - %s\n' "$1"; }
+fail_case() {
+  printf 'not ok - %s: %s\n' "$1" "$2"
+  failures=$((failures + 1))
+}
+
+assert_eq() {
+  local name=$1 expected=$2 actual=$3
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$name"
+  else
+    fail_case "$name" "expected=$expected actual=$actual"
+  fi
+}
+
+run_hook() {
+  local sid=$1
+  set +e
+  printf '{"cwd":"%s","session_id":"%s"}\n' "$ws" "$sid" |
+    TMPDIR="$TMP/guards" bash "$ROOT/adapters/claude-code/checkpoint-stop-hook.sh" \
+      >"$TMP/hook.stdout" 2>"$TMP/hook.stderr"
+  hook_rc=$?
+  set -e
+}
+
+ws="$TMP/ws"
+mkdir -p "$ws" "$TMP/guards"
+"$ROOT/install.sh" --workspace "$ws" >/dev/null
+ws=$(cd "$ws" && pwd -P)
+"$ROOT/install.sh" --enable --workspace "$ws" >/dev/null
+sleep 1
+printf 'x\n' >"$ws/change.txt"
+guard_dir="$TMP/guards/caty-agent-harness-hook"
+
+run_hook 'abc/def'
+assert_eq "slash session blocks" "2" "$hook_rc"
+grep -Fq 'caty-agent-harness CHECKPOINT' "$TMP/hook.stderr" \
+  && pass "slash session emits checkpoint reminder" \
+  || fail_case "slash session emits checkpoint reminder" "reminder missing"
+[[ -f "$guard_dir/nagged-abcdef" ]] \
+  && pass "slash session creates sanitized guard" \
+  || fail_case "slash session creates sanitized guard" "nagged-abcdef missing"
+[[ ! -e "$guard_dir/abc" ]] \
+  && pass "slash session creates no abc path" \
+  || fail_case "slash session creates no abc path" "abc path exists"
+grep -Fq 'session=abcdef ' "$TMP/hook.stderr" \
+  && pass "flush stamp uses sanitized session" \
+  || fail_case "flush stamp uses sanitized session" "session=abcdef missing"
+
+run_hook '../../escape'
+assert_eq "traversal session blocks" "2" "$hook_rc"
+[[ -f "$guard_dir/nagged-....escape" ]] \
+  && pass "traversal session keeps dots inside guard directory" \
+  || fail_case "traversal session keeps dots inside guard directory" "nagged-....escape missing"
+[[ ! -e "$TMP/guards/escape" && ! -e "$TMP/escape" ]] \
+  && pass "traversal session creates no escaped paths" \
+  || fail_case "traversal session creates no escaped paths" "escaped path exists"
+
+run_hook 'abc/def'
+assert_eq "repeated slash session allows stop" "0" "$hook_rc"
+assert_eq "repeated slash session has empty stderr" "0" "$(wc -c <"$TMP/hook.stderr" | tr -d ' ')"
+
+run_hook '///'
+assert_eq "empty sanitized session blocks" "2" "$hook_rc"
+fallback_guard=$(find "$guard_dir" -type f -name 'nagged-cwd-*' -print -quit)
+[[ -n "$fallback_guard" ]] \
+  && pass "empty sanitized session uses cwd guard fallback" \
+  || fail_case "empty sanitized session uses cwd guard fallback" "nagged-cwd-* missing"
+
+printf 'Claude Code checkpoint hook tests: %s failure(s)\n' "$failures"
+if (( failures )); then
+  exit 1
+fi


### PR DESCRIPTION
> **Superseding record (L1-8), 2026-09-07** — candidate SHA c352de8 → 0997887 after a rebase onto main (adjacent PR #281 merged; L0-7 obligation). Re-verification after rebase: bash tests/claude-code-checkpoint-hook.test.sh → 0 failure(s); bash tests/pause-contract.test.sh rc 0; make lint → 90 shell files OK. git diff c352de8 0997887 -- adapters/claude-code/checkpoint-stop-hook.sh tests/claude-code-checkpoint-hook.test.sh is empty, so the seats' r1 verdicts (all GO on content-identical diff) carry over; no re-review requested.

## Summary

The Claude Code checkpoint Stop hook built its once-per-session guard path from the raw hook-JSON `session_id`. A slash-bearing id made `touch "$guard"` fail into the silent `|| exit 0`, suppressing the CHECKPOINT reminder; a crafted id could point the guard file outside the guard dir. The id is now sanitized once, immediately after it is read (same shape as the codex and kimi hooks), reused for the flush stamp, with the existing cwd fallback kept for ids that sanitize to empty.

Closes #98

## Files touched (L0-6)

- `adapters/claude-code/checkpoint-stop-hook.sh` (+2 / -2: sanitize after read; `stamp_sid=$session_id`)
- `tests/claude-code-checkpoint-hook.test.sh` (new, 12 assertions: `abc/def`, `../../escape`, repeat-id guard, `///` fallback)

## 完了記録 (Completion record)

candidate SHA: 099788762ddc700a6f2ae55c3b7005cdcd6d2710
implementer: Codex gpt-6-astra (medium) via `codex exec`, commit by alpha (Claude Code)
reviewer: 3 heterogeneous seats — Grok 4.6 (CLI), Opus 5 (Claude Code Agent code-reviewer), Kimi K3 (CLI); seat decision by `loom-seats --size S --absent glm-5.3` (GLM 5.3 absent: 429 weekly/monthly limit until 2026-09-10, observed 2026-09-07)
identity check: 別モデル（writer = Codex; seats = Grok / Opus / Kimi）
CI: green — test-lint run 34061927919 @ 0997887 (rebased head): lint pass, test pass, test-macos pass; gitleaks / history-check / pr-size / risk-review-gate / repo-state / watch all pass (2026-09-07). Earlier head c352de8 was also fully green (run 34059002674).
release: v0.26.1（出荷相当: the Claude Code Stop hook's runtime behavior changes — the CHECKPOINT reminder now fires for session ids containing '/', which it silently never did before）
previous release: v0.26.0 → https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.26.0（Release 実在確認 2026-09-07）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| The session id is sanitized once, before any path construction, matching the codex/kimi hooks | PASS | `git diff`: `session_id=$(printf '%s' "$session_id" \| tr -cd 'A-Za-z0-9._-')` inserted directly after `session_id=$(json_get session_id)`; the later re-sanitization replaced by `stamp_sid=$session_id` (identical to adapters/codex:49-50,86 and adapters/kimi:51-52,88) (2026-09-07) |
| Regression test covers a session id containing `/` and `..` | PASS | `bash tests/claude-code-checkpoint-hook.test.sh` → 12 × `ok -`, `Claude Code checkpoint hook tests: 0 failure(s)` (writer run + alpha re-run 2026-09-07). Negative control (sanitization line removed in a temp copy): exit 1, 8 × `not ok` incl. `slash session creates sanitized guard: nagged-abcdef missing` (2026-09-07) |
| テスト / lint green | PASS | `make test` → `Suite Summary: 44 PASS, 0 FAIL`; `make lint` → `lint: 90 shell files OK` (2026-09-07) |

Tests added: `tests/claude-code-checkpoint-hook.test.sh` (T-2/T-3: regression test red on base, green with fix).

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...099788762ddc700a6f2ae55c3b7005cdcd6d2710: adapters/claude-code/checkpoint-stop-hook.sh | 4 +- / tests/claude-code-checkpoint-hook.test.sh | 81 ++++ / 2 files changed, 83 insertions(+), 2 deletions(-)
宣言ファイル集合との差分: なし

### Review record

Panel: 3 heterogeneous seats, blind (identical packet, no cross-visibility), read-only against candidate c352de8. Alpha (orchestrator) is not counted as a seat. GLM 5.3 absent (429 weekly/monthly limit, reset 2026-09-10); decision `loom-seats --size S --absent glm-5.3` → Grok 4.6 substitutes.

| seat | requested → actual | verdict | blocking | F1..F5 | evidence highlights |
|---|---|---|---|---|---|
| Grok 4.6 (CLI `grok`, effort high) | grok-4.6 → grok-4.6 | GO | 0 | PASS ×5 | new suite 12/12 ok; red-on-base proof in /tmp copy (8 failures); pause-contract green; live `..` / slash / traversal / empty probes; `make lint` OK. NIT-1: two negative assertions (test :51, :63) also pass on base (the 8 positive pins are what discriminate); NIT-2: sanitizer collisions constructible, same charset as codex/kimi by design |
| Opus 5 (Claude Code Agent code-reviewer) | opus-5 → claude-opus-5[1m] | GO | 0 | PASS ×5 | git-archive base overlay → 8/12 red on base; heredoc/exit codes/fallback byte-identical; stamp value identical on all inputs; `session_id=".."` → `nagged-..` inside guard dir, GC reaps it; `make test` 44 PASS 0 FAIL; `make lint` 90 files OK. Notes the base defect is fail-open denial-of-function (reminder never fired for any id containing `/`). MINOR-1: lossy sanitizer collisions (unreachable with UUID ids, shared contract); MINOR-2: `tr` on invalid multibyte can abort under `set -euo pipefail`, now on the hot path — currently unreachable (json_get goes through Python strict UTF-8) → follow-up Issue across claude-code/codex/kimi (`LC_ALL=C tr ... \|\| true`); NIT: pin bare `..`; NIT: PASS_FLOOR not raised |
| Kimi K3 (CLI `kimi -p`) | kimi-code/k3 → Kimi K3 | GO | 0 | PASS ×5 | 12/12 ok; `make test` 44 PASS 0 FAIL (~26 min); red-on-base by execution with byte-identical reverted temp copy (rc 0 / no guard / no stderr vs asserted rc 2); F2: `..` becomes inert filename `nagged-..`, never a path component. M1: collision `abc/def` vs `abcdef` (bounded, fail-open, same as codex/kimi) |

Adjudication (alpha): 3/3 GO, zero blocking. Convergent non-blocking finding (sanitizer collision) is the charset the Issue requires matching; not changed here. Opus MINOR-2 (`tr` + invalid UTF-8 under pipefail) is a real latent window shared by all three adapters and is filed as a follow-up Issue after merge. Seat files: session scratchpad `seats-98/{grok,opus,kimi}.md`.
