### PR TITLE
fix(#151): validate wc/stat output inside distill-audit's find subshells and fail closed

### DIFF
--- a/adapters/openclaw/distill-audit.sh
+++ b/adapters/openclaw/distill-audit.sh
@@ -123,6 +123,7 @@ injection_size_check() {
       continue
     fi
 
+    # #151: advisory monitoring, not a gate; unreadable counts fall back to zero.
     chars=$(wc -m <"$file" 2>/dev/null) || chars=0
     chars=${chars//[[:space:]]/}
     if [[ ! "$chars" =~ ^[0-9]+$ ]]; then
@@ -484,9 +485,11 @@ if [[ -e "$marker_file" ]]; then
         esac
         mtime=$(stat -c "%Y" "$path" 2>/dev/null || stat -f "%m" "$path")
         size=$(wc -c <"$path" | tr -d "[:space:]")
+        case "$size" in ""|*[!0-9]*) printf "distill-audit: unreadable size for %s\n" "$path" >&2; exit 1 ;; esac
+        case "$mtime" in ""|*[!0-9]*) printf "distill-audit: unreadable mtime for %s\n" "$path" >&2; exit 1 ;; esac
         printf "%s\t%s\t%s\n" "$mtime" "$size" "$path"
       done
-    ' sh {} + >>"$candidate_list"
+    ' sh {} + >>"$candidate_list" || infra_fail "candidate enumeration failed (size/mtime unreadable)"
   done
 else
   for input_dir in "${input_dirs[@]}"; do
@@ -499,11 +502,28 @@ else
         esac
         mtime=$(stat -c "%Y" "$path" 2>/dev/null || stat -f "%m" "$path")
         size=$(wc -c <"$path" | tr -d "[:space:]")
+        case "$size" in ""|*[!0-9]*) printf "distill-audit: unreadable size for %s\n" "$path" >&2; exit 1 ;; esac
+        case "$mtime" in ""|*[!0-9]*) printf "distill-audit: unreadable mtime for %s\n" "$path" >&2; exit 1 ;; esac
         printf "%s\t%s\t%s\n" "$mtime" "$size" "$path"
       done
-    ' sh {} + >>"$candidate_list"
+    ' sh {} + >>"$candidate_list" || infra_fail "candidate enumeration failed (size/mtime unreadable)"
   done
 fi
+
+# Preserve empty fields: tab-delimited read would collapse adjacent tabs.
+while IFS= read -r row || [[ -n "$row" ]]; do
+  [[ "$row" == *$'\t'* ]] || infra_fail "invalid candidate row: $row"
+  mtime=${row%%$'\t'*}
+  remainder=${row#*$'\t'}
+  [[ "$remainder" == *$'\t'* ]] || infra_fail "invalid candidate row: $row"
+  size=${remainder%%$'\t'*}
+  path=${remainder#*$'\t'}
+  if [[ -z "$path" || "$path" == *$'\t'* ]] \
+    || ! _classify_is_nonnegative_integer "$mtime" \
+    || ! _classify_is_nonnegative_integer "$size"; then
+    infra_fail "invalid candidate row: $row"
+  fi
+done <"$candidate_list"
 
 LC_ALL=C sort -n "$candidate_list" >"$work_dir/candidates.sorted.tsv"
 mv "$work_dir/candidates.sorted.tsv" "$candidate_list"

--- a/adapters/openclaw/distill-audit.sh
+++ b/adapters/openclaw/distill-audit.sh
@@ -489,7 +489,7 @@ if [[ -e "$marker_file" ]]; then
         case "$mtime" in ""|*[!0-9]*) printf "distill-audit: unreadable mtime for %s\n" "$path" >&2; exit 1 ;; esac
         printf "%s\t%s\t%s\n" "$mtime" "$size" "$path"
       done
-    ' sh {} + >>"$candidate_list" || infra_fail "candidate enumeration failed (size/mtime unreadable)"
+    ' sh {} + >>"$candidate_list" || infra_fail "candidate enumeration failed (size/mtime unreadable) — rename or remove the offending input file, or rerun if it was transient"
   done
 else
   for input_dir in "${input_dirs[@]}"; do
@@ -506,22 +506,22 @@ else
         case "$mtime" in ""|*[!0-9]*) printf "distill-audit: unreadable mtime for %s\n" "$path" >&2; exit 1 ;; esac
         printf "%s\t%s\t%s\n" "$mtime" "$size" "$path"
       done
