### PR TITLE
fix(#60): bind the API-served model id into the hermes verifier attestation

### DIFF
--- a/adapters/hermes/INSTALL.md
+++ b/adapters/hermes/INSTALL.md
@@ -229,11 +229,17 @@ The rules there apply in addition to the Hermes-specific wiring below.
 
    The conformance gate pins the staged wrapper, provider, and probe files by SHA-256,
    plus the TTL and recorded behavioral flags. It does not pin the API key,
-   `VERIFIER_API_BASE`, `VERIFIER_API_ALLOWED_HOSTS`, or live `VERIFIER_MODEL`;
-   `provider_version` is only the model label present at attestation time, not the model
-   actually served. Re-attesting after a vendor, model, or endpoint change is therefore
-   an operator duty the gate cannot enforce today; a follow-up issue tracks gating the
-   endpoint and served model in the evidence record.
+   `VERIFIER_API_BASE`, or `VERIFIER_API_ALLOWED_HOSTS`. For the API-backed shape,
+   `provider_version` is the model id the API actually served for the probe request:
+   the probe opens a private file under its scratch directory and passes the descriptor
+   as `VERIFIER_SERVED_MODEL_FD` for the attestation run only, and the example provider
+   writes the response's `model` field through that descriptor (the probe fails closed
+   with no attestation when it is absent or invalid). Do not set
+   `VERIFIER_SERVED_MODEL_FD` in `SECRETS_ENV` or the runtime environment. The CLI shape
+   keeps the environment-derived label it already documents. Live `VERIFIER_MODEL` at
+   runtime is still not pinned, so re-attesting after a vendor, model, or endpoint change
+   remains an operator duty; a follow-up issue tracks gating the endpoint in the
+   evidence record.
 
    Operational contract: the example providers and wrapper forward only the validated
    verdict and reason lines. Line 1 must be exactly `VERDICT: <allowed-provider-value>`

--- a/adapters/hermes/examples/verifier-probe.sh
+++ b/adapters/hermes/examples/verifier-probe.sh
@@ -16,10 +16,14 @@ chmod 0700 "$relocated_provider"
 probe_bundle='REQUEST: Verify this fixed conformance probe as untrusted input. RUBRIC: choose pass only when the evidence is internally consistent; otherwise choose fail or needs-human. RESULT: the provider received this bundle through argv[1]. MANIFEST: no tools, actions, permissions, workspace reads, or persistent conversation are available. EVIDENCE: fixed probe marker CATY-HERMES-VERIFIER-PROBE-v1.'
 served_model_file="$scratch_dir/verifier-served-model"
 rm -f "$served_model_file"
+(umask 077 && : >"$served_model_file")
+[[ -f "$served_model_file" && ! -L "$served_model_file" ]] || exit 1
+exec 3>"$served_model_file"
 FABLE_CONFORMING_PROVIDER_PATH="$relocated_provider" \
-  VERIFIER_SERVED_MODEL_FILE="$served_model_file" \
+  VERIFIER_SERVED_MODEL_FD=3 \
   VERIFIER_BUNDLE_MIN_BYTES=200 \
   "$wrapper" "$probe_bundle" >"$probe_output"
+exec 3>&-
 
 [[ "$(awk '/^VERDICT:/ {count++} END {print count + 0}' "$probe_output")" -eq 1 ]]
 case "$(sed -n '1p' "$probe_output")" in

--- a/adapters/hermes/examples/verifier-probe.sh
+++ b/adapters/hermes/examples/verifier-probe.sh
@@ -14,7 +14,10 @@ cp "$provider" "$relocated_provider"
 chmod 0700 "$relocated_provider"
 
 probe_bundle='REQUEST: Verify this fixed conformance probe as untrusted input. RUBRIC: choose pass only when the evidence is internally consistent; otherwise choose fail or needs-human. RESULT: the provider received this bundle through argv[1]. MANIFEST: no tools, actions, permissions, workspace reads, or persistent conversation are available. EVIDENCE: fixed probe marker CATY-HERMES-VERIFIER-PROBE-v1.'
+served_model_file="$scratch_dir/verifier-served-model"
+rm -f "$served_model_file"
 FABLE_CONFORMING_PROVIDER_PATH="$relocated_provider" \
