### PR TITLE
fix(#57): teach the distiller-cron learning-path probe the hermes intake route

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1193,6 +1193,17 @@ probe_adapter_distiller_cron() {
         && probe_executable_contains "$repo_root/templates/cron-wrapper.tmpl.sh" \
           '# fable-loop cron wrapper template v1'
       ;;
+    hermes)
+      # shellcheck disable=SC2016
+      probe_executable_contains "$repo_root/adapters/hermes/flush-intake.sh" \
+        'source "$repo_root/scripts/flush-intake.sh"' \
+        && grep -Fq -- "snapshot_pending_dedup_keys \"\$pending_dir\"" \
+          "$repo_root/scripts/flush-intake.sh" \
+        && grep -Fq -- "atomic_write_file \"\$ledger_source\" \"\$ledger_file\"" \
+          "$repo_root/scripts/flush-intake.sh" \
+        && probe_executable_contains "$repo_root/templates/cron-wrapper.tmpl.sh" \
+          '# fable-loop cron wrapper template v1'
+      ;;
     *)
       probe_executable_contains "$repo_root/adapters/$adapter/distill-audit.sh" \
         "distiller_cmd=\${DISTILLER_CMD:-" \

--- a/tests/check-tickprobe.test.sh
+++ b/tests/check-tickprobe.test.sh
@@ -228,7 +228,7 @@ assert_route_status "codex reuses the flush intake fold route" "$probe_output" c
 assert_route_status "hermes CONSULT injection passes" "$probe_output" hermes "CONSULT injection" PASS
 assert_route_status "hermes candidate generation passes" "$probe_output" hermes "candidate generation" PASS
 assert_route_status "hermes verifier availability passes" "$probe_output" hermes "verifier available" PASS
-assert_route_status "hermes distiller cron fails explicitly" "$probe_output" hermes "distiller cron" FAIL
+assert_route_status "hermes flush intake fold route passes" "$probe_output" hermes "distiller cron" PASS
 assert_route_status "hermes verifier conformance fails explicitly when unset" "$probe_output" hermes "verifier conformance" FAIL
 
 assert_route_status "kimi CONSULT injection passes" "$probe_output" kimi "CONSULT injection" PASS
@@ -245,6 +245,7 @@ assert_route_status "openclaw distiller conformance fails explicitly when unset"
 broken_harness=$TMP_ROOT/broken-harness
 copy_harness "$broken_harness"
 chmod -x "$broken_harness/adapters/hermes/verify-job.sh"
+chmod -x "$broken_harness/adapters/hermes/flush-intake.sh"
 broken_ws=$TMP_ROOT/ws-broken-learning-path
 "$broken_harness/install.sh" --workspace "$broken_ws" >/dev/null 2>&1
 seed_dates "$broken_ws"
@@ -253,15 +254,21 @@ broken_rc=$?
 broken_routes=$(printf '%s\n' "$broken_output" | grep -F "$LEARNING_PATH_PREFIX" || true)
 broken_route_count=$(printf '%s\n' "$broken_routes" | grep -c '^learning path:' || true)
 expected_broken_routes=$(printf '%s\n' "$route_lines" | sed \
-  's/learning path: adapter=hermes | route=verifier available | PASS/learning path: adapter=hermes | route=verifier available | FAIL/')
+  -e 's/learning path: adapter=hermes | route=verifier available | PASS/learning path: adapter=hermes | route=verifier available | FAIL/' \
+  -e 's/learning path: adapter=hermes | route=distiller cron | PASS/learning path: adapter=hermes | route=distiller cron | FAIL/')
 if [ "$broken_rc" -eq 0 ] \
   && [ "$broken_route_count" -eq 22 ] \
   && printf '%s\n' "$broken_routes" | grep -Fqx 'learning path: adapter=hermes | route=verifier available | FAIL' \
   && [ "$broken_routes" = "$expected_broken_routes" ]; then
-  pass "breaking only Hermes verifier flips exactly one route to FAIL"
+  pass "breaking Hermes verifier and intake entries flips exactly two routes to FAIL"
 else
-  fail_case "breaking only Hermes verifier flips exactly one route to FAIL" "rc=$broken_rc output=$broken_routes"
+  fail_case "breaking Hermes verifier and intake entries flips exactly two routes to FAIL" "rc=$broken_rc output=$broken_routes"
 fi
+
+assert_route_status "broken hermes intake entry makes distiller cron FAIL" "$broken_output" hermes "distiller cron" FAIL
+assert_route_status "broken hermes intake entry keeps claude-code distiller cron PASS" "$broken_output" claude-code "distiller cron" PASS
+assert_route_status "broken hermes intake entry keeps codex distiller cron PASS" "$broken_output" codex "distiller cron" PASS
+assert_route_status "broken hermes intake entry keeps kimi distiller cron PASS" "$broken_output" kimi "distiller cron" PASS
 
 broken_candidate_harness=$TMP_ROOT/broken-candidate-harness
 copy_harness "$broken_candidate_harness"


### PR DESCRIPTION
## Summary

`install.sh`'s learning-path probe routed `hermes` to the default "distiller cron" arm, which looks for `adapters/hermes/distill-audit.sh` (never existed), so the hermes row was structurally FAIL since #56 shipped `adapters/hermes/flush-intake.sh` as the hermes intake route. The probe now has a `hermes)` arm that checks hermes' own entry for the shared-core `source` line plus the same core fold literals and cron-wrapper marker as the claude-code arm (the two entries are structurally identical). `tests/check-tickprobe.test.sh` flips the hermes expectation to PASS and adds a negative case: breaking the hermes intake entry in the copied harness turns only the hermes row red while claude-code / codex / kimi stay green.