-    ' sh {} + >>"$candidate_list" || infra_fail "candidate enumeration failed (size/mtime unreadable)"
+    ' sh {} + >>"$candidate_list" || infra_fail "candidate enumeration failed (size/mtime unreadable) — rename or remove the offending input file, or rerun if it was transient"
   done
 fi
 
 # Preserve empty fields: tab-delimited read would collapse adjacent tabs.
 while IFS= read -r row || [[ -n "$row" ]]; do
-  [[ "$row" == *$'\t'* ]] || infra_fail "invalid candidate row: $row"
+  [[ "$row" == *$'\t'* ]] || infra_fail "invalid candidate row: $row — rename or remove the offending input file, or rerun if it was transient"
   mtime=${row%%$'\t'*}
   remainder=${row#*$'\t'}
-  [[ "$remainder" == *$'\t'* ]] || infra_fail "invalid candidate row: $row"
+  [[ "$remainder" == *$'\t'* ]] || infra_fail "invalid candidate row: $row — rename or remove the offending input file, or rerun if it was transient"
   size=${remainder%%$'\t'*}
   path=${remainder#*$'\t'}
   if [[ -z "$path" || "$path" == *$'\t'* ]] \
-    || ! _classify_is_nonnegative_integer "$mtime" \
-    || ! _classify_is_nonnegative_integer "$size"; then
-    infra_fail "invalid candidate row: $row"
+    || ! is_nonnegative_integer "$mtime" \
+    || ! is_nonnegative_integer "$size"; then
+    infra_fail "invalid candidate row: $row — rename or remove the offending input file, or rerun if it was transient"
   fi
 done <"$candidate_list"
 

--- a/tests/distill-audit.test.sh
+++ b/tests/distill-audit.test.sh
@@ -305,6 +305,96 @@ else
   fail_case "snapshot terms inside ordinary conversation filenames are not over-filtered" "rc=$rc output=$output"
 fi
 
+# #151: external candidate metadata must fail closed in both find branches.
+metadata_bin=$TMP_ROOT/metadata-bin
+mkdir -p "$metadata_bin"
+cat >"$metadata_bin/wc" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == -c ]] && python3 -c '
+import os, sys
+candidate = os.stat(sys.argv[1])
+stdin = os.fstat(0)
+sys.exit(0 if (candidate.st_dev, candidate.st_ino) == (stdin.st_dev, stdin.st_ino) else 1)
+' "$ISSUE151_PATH"; then
+  case "$ISSUE151_MODE" in
+    empty-size) exit 1 ;;
+    invalid-size) printf 'not-a-number\n'; exit 0 ;;
+  esac
+fi
+if [[ "${1:-}" == -m && "$ISSUE151_MODE" == advisory ]]; then
+  printf 'called\n' >>"$ISSUE151_WC_LOG"
+  exit 1
+fi
+exec /usr/bin/wc "$@"
+SH
+cat >"$metadata_bin/stat" <<'SH'
+#!/usr/bin/env bash
+if [[ "${3:-}" == "$ISSUE151_PATH" ]]; then
+  case "$ISSUE151_MODE" in
+    empty-mtime) exit 0 ;;
+    invalid-mtime) printf 'not-a-number\n'; exit 0 ;;
+    leading-zero-mtime) printf '0123\n'; exit 0 ;;
+  esac
+fi
+exec /usr/bin/stat "$@"
+SH
+chmod +x "$metadata_bin/wc" "$metadata_bin/stat"
+for branch in fresh incremental; do
+  for mode in empty-size invalid-size empty-mtime invalid-mtime leading-zero-mtime extra-field; do
+    ws=$(make_ws "metadata-$branch-$mode")
+    candidate=$ws/input/session.log
+    if [[ "$mode" == extra-field ]]; then
+      mv "$candidate" "$ws/input/"$'extra\tfield.log'
+      candidate="$ws/input/"$'extra\tfield.log'
+    fi
+    # A missing size used to count this oversized transcript as zero and skip truncation.
+    write_chars "$candidate" 120000 x
+    if [[ "$branch" == incremental ]]; then
+      printf 'existing marker\n' >"$ws/loop/.distill-last-run"
+      touch -t 202001010000 "$ws/loop/.distill-last-run"
+      cp -p "$ws/loop/.distill-last-run" "$ws/marker-before"
+    fi
+    prompt_dump=$TMP_ROOT/metadata-$branch-$mode-prompt.md
+    output=$(PATH="$metadata_bin:$PATH" ISSUE151_PATH="$candidate" ISSUE151_MODE="$mode" \
+      PROMPT_DUMP="$prompt_dump" DISTILLER_CMD="$distiller" \
+      bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)
+    rc=$?
+    expected='candidate enumeration failed (size/mtime unreadable)'
+    case "$mode" in leading-zero-mtime|extra-field) expected='invalid candidate row:' ;; esac
+    marker_unchanged=0
+    if [[ "$branch" == fresh ]]; then
+      [[ ! -e "$ws/loop/.distill-last-run" ]] && marker_unchanged=1
+    elif cmp -s "$ws/marker-before" "$ws/loop/.distill-last-run" \
+      && [[ ! "$ws/loop/.distill-last-run" -nt "$ws/marker-before" ]]; then
+      marker_unchanged=1
+    fi
+    if [[ "$rc" -eq 3 && "$marker_unchanged" -eq 1 && ! -e "$prompt_dump" ]] \
+      && printf '%s\n' "$output" | grep -Fq "distill-audit infra error: $expected" \
+      && ! find "$ws/loop/pending" -name 'distill-*.md' -print | grep -q .; then
+      pass "candidate metadata $branch $mode fails closed before prompt or marker"
+    else
+      prompt_bytes=0
+      [[ ! -f "$prompt_dump" ]] || prompt_bytes=$(/usr/bin/wc -c <"$prompt_dump")
+      fail_case "candidate metadata $branch $mode fails closed before prompt or marker" \
+        "rc=$rc prompt_bytes=$prompt_bytes marker_unchanged=$marker_unchanged output=$output"
+    fi
+  done
+done
+
+ws=$(make_ws advisory-character-count)
+prompt_dump=$TMP_ROOT/advisory-character-count-prompt.md
+wc_log=$TMP_ROOT/advisory-wc.log
+output=$(PATH="$metadata_bin:$PATH" ISSUE151_PATH="$ws/input/session.log" ISSUE151_MODE=advisory \
+  ISSUE151_WC_LOG="$wc_log" PROMPT_DUMP="$prompt_dump" DISTILLER_CMD="$distiller" \
+  bash "$SCRIPT" --workspace "$ws" --input "$ws/input" 2>&1)
+rc=$?
+if [[ "$rc" -eq 0 && -s "$wc_log" && -s "$prompt_dump" && -e "$ws/loop/.distill-last-run" ]] \
+  && ! printf '%s\n' "$output" | grep -Eq 'WARNING: STATE.md|VIOLATION: STATE.md'; then
+  pass "advisory wc -m failure falls back to zero without aborting"
+else
+  fail_case "advisory wc -m failure falls back to zero without aborting" "rc=$rc output=$output"
+fi
+
 ws=$(make_ws cap)
 distiller=$TMP_ROOT/fake-distiller.sh
 write_distiller "$distiller"

