### PR TITLE
docs(#69): resolve the Hermes profile system-instructions path deterministically

### DIFF
--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -25,14 +25,26 @@ The rules there apply in addition to the Hermes-specific wiring below.
 
 3. Append the marker-aware block with the managed installer.
 
-   For Cero, use the profile's absolute system-instruction/bootstrap path:
+   The target is the profile's `SOUL.md`, Hermes' identity slot, loaded into the
+   system prompt of that profile. The command below resolves its absolute path
+   from `hermes profile show`:
 
    ```sh
    HARNESS=/absolute/path/to/caty-agent-harness
+   PROFILE=<profile>                       # as listed by: hermes profile list
    WS=/absolute/path/to/.hermes/profiles/<profile>/workspace
-   "$HARNESS/install.sh" --workspace "$WS" --bootstrap-runtime hermes \
-     --append-bootstrap /absolute/path/to/profile-system-instructions.md
+   PROFILE_HOME=$(hermes profile show "$PROFILE" | sed -n 's/^Path:[[:space:]]*//p')
+   SOUL="$PROFILE_HOME/SOUL.md"
+   [ -n "$PROFILE_HOME" ] && [ -f "$SOUL" ] || { echo "stop: cannot resolve SOUL.md for profile '$PROFILE'" >&2; exit 1; }
+   "$HARNESS/install.sh" --workspace "$WS" --bootstrap-runtime hermes --append-bootstrap "$SOUL"
    ```
+
+   If `hermes profile show` errors or prints no `Path:` line, or `SOUL.md` does
+   not exist, STOP. Do not guess among files or create `SOUL.md` by hand. Check
+   `hermes profile list`, create the profile first with `hermes profile create <name>`
+   if it does not exist, then re-run the discovery. For the `default` profile,
+   the resolved home is `~/.hermes` itself; for named profiles it is
+   `~/.hermes/profiles/<name>`.
 
    The existing file is preserved and its path is registered under the workspace.
    Pause and resume without deleting state, learning records, queue, or artifacts:

--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -44,7 +44,9 @@ The rules there apply in addition to the Hermes-specific wiring below.
    `hermes profile list`, create the profile first with `hermes profile create <name>`
    if it does not exist, then re-run the discovery. For the `default` profile,
    the resolved home is `~/.hermes` itself; for named profiles it is
-   `~/.hermes/profiles/<name>`.
+   `~/.hermes/profiles/<name>`. The harness workspace stays at
+   `~/.hermes/profiles/<profile>/workspace` for every profile, including `default`;
+   only `SOUL.md` lives in the resolved profile home.
 
    The existing file is preserved and its path is registered under the workspace.
    Pause and resume without deleting state, learning records, queue, or artifacts:

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -39,7 +39,7 @@ Pick the row that matches the tool **you** are running in right now:
 | Claude Code | `claude-code` | `<workspace>/CLAUDE.md` |
 | Codex CLI | `codex` | `<workspace>/AGENTS.md` |
 | Kimi Code CLI | `kimi` | `<workspace>/AGENTS.md` |
-| Hermes Agent | `hermes` | profile system-instructions file — follow [adapters/hermes/INSTALL.md](../adapters/hermes/INSTALL.md) for the exact invocation |
+| Hermes Agent | `hermes` | profile system-instructions file (the profile's SOUL.md; step 3 of [adapters/hermes/INSTALL.md](../adapters/hermes/INSTALL.md) resolves its path) — follow that document for the exact invocation |
 | OpenClaw | `openclaw` | `<workspace>/AGENTS.md` — follow [adapters/openclaw/INSTALL.md](../adapters/openclaw/INSTALL.md) for the exact invocation |
 
 If you are none of these, stop and tell the human this tool is not yet supported (the list is exact; do not improvise).

--- a/tests/hermes-install-discovery.test.sh
+++ b/tests/hermes-install-discovery.test.sh
@@ -21,8 +21,8 @@ assert_eq() {
   fi
 }
 
-for required in 'hermes profile show' "sed -n 's/^Path:[[:space:]]*//p'" '[ -f "$SOUL" ]'; do
-  if grep -Fq "$required" "$DOC"; then
+for required in 'hermes profile show' "sed -n 's/^Path:[[:space:]]*//p'" '[ -f "$SOUL" ]' '--bootstrap-runtime hermes --append-bootstrap "$SOUL"'; do
+  if grep -Fq -- "$required" "$DOC"; then
     pass "INSTALL.md contains $required"
   else
     fail_case "INSTALL.md contains $required" 'required guidance missing'

--- a/tests/hermes-install-discovery.test.sh
+++ b/tests/hermes-install-discovery.test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/caty-hermes-install-test.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+failures=0
+DOC="$ROOT/adapters/hermes/INSTALL.md"
+
+pass() { printf 'ok - %s\n' "$1"; }
+fail_case() {
+  printf 'not ok - %s: %s\n' "$1" "$2"
+  failures=$((failures + 1))
+}
+assert_eq() {
+  local name=$1 expected=$2 actual=$3
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$name"
+  else
+    fail_case "$name" "expected=$expected actual=$actual"
+  fi
+}
+
+for required in 'hermes profile show' "sed -n 's/^Path:[[:space:]]*//p'" '[ -f "$SOUL" ]'; do
+  if grep -Fq "$required" "$DOC"; then
+    pass "INSTALL.md contains $required"
+  else
+    fail_case "INSTALL.md contains $required" 'required guidance missing'
+  fi
+done
+if grep -Fq '/absolute/path/to/profile-system-instructions.md' "$DOC"; then
+  fail_case 'unresolvable bootstrap placeholder is absent' 'placeholder remains'
+else
+  pass 'unresolvable bootstrap placeholder is absent'
+fi
+
+# Extract executable lines only from sh fences, not explanatory prose.
+shell_lines=$(awk '
+  /^   ```sh$/ { in_sh=1; next }
+  /^   ```$/ { in_sh=0 }
+  in_sh { sub(/^   /, ""); print }
+' "$DOC")
+profile_line=$(printf '%s\n' "$shell_lines" | grep -F 'PROFILE_HOME=' || true)
+soul_line=$(printf '%s\n' "$shell_lines" | grep -F 'SOUL=' || true)
+guard_line=$(printf '%s\n' "$shell_lines" | grep -F '[ -n "$PROFILE_HOME" ] &&' || true)
+extraction_ok=1
+for line in "$profile_line" "$soul_line" "$guard_line"; do
+  if [[ -z "$line" || "$line" == *$'\n'* ]]; then
+    fail_case 'discovery extraction is nonempty and unique' "extracted=$line"
+    extraction_ok=0
+  fi
+done
+
+if [[ "$extraction_ok" == 1 ]]; then
+  pass 'discovery extraction is nonempty and unique'
+  mkdir -p "$TMP/bin" "$TMP/home"
+  cat >"$TMP/bin/hermes" <<'SH'
+#!/bin/sh
+if [ "$#" -ne 3 ] || [ "$1" != profile ] || [ "$2" != show ] || [ "$3" != default ]; then
+  exit 1
+fi
+printf '\n'
+cat <<EOF
+Profile: default
+Path:    $HERMES_TEST_HOME
+Model:   gpt-5.6-sol (openai-codex)
+Gateway: stopped
+Skills:  70
+.env:    exists
+SOUL.md: exists
+EOF
+SH
+  chmod +x "$TMP/bin/hermes"
+
+  run_discovery() (
+    export PATH="$TMP/bin:$PATH" HERMES_TEST_HOME="$TMP/home"
+    PROFILE=$1
+    # Match the documented POSIX shell: a failed pipeline must reach the guard.
+    set +e
+    set +o pipefail
+    eval "$profile_line"
+    eval "$soul_line"
+    eval "$guard_line"
+    guard_rc=$?
+    printf '%s\n' "$SOUL"
+    exit "$guard_rc"
+  )
+
+  touch "$TMP/home/SOUL.md"
+  set +e
+  resolved=$(run_discovery default 2>"$TMP/present.stderr")
+  present_rc=$?
+  set -e
+  assert_eq 'existing SOUL.md passes the documented guard' '0' "$present_rc"
+  assert_eq 'multiple Path spaces resolve the exact SOUL.md path' "$TMP/home/SOUL.md" "$resolved"
+
+  rm "$TMP/home/SOUL.md"
+  set +e
+  run_discovery default >"$TMP/missing.stdout" 2>"$TMP/missing.stderr"
+  missing_rc=$?
+  run_discovery nonexistent >"$TMP/nonexistent.stdout" 2>"$TMP/nonexistent.stderr"
+  nonexistent_rc=$?
+  set -e
+  for scenario in missing nonexistent; do
+    if [[ "$scenario" == missing ]]; then
+      rc=$missing_rc
+    else
+      rc=$nonexistent_rc
+    fi
+    if [[ "$rc" != 0 ]]; then
+      pass "$scenario fails closed"
+    else
+      fail_case "$scenario fails closed" 'guard exited zero'
+    fi
+    if grep -Fq 'stop:' "$TMP/$scenario.stderr"; then
+      pass "$scenario prints stop: on stderr"
+    else
+      fail_case "$scenario prints stop: on stderr" "$(cat "$TMP/$scenario.stderr")"
+    fi
+  done
+fi
+
+printf 'Hermes install discovery summary: %s failure(s)\n' "$failures"
+if (( failures )); then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

`adapters/hermes/INSTALL.md` step 3 asked for `--append-bootstrap /absolute/path/to/profile-system-instructions.md`, a placeholder with no way to resolve it. #67 (the first external README-led install) stopped exactly there and correctly refused to guess. The target is the profile's `SOUL.md` (Hermes' identity slot, loaded into that profile's system prompt); the step now resolves it from `hermes profile show <profile>` (the `Path:` line), verifies it with `[ -f ]`, and stops fail-closed when discovery returns nothing. `docs/agent-guide.md` Hermes row points at the resolving step. A test pins the discovery strings, the placeholder's absence, the installer line that consumes `$SOUL`, and the guard's behavior against a fake `hermes profile show` (present / missing SOUL.md / unknown profile).

Closes #69. Refs #67 (re-walk confirmation posted there after merge).

## Files touched (L0-6)

- `adapters/hermes/INSTALL.md` (step 3 rewritten: discovery block + fail-closed paragraph + workspace-path clarification)
- `docs/agent-guide.md` (Hermes row, one phrase)
- `tests/hermes-install-discovery.test.sh` (new, 12 assertions)

## 完了記録 (Completion record)

candidate SHA: f48071829df6fe046a8c16d34a86fc670aab188f
implementer: Codex gpt-6-astra (medium) via `codex exec` (r1 + review delta), commit by alpha (Claude Code)
reviewer: 3 heterogeneous seats — Opus 5 (Claude Code Agent code-reviewer), Kimi K3 (CLI), Gemini 3.8 Flash (agy, static); seat decision by `loom-seats --size S --absent glm-5.3 --absent grok-4.6` (GLM 5.3: 429 weekly/monthly limit until 2026-09-10; Grok 4.6: 402 Grok Build balance exhausted mid-review, logged)
identity check: 別モデル（writer = Codex; seats = Opus / Kimi / Gemini）
CI: green — test-lint run 34063978089 @ f480718 (rebased on main after PR #282): lint pass (6s), test pass (19m50s), test-macos pass (27m23s); gitleaks / history-check / pr-size / risk-review-gate / repo-state / watch all pass (2026-09-07). Earlier heads 223e7be and bb7733b were also green on the jobs that completed before each push.
release: N/A（① 利用者が従う規範を含まない docs のみ — install guidance + a docs-pinning test; no runtime behavior, public API, or distributed file changes. The harness's own install.sh is untouched）
previous release: v0.26.0 → https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.26.0（Release 実在確認 2026-09-07）; PR #281 (N/A③) and PR #282 (v0.26.1, fulfilled: tag https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.26.1 on main bbcfc69, Release exists (release-sync run 34063968589 success)) sit between

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| INSTALL.md contains a discovery command such that the #67 reproduction (steps 1–5) reaches a runnable, unambiguous invocation with no out-of-doc knowledge | PASS | INSTALL.md step 3: `PROFILE_HOME=$(hermes profile show "$PROFILE" \| sed -n 's/^Path:[[:space:]]*//p')`, `SOUL="$PROFILE_HOME/SOUL.md"`, guard, then `--append-bootstrap "$SOUL"`. Verified against the real tool on the maintainer machine: `hermes profile show default` prints `Path:    /Users/shojikumaru/.hermes`, sed yields that path, `SOUL.md` exists there (2026-09-07; Opus seat re-verified byte-exact via od -c, Kimi seat re-ran the snippet under bash 3.2 and sh) |
| the placeholder no longer appears as the only guidance; the flow never asks the reader to guess | PASS | `grep -c '/absolute/path/to/profile-system-instructions.md' adapters/hermes/INSTALL.md` → 0; fail-closed paragraph says STOP / do not guess / `hermes profile create` then re-run (2026-09-07) |
| a test pins the guidance; `make test` green | PASS | `bash tests/hermes-install-discovery.test.sh` → 12 × `ok -`, `Hermes install discovery summary: 0 failure(s)`. Negative controls: placeholder restored → 1 failure exit 1; guard line deleted → red (Opus MUT1); `--append-bootstrap` repointed to AGENTS.md → `not ok - INSTALL.md contains --bootstrap-runtime hermes --append-bootstrap "$SOUL"` exit 1 (closed by the review delta). `make test` → `Suite Summary: 44 PASS, 0 FAIL` (writer + Opus ×2 + Kimi); `make lint` → `lint: 90 shell files OK` (2026-09-07) |
| #67 reporter's reproduction path re-walked and confirmed unblocked (comment on #67) | N/A(ordering) | #67 is CLOSED as duplicate of this Issue; the re-walk result is posted to #67 in the MERGED step right after this PR lands (the walk itself = steps 1–5 of the #67 report against the merged INSTALL.md; performed by alpha 2026-09-07 on the candidate: README → agent-guide row → INSTALL.md step 3 → discovery resolves `/Users/shojikumaru/.hermes/SOUL.md` → runnable invocation) |

Tests added: `tests/hermes-install-discovery.test.sh` (T-3: docs-pinning + functional guard test with a stub `hermes`).

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...f48071829df6fe046a8c16d34a86fc670aab188f: adapters/hermes/INSTALL.md | 20 +++++- / docs/agent-guide.md | 2 +- / tests/hermes-install-discovery.test.sh | 126 +++++ / 3 files changed, 144 insertions(+), 4 deletions(-)
宣言ファイル集合との差分: なし（docs/agent-guide.md was declared as conditional in the Issue and in the WIP comment）

### Review record

Panel: 3 heterogeneous seats, blind in r1 (identical packet), read-only. Alpha (orchestrator) is not counted as a seat. GLM 5.3 absent (429 weekly/monthly limit until 2026-09-10) and Grok 4.6 absent (402 Grok Build balance exhausted after 17 turns mid-review, r1 invalid, logged); decision `loom-seats --size S --absent glm-5.3 --absent grok-4.6` → Opus 5 / Kimi K3 / Gemini 3.8 Flash.

**r1 — candidate 223e7be**

| seat | requested → actual | verdict | blocking | F1..F5 | evidence highlights |
|---|---|---|---|---|---|
| Opus 5 (Claude Code Agent code-reviewer) | opus-5 → claude-opus-5[1m] | GO | 0 | PASS ×5 | verified SOUL.md = identity slot in Hermes source (config.py:1030, main.py:14139 `Path:` line), live `hermes profile show default` byte-exact via od -c, nonexistent profile → rc 1 → guard fires; red-on-base 7 failures; mutants MUT1/MUT2/MUT4 caught, **MUT3 (`--append-bootstrap` repointed to AGENTS.md) survived → MINOR-1**; MINOR-2 default-profile note vs workspace path; NIT-3/4/5; `make test` 44 PASS ×2, `make lint` 90 OK |
| Kimi K3 (CLI `kimi -p`) | kimi-code/k3 → Kimi K3 | GO | 0 | PASS ×5 | suite green under bash 5.3 and /bin/bash 3.2.57; `make test` 44 PASS 0 FAIL; red-on-base via temp copy; guard-deleted + placeholder-restored mutants caught; snippet run verbatim under bash 3.2 and sh; no findings |
| Gemini 3.8 Flash (agy) | gemini-3.8-flash-high → Gemini 3.8 Flash (High) | r1a: NO-VERDICT (25 min print-timeout with tools; invalid, logged) / r1b static no-tools: GO | 0 | PASS PASS PASS N/A(static) PASS | 1 NIT: WS path vs default profile root (same point as Opus MINOR-2) |

**Delta (writer: Codex astra, two passes — the first pass's new grep pin was parsed as an option because the pattern starts with `--`; fixed with `grep -Fq --`)** → candidate bb7733b: test pins `--bootstrap-runtime hermes --append-bootstrap "$SOUL"`; INSTALL.md states the workspace stays at `~/.hermes/profiles/<profile>/workspace` for every profile incl. default.

**r2 — cumulative for bb7733b**

| seat | verdict | blocking | evidence |
|---|---|---|---|
| Opus 5 | GO | 0 | MINOR-1 RESOLVED (re-ran own MUT3: now caught; new MUT5 wrong-runtime also caught), MINOR-2 RESOLVED (matches install.sh:37-39); `--` in grep is required, not cosmetic; doc sentence outside the sh fence so the extractor is unaffected; suite 12/12, lint 90 OK; remaining NIT-3/4/5 accepted |
| Kimi K3 | GO | 0 | suite 12 ok under bash 5.3 and 3.2; lint 90 OK; mutation proof with swapped `--append-bootstrap` target → 1 failure exit 1; install.sh:38,1697 workspace derivation confirms the doc sentence |
| Gemini 3.8 Flash (static) | GO | 0 | NIT from r1 addressed by the doc sentence; nothing new introduced |

Adjudication (alpha): 3/3 GO in both rounds, zero blocking at any point. Seat files: session scratchpad `seats-69/{opus,kimi,gemini}.md`, `kimi-r2.md`, `gemini-r2*.stdout.md`.