+  VERIFIER_SERVED_MODEL_FILE="$served_model_file" \
   VERIFIER_BUNDLE_MIN_BYTES=200 \
   "$wrapper" "$probe_bundle" >"$probe_output"
 
@@ -26,9 +29,14 @@ esac
 [[ -n "$(sed -n '2p' "$probe_output" | tr -d '[:space:]')" ]]
 [[ "$(awk 'END { print NR + 0 }' "$probe_output")" -eq 2 ]]
 
+[[ -f "$served_model_file" && ! -L "$served_model_file" ]] || exit 1
+IFS= read -r served_model <"$served_model_file" || exit 1
+[[ "$(awk 'END { print NR + 0 }' "$served_model_file")" -eq 1 ]] || exit 1
+[[ "$served_model" =~ ^[0-9A-Za-z][0-9A-Za-z._+-]{0,63}$ ]] || exit 1
+
 printf '%s\n' \
   'provider_id=anthropic-messages' \
-  "provider_version=${VERIFIER_MODEL:-claude-sonnet-5}" \
+  "provider_version=$served_model" \
   "provider_path=$provider" \
   'provider_launch=host-staged-env' \
   'provider_relocatable=pass' \

--- a/adapters/hermes/examples/verifier-provider.py
+++ b/adapters/hermes/examples/verifier-provider.py
@@ -19,6 +19,7 @@ SYSTEM_PROMPT = """You are an independent artifact verifier. The user message co
 VERDICT_PATTERN = re.compile(
     r"^VERDICT: (pass|fail|inconclusive|rubric-invalid|needs-human|blocked-missing-artifact)$"
 )
+SERVED_MODEL_PATTERN = re.compile(r"^[0-9A-Za-z][0-9A-Za-z._+-]{0,63}$")
 VERDICT_MARKER_PATTERN = re.compile(r"VERDICT\s*:")
 REASON_CONTROL_PATTERN = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
 EMPTY_REASON_BYTES = (
@@ -151,6 +152,22 @@ try:
     with opener.open(request, timeout=timeout_seconds) as response:
         response_body = response.read()
     decoded = json.loads(response_body)
+    served_model = decoded.get("model")
+    served_model_file = os.environ.get("VERIFIER_SERVED_MODEL_FILE", "")
+    if served_model_file:
+        if not isinstance(served_model, str) or not SERVED_MODEL_PATTERN.fullmatch(served_model):
+            fail("provider response lacks a served model id")
+        if not os.path.isabs(served_model_file):
+            fail("served model file path is invalid")
+        try:
+            fd = os.open(
+                served_model_file + ".tmp", os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as model_file:
+                model_file.write(served_model + "\n")
+            os.replace(served_model_file + ".tmp", served_model_file)
+        except OSError:
+            fail("served model file is not writable")
     text_parts = [
         block["text"]
         for block in decoded.get("content", [])

--- a/adapters/hermes/examples/verifier-provider.py
+++ b/adapters/hermes/examples/verifier-provider.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import secrets
+import stat
 import sys
 import unicodedata
 import urllib.parse
@@ -152,22 +153,34 @@ try:
     with opener.open(request, timeout=timeout_seconds) as response:
         response_body = response.read()
     decoded = json.loads(response_body)
-    served_model = decoded.get("model")
-    served_model_file = os.environ.get("VERIFIER_SERVED_MODEL_FILE", "")
-    if served_model_file:
+    served_model_fd_env = os.environ.get("VERIFIER_SERVED_MODEL_FD", "")
+    if served_model_fd_env:
+        if not served_model_fd_env.isdigit():
+            fail("served model sink is invalid")
+        try:
+            fd = int(served_model_fd_env)
+            if fd < 3:
+                fail("served model sink is invalid")
+            st = os.fstat(fd)
+        except (OSError, ValueError, OverflowError):
+            fail("served model sink is invalid")
+        if not stat.S_ISREG(st.st_mode):
+            fail("served model sink is invalid")
+        served_model = decoded.get("model")
         if not isinstance(served_model, str) or not SERVED_MODEL_PATTERN.fullmatch(served_model):
             fail("provider response lacks a served model id")
-        if not os.path.isabs(served_model_file):
-            fail("served model file path is invalid")
         try:
-            fd = os.open(
-                served_model_file + ".tmp", os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
-            )
-            with os.fdopen(fd, "w", encoding="utf-8") as model_file:
-                model_file.write(served_model + "\n")
-            os.replace(served_model_file + ".tmp", served_model_file)
+            os.ftruncate(fd, 0)
+            os.lseek(fd, 0, os.SEEK_SET)
+            model_bytes = (served_model + "\n").encode("utf-8")
+            written = 0
+            while written < len(model_bytes):
+                count = os.write(fd, model_bytes[written:])
+                if count == 0:
+                    fail("served model sink is not writable")
+                written += count
         except OSError:
-            fail("served model file is not writable")
+            fail("served model sink is not writable")
     text_parts = [
         block["text"]
         for block in decoded.get("content", [])

--- a/tests/hermes-verifier-examples.test.sh
+++ b/tests/hermes-verifier-examples.test.sh
@@ -18,7 +18,7 @@ trap cleanup EXIT HUP INT TERM
 mkdir -p "$TMP_ROOT"
 
 # Prevent ambient operator configuration from leaking into test cases.
-unset VERIFIER_API_BASE VERIFIER_API_ALLOWED_HOSTS VERIFIER_SERVED_MODEL_FILE
+unset VERIFIER_API_BASE VERIFIER_API_ALLOWED_HOSTS VERIFIER_SERVED_MODEL_FD
 unset FAKE_SERVED_MODEL FAKE_SKIP_SERVED_MODEL STUB_SERVED_MODEL
 
 pass() {
@@ -44,9 +44,9 @@ cat >"$fake_provider" <<'SH'
 set -eu
 printf '%s' "$1" >"$PROVIDER_MARKER"
 served_model=${FAKE_SERVED_MODEL-claude-sonnet-5-served-fixture}
-if [ -n "${VERIFIER_SERVED_MODEL_FILE:-}" ] && [ -n "$served_model" ] \
+if [ -n "${VERIFIER_SERVED_MODEL_FD:-}" ] && [ -n "$served_model" ] \
   && [ "${FAKE_SKIP_SERVED_MODEL:-0}" != 1 ]; then
-  printf '%s\n' "$served_model" >"$VERIFIER_SERVED_MODEL_FILE"
+  printf '%s\n' "$served_model" >&"$VERIFIER_SERVED_MODEL_FD"
 fi
 printf '%b' "${PROVIDER_OUTPUT:-VERDICT: pass\nfixed provider accepted the probe bundle\n}"
 exit "${PROVIDER_EXIT:-0}"
@@ -498,23 +498,31 @@ request_url_marker=$TMP_ROOT/request-url.marker
 request_key_marker=$TMP_ROOT/request-key.marker
 request_count_marker=$TMP_ROOT/request-count.marker
 served_model_file=$TMP_ROOT/served.txt
-for served_api_case in valid missing invalid relative unwritable unset; do
-  rm -f "$served_model_file" "$served_model_file.tmp"
+for served_api_case in valid missing invalid nonregular nonnumeric closed low-fd unwritable unset; do
+  rm -f "$served_model_file"
+  if [ "$served_api_case" != unset ]; then
+    (umask 077 && : >"$served_model_file")
+  fi
   stub_served_model=claude-sonnet-5-stub
-  model_destination=$served_model_file
   expected_error=
   case "$served_api_case" in
     unset) stub_served_model= ;;
     missing) stub_served_model=; expected_error='provider response lacks a served model id' ;;
     invalid) stub_served_model='bad model/id'; expected_error='provider response lacks a served model id' ;;
-    relative) model_destination=served.txt; expected_error='served model file path is invalid' ;;
-    unwritable) model_destination=$TMP_ROOT/nonexistent/served.txt; expected_error='served model file is not writable' ;;
+    nonregular|nonnumeric|closed|low-fd) expected_error='served model sink is invalid' ;;
+    unwritable) expected_error='served model sink is not writable' ;;
   esac
   set +e
   (
-    if [ "$served_api_case" != unset ]; then
-      export VERIFIER_SERVED_MODEL_FILE="$model_destination"
-    fi
+    case "$served_api_case" in
+      unset) ;;
+      nonregular) exec 3>/dev/null; export VERIFIER_SERVED_MODEL_FD=3 ;;
+      nonnumeric) export VERIFIER_SERVED_MODEL_FD=abc ;;
+      closed) exec 9>&-; export VERIFIER_SERVED_MODEL_FD=9 ;;
+      low-fd) export VERIFIER_SERVED_MODEL_FD=2 ;;
+      unwritable) exec 3<"$served_model_file"; export VERIFIER_SERVED_MODEL_FD=3 ;;
+      *) exec 3>"$served_model_file"; export VERIFIER_SERVED_MODEL_FD=3 ;;
+    esac
     VERIFIER_API_KEY=fixture STUB_SERVED_MODEL="$stub_served_model" \
       REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
       REQUEST_COUNT_MARKER="$request_count_marker" \
@@ -527,7 +535,7 @@ for served_api_case in valid missing invalid relative unwritable unset; do
   served_api_ok=1
   if [ -n "$expected_error" ]; then
     if [ "$served_api_rc" -eq 0 ] || [ -n "$served_api_output" ] \
-      || [ -e "$served_model_file" ] \
+      || [ -s "$served_model_file" ] \
       || ! grep -Fxq "$expected_error" "$TMP_ROOT/served-api.err"; then
       served_api_ok=0
     fi
@@ -540,8 +548,7 @@ stub accepted the request URL' ] \
     if [ "$served_api_case" = valid ]; then
       printf '%s\n' claude-sonnet-5-stub >"$TMP_ROOT/served.expected"
       if ! cmp -s "$served_model_file" "$TMP_ROOT/served.expected" \
-        || [ "$(mode_of "$served_model_file")" != 600 ] \
-        || [ -e "$served_model_file.tmp" ]; then
+        || [ "$(mode_of "$served_model_file")" != 600 ]; then
         served_api_ok=0
       fi
     elif [ -e "$served_model_file" ]; then

--- a/tests/hermes-verifier-examples.test.sh
+++ b/tests/hermes-verifier-examples.test.sh
@@ -18,7 +18,8 @@ trap cleanup EXIT HUP INT TERM
 mkdir -p "$TMP_ROOT"
 
 # Prevent ambient operator configuration from leaking into test cases.
-unset VERIFIER_API_BASE VERIFIER_API_ALLOWED_HOSTS
+unset VERIFIER_API_BASE VERIFIER_API_ALLOWED_HOSTS VERIFIER_SERVED_MODEL_FILE
+unset FAKE_SERVED_MODEL FAKE_SKIP_SERVED_MODEL STUB_SERVED_MODEL
 
 pass() {
   PASS_COUNT=$((PASS_COUNT + 1))
@@ -42,6 +43,11 @@ cat >"$fake_provider" <<'SH'
 #!/usr/bin/env bash
 set -eu
 printf '%s' "$1" >"$PROVIDER_MARKER"
+served_model=${FAKE_SERVED_MODEL-claude-sonnet-5-served-fixture}
+if [ -n "${VERIFIER_SERVED_MODEL_FILE:-}" ] && [ -n "$served_model" ] \
+  && [ "${FAKE_SKIP_SERVED_MODEL:-0}" != 1 ]; then
+  printf '%s\n' "$served_model" >"$VERIFIER_SERVED_MODEL_FILE"
+fi
 printf '%b' "${PROVIDER_OUTPUT:-VERDICT: pass\nfixed provider accepted the probe bundle\n}"
 exit "${PROVIDER_EXIT:-0}"
 SH
@@ -256,12 +262,52 @@ probe_rc=$?
 if [ "$probe_rc" -eq 0 ] && [ -s "$provider_marker" ] \
   && [ "$(wc -c <"$provider_marker" | tr -d '[:space:]')" -ge 200 ] \
   && printf '%s\n' "$probe_output" | grep -Fq "provider_path=$fake_provider" \
-  && printf '%s\n' "$probe_output" | grep -Fq 'provider_relocatable=pass'; then
+  && printf '%s\n' "$probe_output" | grep -Fq 'provider_relocatable=pass' \
+  && printf '%s\n' "$probe_output" | grep -Fxq 'provider_version=claude-sonnet-5-served-fixture'; then
   pass '[7] probe genuinely exercises the wrapper and a relocated provider'
 else
   fail_case '[7] probe genuinely exercises the wrapper and a relocated provider' \
     "rc=$probe_rc output=$probe_output"
 fi
+
+set +e
+served_probe_output=$(VERIFIER_MODEL=env-model-should-not-win \
+  PROBE_PROVIDER_PATH="$fake_provider" PROVIDER_MARKER="$provider_marker" \
+  FABLE_WRAPPER_PATH="$CANONICAL_WRAPPER" FABLE_ATTEST_SCRATCH_DIR="$probe_scratch" "$PROBE")
+served_probe_rc=$?
+set -e
+if [ "$served_probe_rc" -eq 0 ] \
+  && printf '%s\n' "$served_probe_output" | grep -Fxq 'provider_version=claude-sonnet-5-served-fixture' \
+  && ! printf '%s\n' "$served_probe_output" | grep -Fq 'env-model-should-not-win'; then
+  pass '[7a] probe binds the served model; env model should not win'
+else
+  fail_case '[7a] probe binds the served model; env model should not win' \
+    "rc=$served_probe_rc output=$served_probe_output"
+fi
+
+for served_probe_case in missing invalid multiline; do
+  skip_served_model=0
+  fake_served_model='bad model/id'
+  case "$served_probe_case" in
+    missing) skip_served_model=1 ;;
+    multiline) fake_served_model=$(printf 'valid-model\nsecond-model') ;;
+  esac
+  set +e
+  rejected_probe_output=$(FAKE_SKIP_SERVED_MODEL="$skip_served_model" \
+    FAKE_SERVED_MODEL="$fake_served_model" PROBE_PROVIDER_PATH="$fake_provider" \
+    PROVIDER_MARKER="$provider_marker" FABLE_WRAPPER_PATH="$CANONICAL_WRAPPER" \
+    FABLE_ATTEST_SCRATCH_DIR="$probe_scratch" "$PROBE")
+  rejected_probe_rc=$?
+  set -e
+  if [ "$rejected_probe_rc" -ne 0 ] \
+    && ! printf '%s\n' "$rejected_probe_output" | grep -q '^provider_id=' \
+    && [ -z "$rejected_probe_output" ]; then
+    pass "[7b] probe rejects $served_probe_case served model evidence without attestation"
+  else
+    fail_case "[7b] probe rejects $served_probe_case served model evidence without attestation" \
+      "rc=$rejected_probe_rc output=$rejected_probe_output"
+  fi
+done
 
 wrapper_sha=$(shasum -a 256 "$CANONICAL_WRAPPER" | cut -d' ' -f1)
 provider_sha=$(shasum -a 256 "$PROVIDER" | cut -d' ' -f1)
@@ -380,6 +426,7 @@ class StubResponse:
         )
         return json.dumps(
             {
+                "model": os.environ.get("STUB_SERVED_MODEL", "claude-sonnet-5-stub"),
                 "content": [
                     {
                         "type": "text",
@@ -450,6 +497,65 @@ PY
 request_url_marker=$TMP_ROOT/request-url.marker
 request_key_marker=$TMP_ROOT/request-key.marker
 request_count_marker=$TMP_ROOT/request-count.marker
+served_model_file=$TMP_ROOT/served.txt
+for served_api_case in valid missing invalid relative unwritable unset; do
+  rm -f "$served_model_file" "$served_model_file.tmp"
+  stub_served_model=claude-sonnet-5-stub
+  model_destination=$served_model_file
+  expected_error=
+  case "$served_api_case" in
+    unset) stub_served_model= ;;
+    missing) stub_served_model=; expected_error='provider response lacks a served model id' ;;
+    invalid) stub_served_model='bad model/id'; expected_error='provider response lacks a served model id' ;;
+    relative) model_destination=served.txt; expected_error='served model file path is invalid' ;;
+    unwritable) model_destination=$TMP_ROOT/nonexistent/served.txt; expected_error='served model file is not writable' ;;
+  esac
+  set +e
+  (
+    if [ "$served_api_case" != unset ]; then
+      export VERIFIER_SERVED_MODEL_FILE="$model_destination"
+    fi
+    VERIFIER_API_KEY=fixture STUB_SERVED_MODEL="$stub_served_model" \
+      REQUEST_URL_MARKER="$request_url_marker" REQUEST_KEY_MARKER="$request_key_marker" \
+      REQUEST_COUNT_MARKER="$request_count_marker" \
+      python3 "$opener_stub" "$PROVIDER" "$bundle" \
+      >"$TMP_ROOT/served-api.out" 2>"$TMP_ROOT/served-api.err"
+  )
+  served_api_rc=$?
+  set -e
+  served_api_output=$(cat "$TMP_ROOT/served-api.out")
+  served_api_ok=1
+  if [ -n "$expected_error" ]; then
+    if [ "$served_api_rc" -eq 0 ] || [ -n "$served_api_output" ] \
+      || [ -e "$served_model_file" ] \
+      || ! grep -Fxq "$expected_error" "$TMP_ROOT/served-api.err"; then
+      served_api_ok=0
+    fi
+  else
+    if [ "$served_api_rc" -ne 0 ] || [ "$served_api_output" != 'VERDICT: pass
+stub accepted the request URL' ] \
+      || [ "$(awk 'END { print NR + 0 }' "$TMP_ROOT/served-api.out")" -ne 2 ]; then
+      served_api_ok=0
+    fi
+    if [ "$served_api_case" = valid ]; then
+      printf '%s\n' claude-sonnet-5-stub >"$TMP_ROOT/served.expected"
+      if ! cmp -s "$served_model_file" "$TMP_ROOT/served.expected" \
+        || [ "$(mode_of "$served_model_file")" != 600 ] \
+        || [ -e "$served_model_file.tmp" ]; then
+        served_api_ok=0
+      fi
+    elif [ -e "$served_model_file" ]; then
+      served_api_ok=0
+    fi
+  fi
+  if [ "$served_api_ok" -eq 1 ]; then
+    pass "[10a] API provider served model side channel: $served_api_case"
+  else
+    fail_case "[10a] API provider served model side channel: $served_api_case" \
+      "rc=$served_api_rc output=$served_api_output"
+  fi
+done
+
 expected_anthropic_base='https://api.'"anthropic.com"
 rm -f "$request_url_marker"
 set +e


### PR DESCRIPTION
> **Superseding record (L1-8), 2026-09-07** — candidate SHA 0e09d5b → 2626dce after a rebase onto main (adjacent PR #281 merged; L0-7 obligation). Rebase only (PR #289 / v0.26.2 merged meanwhile); git diff 0e09d5b 2626dce on the four declared files is empty, re-verified: hermes-verifier-examples 43/43, make lint 91 OK. The 5-seat r2 verdicts (all GO on the content-identical diff) carry over. Release stays declared v0.26.2 in this record; since v0.26.2 was consumed by PR #289, the tag for this merge will be v0.26.3 — the difference and reason will be stated in the MERGED comment per T-5.

## Summary

The Hermes verifier attestation recorded `provider_version` from the probe's own environment (`${VERIFIER_MODEL:-claude-sonnet-5}`), so the attestation could name a model that was never exercised whenever attest-time and runtime env differed. The example provider now writes the `model` field of the Anthropic Messages response to a probe-designated side-channel file (`VERIFIER_SERVED_MODEL_FILE`, absolute path required, tmp + `os.replace`, mode 0600, value validated against the attester's label alphabet), and the probe binds that served id into `provider_version`, exiting 1 with no attestation KV lines when it is absent or invalid. The provider's 2-line stdout contract, the attester's 12-key set, and the runtime path with the env var unset are unchanged.

Closes #60

Out of scope: the CLI variant (`verifier-provider-cli.sh` / `verifier-probe-cli.sh`) cannot observe a served model id; it keeps the env-derived label + CLI digest it already binds.

## Files touched (L0-6)

- `adapters/hermes/examples/verifier-provider.py` (served-model side channel, fail-closed validation)
- `adapters/hermes/examples/verifier-probe.sh` (sets the side-channel file, binds `provider_version` from it, fails closed)
- `tests/hermes-verifier-examples.test.sh` (fake provider + opener stub extended; new cases: served id wins over env, missing → probe exit ≠ 0 with no KV, invalid label → exit ≠ 0, provider writes file / rejects missing id / untouched without env)

## 完了記録 (Completion record)

candidate SHA: 2626dce94dc47cfbde884b0fedeb4f4e500701c4
implementer: Codex gpt-6-astra (medium) via `codex exec`, commit by alpha (Claude Code)
reviewer: 5 heterogeneous seats (high-risk area: verifier-provider.py is a declared risk_paths_outbound) — Opus 5 (Claude Code Agent code-reviewer), Kimi K3 (CLI), Gemini 3.8 Flash (agy, static), Muse Spark 1.3 (CLI), Codex GPT-5.6 Sol (codex exec, scratch cwd); decision loom-seats --size M --risk permission-boundary --absent glm-5.3 --absent grok-4.6; r1 4 GO + 1 NO-GO (adopted), r2 5/5 GO — see Review record
identity check: 別モデル（writer = Codex; seats as listed）
CI: green on every check except risk-review-gate — test-lint run 34074750589 @ 2626dce (rebased on main after PR #289): lint pass (4s), test pass (22m34s), test-macos pass (29m33s); all other checks pass. risk-review-gate stays red until the owner applies the risk-reviewed label (declared risk_paths_outbound); no T-4 exception claimed (2026-09-07)
release: v0.26.2（出荷相当: the distributed example provider and probe change behavior — the attestation now binds the API-served model id and fails closed without it; operator-facing INSTALL.md text changes）
previous release: v0.26.1 → https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.26.1（履行済み: Release exists, release-sync run 34063968589）; PRs #283 (N/A①) and #286 (N/A②) since

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| The provider (or probe) binds the API-served model id into the attestation evidence, or a single source of truth for VERIFIER_MODEL is enforced across attest and runtime | PASS | Provider: after `json.loads`, `decoded["model"]` is validated and written to `$VERIFIER_SERVED_MODEL_FILE`; probe: `provider_version=$served_model` read from that file. Test: probe run with `VERIFIER_MODEL=env-model-should-not-win` and a fake provider serving `claude-sonnet-5-served-fixture` → output contains `provider_version=claude-sonnet-5-served-fixture` and not the env value; fake provider writing nothing → probe rc ≠ 0 and no `provider_id=` line; invalid label → rc ≠ 0 (2026-09-07) |
| テスト / lint green | PASS | `bash tests/hermes-verifier-examples.test.sh` all PASS; `make test` → `Suite Summary: 44 PASS, 0 FAIL`; `make lint` → `lint: 91 shell files OK` (2026-09-07) |

Tests changed: `tests/hermes-verifier-examples.test.sh` (T-2 regression: the "env model should not win" case is red with the old probe line).

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...2626dce94dc47cfbde884b0fedeb4f4e500701c4: adapters/hermes/INSTALL.md | 16 ++-- / adapters/hermes/examples/verifier-probe.sh | 14 ++- / adapters/hermes/examples/verifier-provider.py | 30 +++ / tests/hermes-verifier-examples.test.sh | 117 +++++ / 4 files changed, 169 insertions(+), 8 deletions(-)
宣言ファイル集合との差分: なし

### Review record

Panel: **5 heterogeneous seats** (high-risk area: `adapters/hermes/examples/verifier-provider.py` is declared `risk_paths_outbound` in `.github/workflows/review-labels.yml`; the panel was widened from 3 to 5 after the Opus r1 seat pointed at that declaration). Blind in r1 (identical packet), read-only. Alpha (orchestrator) is not counted as a seat. GLM 5.3 (429 until 2026-09-10) and Grok 4.6 (402) absent; decision `loom-seats --size M --risk permission-boundary --absent glm-5.3 --absent grok-4.6` → Opus 5 / Kimi K3 / Gemini 3.8 Flash / Muse Spark 1.3 / Codex GPT-5.6 Sol. Same-family note: Codex Sol seat vs Codex astra writer — same vendor family; the loom roster authorizes this pairing for a Codex writer (review_council 5, 2026-08-12); recorded here as required by L1-10, and the seat was in fact the one that found the blocking defect.

**r1 — candidate 0b2f9b3 (path side channel)**

| seat | requested → actual | verdict | blocking | evidence highlights |
|---|---|---|---|---|
| Opus 5 | opus-5 → claude-opus-5[1m] | GO | 0 | 10 new assertions red on base; alphabet byte-identical across provider/probe/attester; silent-fallback constructed and closed; SystemExit propagation verified; make test 44/44. MINOR: stale INSTALL.md paragraph; CLI route out of scope; runtime unpinned. NIT ×5 (.tmp residue, O_NOFOLLOW, isabs vs `..`, undocumented env, empty-file case). Flagged the repo's risk_paths_outbound declaration → recommended 5 seats |
| Kimi K3 | kimi-code/k3 → Kimi K3 | GO | 0 | suite 40/40, lint, py_compile; MINOR: INSTALL.md contradiction; NIT: .tmp symlink follow, mode & ~umask |
| Gemini 3.8 Flash (static) | gemini-3.8-flash-high → same | GO | 0 | 0 findings; "5-seat escalation not warranted" |
| Muse Spark 1.3 | muse-spark-1.3 → same | GO | 0 | NIT: any-absolute-path clobber (constrain to scratch dir), TOCTOU |
| **Codex GPT-5.6 Sol** | gpt-5.6-sol → gpt-5.6-sol | **NO-GO** | **1** | **MAJOR: the env-selected absolute path is an unconstrained same-UID clobber primitive** — reproduced: `..` escape accepted; pre-planted `<dest>.tmp` symlink truncated and installed; pre-existing 0644 `.tmp` keeps its mode; late `os.replace` failure leaves `.tmp`. Recommended: pass an inherited descriptor, never a path. MINOR: test matrix misses these boundaries; INSTALL.md contradiction |

Adjudication r1 (alpha): 4 GO / 1 NO-GO — **the NO-GO is adopted on evidence** (reproduced, and the GO seats' NITs pointed at the same surface from weaker angles). Delta ordered: replace the path side channel with an inherited file descriptor (`VERIFIER_SERVED_MODEL_FD`, decimal ≥ 3, fstat + S_ISREG, ftruncate/lseek/full write, fail-closed), probe pre-creates the 0600 file under its 0700 scratch dir and closes the fd after the run; tests rewritten; `VERIFIER_SERVED_MODEL_FILE` removed. Then rebase on main (#281/#282/#283) and the INSTALL.md paragraph rewrite (FD design, "do not set in SECRETS_ENV", CLI shape unchanged, endpoint still unpinned). Writer: Codex astra (two passes). Decision logged via mc-log.

**r2 — cumulative for 8c32b7e (fd side channel + doc)**

| seat | verdict | blocking | evidence |
|---|---|---|---|
| Opus 5 | GO | 0 | all 8 r1 items RESOLVED; r1 attack replayed with `..` → dead; leaked-fd primitive constructible only if the caller already opened fd ≥ 3 — wrapper fd-table enumeration shows none on the runtime path; `fd < 3` guard matters (fds 1/2 are regular files); suite 43/43 under bash 5 and 3.2.57; lint 91 OK. New NIT-6: probe TOCTOU (check-then-`exec 3>f` by path) — same-uid only. Self-correction recorded (r1 under-rated the path sink) |
| Kimi K3 | GO | 0 | Codex MAJOR RESOLVED (no path reaches the provider); own MINOR/NITs RESOLVED or moot; vectors enumerated (inherited fd → fstat/S_ISREG/isdigit/<3; symlinked file → rm -f + fresh create + recheck; wrapper fd clobber → operator-side, no crossing; O_APPEND → ftruncate+lseek) |
| Gemini 3.8 Flash (static) | GO | 0 | "No permission or secret-boundary escalation remains" |
| Muse Spark 1.3 | GO | 0 | r1 NIT-1 resolved by construction; panel MAJOR RESOLVED; suite 43/43, lint 91 OK |
| Codex GPT-5.6 Sol | GO | 0 | MAJOR 1 RESOLVED (path sink gone; provider accepts only an extant regular fd ≥ 3, the canonical probe neither closes nor reopens fd 3); MINOR 1/2 RESOLVED; a direct caller naming another regular fd is an explicitly delegated already-open capability, not path authority gained from env; 'no permission-boundary expansion remains in the harness design, and no secret-boundary expansion remains'; suite green under bash 5 and 3.2; lint; py_compile; own descriptor probe |

Adjudication r2 (alpha): 5/5 GO, zero blocking at r2; the r1 blocking finding is confirmed resolved by the seat that raised it and independently by the other four (two of them by constructing leaked-fd / traversal probes). Seat files: session scratchpad `seats-60/{opus,kimi,gemini,muse,codex}.md` (r1) and `*-r2*` (r2). Merge additionally requires the repository's own `risk-review-gate` (`risk-reviewed` label by the owner) — `ball:human` is set on PR #287 and Issue #60.