--- a/tests/distill-audit.test.sh
+++ b/tests/distill-audit.test.sh
@@ -347,7 +347,9 @@ for branch in fresh incremental; do
       mv "$candidate" "$ws/input/"$'extra\tfield.log'
       candidate="$ws/input/"$'extra\tfield.log'
     fi
-    # A missing size used to count this oversized transcript as zero and skip truncation.
+    # Pre-fix, an empty size coerced to 0 under-counted the awk budget, then the truncation
+    # comparison aborted with a bash arithmetic error (rc=1, no prompt). Non-numeric or
+    # leading-zero mtime and an extra tab field silently passed (rc=0, prompt written, marker advanced).
     write_chars "$candidate" 120000 x
     if [[ "$branch" == incremental ]]; then
       printf 'existing marker\n' >"$ws/loop/.distill-last-run"


### PR DESCRIPTION
> **Superseding record (L1-8), 2026-09-07** — candidate SHA adc37da → 7d729dd after a rebase onto main (adjacent PR #287 / v0.26.3 merged; L0-7 obligation). Rebase only; git diff adc37da 7d729dd on the two declared files is empty. Re-verified after the rebase: distill-audit suite 66/66, make test 45/45, make lint 91 OK. The r1 3/3 GO and Opus r2 delta-confirmation GO carry over to the content-identical diff.

## Summary

In `adapters/openclaw/distill-audit.sh` the `wc -c` / `stat` inside the two `find … -exec sh -c` blocks ran outside the parent's `set -euo pipefail`, so a failed `wc` left an empty size that the prompt-budget awk coerced to 0 (under-count against `cap_bytes`), and downstream the tab-delimited reader collapsed the empty field so `$size` became the path (bash arithmetic error mid-run); a non-numeric mtime or an extra tab field passed silently. Now the inner `sh` rejects a non-numeric size or mtime and exits 1, each `find` invocation is wrapped with an explicit `infra_fail`, and the parent re-validates every candidate row with an exact tab split before the budget. The advisory `wc -m` char count at the injection size check stays a fallback to 0 (monitoring, not a gate) and says so in a comment.

Closes #151

Recorded decisions:
- Tab-bearing candidate filenames are now rejected on purpose (a tab in a name can forge TSV fields); base round-tripped them via the last-field read. Narrowing beyond the Issue's literal Done-when, made explicit here.
- Done-when 5 (race end-to-end): **未再現** — the find→wc race was not reproduced end-to-end; it is simulated via a fake `wc` / `stat` on PATH, which is the mechanism that matters (an empty or non-numeric metadata value reaching the budget).
- The pre-fix behaviour, measured on base by the writer and two seats: awk under-count then a bash arithmetic error (rc 1, no prompt) for empty/invalid size; **silent success** (rc 0, prompt written, marker advanced) for invalid / leading-zero mtime and an extra tab field. Both classes are now an explicit early infra error (exit 3).

Follow-up: newline-bearing candidate filenames can still forge an extra TSV row and pull an unrelated file into the prompt — pre-existing on base, tracked in #293.

## Files touched (L0-6)

- `adapters/openclaw/distill-audit.sh` (inner-sh numeric validation + `|| infra_fail`, parent-side row validation, advisory comment, operator hint in the two new messages)
- `tests/distill-audit.test.sh` (fake `wc` / fake `stat` metadata cases × fresh and incremental branches, advisory `wc -m` fallback pinned)

## 完了記録 (Completion record)

candidate SHA: 7d729dd
implementer: Codex gpt-6-astra (medium) via `codex exec` (r1 + micro-delta), commit by alpha (Claude Code)
reviewer: Opus 5 (Agent code-reviewer) / Kimi K3 (kimi -p) / Gemini 3.8 Flash (agy static) — r1 3/3 GO + Opus r2 delta confirmation GO (record below)
identity check: 別モデル（writer = Codex; seats as listed）
CI: test-lint run 34081251364 green on 7d729dd (test, test-macos, lint all SUCCESS)
release: N/A② (internal hardening of distill-audit's own enumeration; no public API, distribution or norm change)
previous release: v0.26.3 → https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.26.3（履行済み: Release exists, release-sync run 34080576726）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| `sh -c` 内の `wc` 出力を検証してから使う（POSIX sh イディオム） | PASS | inner `case "$size" in ""\|*[!0-9]*) … exit 1` and the same for `$mtime` in both find blocks; Opus seat verified the pattern in /bin/sh (empty, non-numeric, space all rejected) (2026-09-07) |
| 検証失敗時は明示エラーで停止（空を 0 として続行しない） | PASS | `find … \|\| infra_fail "candidate enumeration failed (size/mtime unreadable) …"` (exit 3) plus parent `invalid candidate row: …`; BSD find returns 1 on a failing `-exec … +` child (constructed by Opus and Kimi seats) (2026-09-07) |
| `:118` `chars=$(wc -m …) \|\| chars=0` の扱いを決めて明記 | PASS | decision: advisory monitoring, not a gate — comment added at the call site; test `advisory wc -m failure falls back to zero without aborting` pins rc 0 + prompt + marker (2026-09-07) |
| T-2: 検証が無いと予算が過小になることを示す再現テスト（fix 前赤・fix 後緑） | PASS | `bash tests/distill-audit.test.sh` → `Summary: 66 PASS, 0 FAIL` (bash 5 and /bin/bash 3.2.57); base tree + new test (git archive) → `Summary: 54 PASS, 12 FAIL` (Opus seat; writer's negative control agrees) (2026-09-07) |
| レース条件の end-to-end 再現（不能なら「未再現」と明記） | N/A(未再現 — 明記) | not reproduced end-to-end; simulated via fake `wc` / `stat` on PATH (see Recorded decisions) (2026-09-07) |
| テスト / lint green | PASS | `make test` → `Suite Summary: 45 PASS, 0 FAIL`; `make lint` → `lint: 91 shell files OK` (2026-09-07) |

Tests added: 12 metadata cases + 1 advisory case in `tests/distill-audit.test.sh` (T-2 regression, red on base).

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...7d729dd: 2 files changed, 114 insertions(+), 2 deletions(-)
宣言ファイル集合との差分: なし

### Review record

Panel: 3 heterogeneous seats, blind in r1 (identical packet), read-only against candidate 9876ee2. Alpha (orchestrator) is not a seat. GLM 5.3 (429 until 2026-09-10) and Grok 4.6 (402) absent; decision `loom-seats --size S --absent glm-5.3 --absent grok-4.6` → Opus 5 / Kimi K3 / Gemini 3.8 Flash.

**r1 — candidate 9876ee2**

| seat | requested → actual | verdict | blocking | F1..F5 | evidence highlights |
|---|---|---|---|---|---|
| Opus 5 (Claude Code Agent code-reviewer) | opus-5 → claude-opus-5[1m] | GO | 0 | PASS ×5 | 12 new cases red on base (git archive; 3 modes silently succeeded on base, 3 aborted with a bash arithmetic error), green on candidate (66); POSIX case pattern verified in /bin/sh; BSD find `-exec … +` returns 1 on a failing child (GNU reasoned); tab-collapse of the base reader reproduced and the new exact-tab split verified incl. paths with spaces end-to-end; advisory wc -m unchanged and pinned; make test 45/45; /bin/bash 3.2 suite green. MINOR-1 false test comment; MINOR-2 tab-bearing names now rejected (record the decision); MINOR-3 operator hint; MINOR-4 lib-private helper vs local twin; MINOR-5 state 未再現; MINOR-6 pre-existing newline-in-filename row forgery (canary leaks on base and candidate) |
| Kimi K3 (CLI `kimi -p`) | kimi-code/k3 → Kimi K3 | GO | 0 | PASS ×5 | suite ×2 on candidate + base mirror; BSD find exit-status construction; MINOR: PR narrative understates base silent-success modes (mtime corruption, tab-in-path); NIT: race simulated not raced; NIT: inner wc stderr not redirected |
| Gemini 3.8 Flash (agy static) | gemini-3.8-flash-high → Gemini 3.8 Flash (High) | GO | 0 | PASS PASS PASS N/A(static) PASS | 0 findings |

Adjudication r1 (alpha): 3/3 GO, zero blocking. Adopted before merge as a micro-delta (writer Codex astra): reword the false test comment (Opus MINOR-1 / Kimi MINOR), use the local `is_nonnegative_integer` (MINOR-4), add an operator remediation hint to the two new infra messages (MINOR-3). Recorded decisions: tab-bearing candidate names are rejected on purpose (a tab in a name can forge TSV fields; MINOR-2); the find→wc race was not reproduced end-to-end — simulated via a fake `wc`/`stat` on PATH (Done-when 5, "未再現"). Follow-up Issue: newline-bearing filename row forgery (MINOR-6, pre-existing).

**Delta confirmation — candidate 7d729dd81443c373e159c0102ac0bcbd059e4bbf**

Opus 5 r2: GO (cumulative for 7d729dd) — boundary re-verified against the true base 0c08770 (2 declared files only; other paths in the raw 9876ee2..7d729dd diff are rebase noise from #81/#289); MINOR-1/3/4 RESOLVED; MINOR-2/5/6 accepted as recorded decisions / #293; suite 66/66 under bash 5 and 3.2.57; lint 91 OK; delta touches only comment text, message strings and one helper name (no control flow / exit codes / validation semantics). Kimi and Gemini r1 GO carry over (content of the validated paths unchanged).

Seat files: session scratchpad `seats-151/{opus,kimi,gemini}.md`.