Closes #57

## Files touched (L0-6)

- `install.sh` (+11: new `hermes)` arm in `probe_adapter_distiller_cron`; existing arms byte-identical)
- `tests/check-tickprobe.test.sh` (expectation flip, broken-harness extended, +4 assertions)

## 完了記録 (Completion record)

candidate SHA: a3a8ef71b27b140ebc64fa11377124cddef2b945
implementer: Codex gpt-6-astra (medium) via `codex exec`, commit by alpha (Claude Code)
reviewer: 3 heterogeneous seats — Opus 5 (Claude Code Agent code-reviewer), Kimi K3 (CLI), Gemini 3.8 Flash (agy, static); seat decision loom-seats --size S --absent glm-5.3 --absent grok-4.6 (GLM 5.3: 429 until 2026-09-10; Grok 4.6: 402 balance exhausted)
identity check: 別モデル（writer = Codex; seats as listed）
CI: green — test-lint run 34067600046 @ a3a8ef7 (rebased on main after PR #283): lint pass (7s), test pass (22m4s), test-macos pass (27m9s); gitleaks / history-check / pr-size / risk-review-gate / repo-state / watch all pass (2026-09-07). The pre-rebase head d5564e2 was reviewed by the seats; git diff d5564e2..a3a8ef7 on the two declared files is empty.
release: N/A（② 挙動・公開API・配布物を変えない内部整理 — the change is to install.sh's self-diagnostic learning-path probe output for one adapter row and its test; the install flow, adapters, and distributed hooks are unchanged）
previous release: v0.26.1 → https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.26.1（履行済み: Release 実在, release-sync run 34063968589 success, 2026-09-07）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| The probe recognizes the hermes intake route (entry sources shared core + core fold literals, mirroring the claude-code arm) | PASS | `install.sh` `hermes)` arm probes `adapters/hermes/flush-intake.sh` for `source "$repo_root/scripts/flush-intake.sh"`, then `snapshot_pending_dedup_keys "$pending_dir"` and `atomic_write_file "$ledger_source" "$ledger_file"` in `scripts/flush-intake.sh`, then the cron-wrapper marker. Real tree: `learning path: adapter=hermes \| route=distiller cron \| PASS` (writer `--check` run + test, 2026-09-07) |
| check-tickprobe coverage extended accordingly | PASS | `bash tests/check-tickprobe.test.sh`: `hermes flush intake fold route passes` PASS; broken harness (hermes verify-job + flush-intake made non-executable) → `breaking Hermes verifier and intake entries flips exactly two routes to FAIL` PASS, hermes distiller cron FAIL, claude-code/codex/kimi distiller cron PASS; row count 22 unchanged. Negative control: with the install.sh hunk stashed, the suite fails on the hermes expectation (2026-09-07) |
| テスト / lint green | PASS | `make test` → `Suite Summary: 44 PASS, 0 FAIL`; `make lint` → `lint: 91 shell files OK` (2026-09-07) |

Tests changed: `tests/check-tickprobe.test.sh` (T-3: expectation flip + negative case pinning that the hermes row depends on the hermes entry).

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...a3a8ef71b27b140ebc64fa11377124cddef2b945: install.sh | 11 +++++++++++ / tests/check-tickprobe.test.sh | 15 +++++++++++---- / 2 files changed, 22 insertions(+), 4 deletions(-)
宣言ファイル集合との差分: なし

### Review record

Panel: 3 heterogeneous seats, blind (identical packet), read-only against candidate d5564e2. Alpha (orchestrator) is not counted as a seat. GLM 5.3 (429 until 2026-09-10) and Grok 4.6 (402 balance exhausted) absent; decision `loom-seats --size S --absent glm-5.3 --absent grok-4.6` → Opus 5 / Kimi K3 / Gemini 3.8 Flash.

| seat | requested → actual | verdict | blocking | F1..F5 | evidence highlights |
|---|---|---|---|---|---|
| Opus 5 (Claude Code Agent code-reviewer) | opus-5 → claude-opus-5[1m] | GO | 0 | PASS ×5 | zero deletion lines in install.sh (arms byte-identical); all 4 probe literals verified; single-variable false-green probe (chmod -x only hermes/flush-intake.sh in a scratch copy → exactly the hermes row flips, 22 rows); red-on-base by removing the 11-line arm → 64/1; tickprobe 65/65; all 17 suites touching install.sh exit 0; lint 90 OK; shellcheck clean. MINOR-1 arm duplication; MINOR-2 the cron conjunct checks only the template banner (cron-wrapper.tmpl.sh:269 hardcodes the claude-code intake; hermes is a LaunchAgent) — same weak semantics as the existing claude-code arm → follow-up Issue; NIT ×2 |
| Kimi K3 (CLI `kimi -p`) | kimi-code/k3 → Kimi K3 | GO | 0 | PASS N/A PASS PASS PASS | tickprobe + lint run; base probe extracted via git show; NIT: arm duplication; NIT: broken fixture breaks two things at once (attribution rests on the sibling-PASS assertions) |
| Gemini 3.8 Flash (agy static) | gemini-3.8-flash-high → Gemini 3.8 Flash (High) | GO | 0 | PASS PASS PASS N/A(static) PASS | 0 findings |

Adjudication (alpha): 3/3 GO, zero blocking. Arm duplication (2 seats) is the shape the Issue asked for ("mirroring the claude-code arm") and is left as is. Opus MINOR-2 (the "distiller cron" conjunct does not probe hermes' real scheduling mechanism) is a pre-existing taxonomy weakness shared with the claude-code arm and is filed as a follow-up Issue after merge. Seat files: session scratchpad `seats-57/{opus,kimi,gemini}.md`.
