### PR TITLE
fix(#279): strip the model-written date/job-id prefix once at fold time and make dedup agree

### DIFF
--- a/scripts/flush-intake.sh
+++ b/scripts/flush-intake.sh
@@ -162,10 +162,15 @@ consider_candidate() {
   fi
   if [[ "$target" == lessons ]]; then
     # Remove one model-written prefix; a second date belongs to the lesson.
-    text=$(printf '%s\n' "$text" | LC_ALL=C awk '
+    if ! text=$(printf '%s\n' "$text" | LC_ALL=C awk '
       {
-        sub(/^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][[:space:]]+/, "")
-        if (match($0, /^(\|[[:space:]]+)?[A-Za-z0-9][A-Za-z0-9._-]*[[:space:]]+\|([[:space:]]+|$)/)) {
+        # Inspect the original bullet before removing any metadata.
+        fields = ($0 ~ /\|[[:space:]]+next:/) + ($0 ~ /\|[[:space:]]+blockers:/) + \
+                 ($0 ~ /\|[[:space:]]+artifact:/) + ($0 ~ /\|[[:space:]]+handoff:/)
+        if (($0 ~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]([[:space:]]|$)/ && fields >= 2) ||
+            $0 ~ /^next:.*[[:space:]]\|[[:space:]]+/) exit 1
+        dated = sub(/^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][[:space:]]+/, "")
+        if (dated && match($0, /^(\|[[:space:]]+)?[A-Za-z0-9][A-Za-z0-9._-]*[[:space:]]+\|([[:space:]]+|$)/)) {
           prefix_length = RLENGTH
           token = substr($0, 1, prefix_length)
           sub(/^\|[[:space:]]+/, "", token)
@@ -177,17 +182,14 @@ consider_candidate() {
         sub(/^[[:space:]]+/, "")
         print
       }
-    ')
+    '); then
+      rejected=$((rejected + 1))
+      return 0
+    fi
     if [[ -z "$text" ]]; then
       rejected=$((rejected + 1))
       return 0
     fi
-  fi
-  # Keep fields visible even when their preceding token was stripped as an id.
-  if [[ "$target" == lessons ]] && printf '%s\n' "$text" "$2" | \
-    LC_ALL=C grep -Eq '(^next:|\|[[:space:]]+(next|blockers|artifact|handoff):)'; then
-    rejected=$((rejected + 1))
-    return 0
   fi
   if (( budget_used >= max_fold )); then
     deferred=$((deferred + 1))

--- a/scripts/flush-intake.sh
+++ b/scripts/flush-intake.sh
@@ -160,6 +160,35 @@ consider_candidate() {
     rejected=$((rejected + 1))
     return 0
   fi
+  if [[ "$target" == lessons ]]; then
+    # Remove one model-written prefix; a second date belongs to the lesson.
+    text=$(printf '%s\n' "$text" | LC_ALL=C awk '
+      {
+        sub(/^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][[:space:]]+/, "")
+        if (match($0, /^(\|[[:space:]]+)?[A-Za-z0-9][A-Za-z0-9._-]*[[:space:]]+\|([[:space:]]+|$)/)) {
+          prefix_length = RLENGTH
+          token = substr($0, 1, prefix_length)
+          sub(/^\|[[:space:]]+/, "", token)
+          sub(/[[:space:]]+\|[[:space:]]*$/, "", token)
+          # The parser has already trimmed trailing whitespace from empty bodies.
+          if (length(token) <= 64 && token !~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)
+            $0 = substr($0, prefix_length + 1)
+        }
+        sub(/^[[:space:]]+/, "")
+        print
+      }
+    ')
+    if [[ -z "$text" ]]; then
+      rejected=$((rejected + 1))
+      return 0
+    fi
+  fi
+  # Keep fields visible even when their preceding token was stripped as an id.
+  if [[ "$target" == lessons ]] && printf '%s\n' "$text" "$2" | \
+    LC_ALL=C grep -Eq '(^next:|\|[[:space:]]+(next|blockers|artifact|handoff):)'; then
+    rejected=$((rejected + 1))
+    return 0
+  fi
   if (( budget_used >= max_fold )); then
     deferred=$((deferred + 1))
     return 1

--- a/scripts/lib-state-fold.sh
+++ b/scripts/lib-state-fold.sh
@@ -121,7 +121,14 @@ normalize_state_candidate() {
   printf '%s\n' "$1" | awk '
     {
       $1 = $1
-      sub(/^- [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] /, "")
+      # Old intake lines can carry both the fold date and a model-written prefix.
+      if (sub(/^- ([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] )+/, "")) {
+        if (match($0, /^(\| )?[A-Za-z0-9][A-Za-z0-9._-]* \| /)) {
+          prefix = substr($0, 1, RLENGTH)
+          sub(/^\| /, "", prefix)
+          if (length(prefix) - 3 <= 64) $0 = substr($0, RLENGTH + 1)
+        }
+      }
       sub(/[[:space:]]+\[mech_check: (yes|no)\]$/, "")
       sub(/[[:space:]]+\(source: [a-z-]+\)$/, "")
       $1 = $1

--- a/scripts/lib-state-fold.sh
+++ b/scripts/lib-state-fold.sh
@@ -121,12 +121,17 @@ normalize_state_candidate() {
   printf '%s\n' "$1" | awk '
     {
       $1 = $1
-      # Old intake lines can carry both the fold date and a model-written prefix.
-      if (sub(/^- ([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] )+/, "")) {
-        if (match($0, /^(\| )?[A-Za-z0-9][A-Za-z0-9._-]* \| /)) {
-          prefix = substr($0, 1, RLENGTH)
-          sub(/^\| /, "", prefix)
-          if (length(prefix) - 3 <= 64) $0 = substr($0, RLENGTH + 1)
+      # Strip one fold date; a second date is metadata only with a valid job id.
+      if (sub(/^- [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] /, "")) {
+        body = $0
+        sub(/^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] /, "", body)
+        if (match(body, /^(\| )?[A-Za-z0-9][A-Za-z0-9._-]* \| /)) {
+          prefix_length = RLENGTH
+          token = substr(body, 1, prefix_length)
+          sub(/^\| /, "", token)
+          sub(/ \| $/, "", token)
+          if (length(token) <= 64 && token !~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)
+            $0 = substr(body, prefix_length + 1)
         }
       }
       sub(/[[:space:]]+\[mech_check: (yes|no)\]$/, "")

--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -621,7 +621,145 @@ bash -c '
 ' _ "$ROOT/scripts/lib-state-fold.sh" "$mech_normalized_input" >"$mech_normalized"
 hash_plain=$(bash -c 'source "$1"; candidate_lesson_hash "$2"' _ "$ROOT/scripts/lib-state-fold.sh" '- 2026-07-14 Keep a repeated route identity. (source: distill-audit)')
 hash_mech=$(bash -c 'source "$1"; candidate_lesson_hash "$2"' _ "$ROOT/scripts/lib-state-fold.sh" '- 2026-07-14 Keep a repeated route identity. (source: distill-audit) [mech_check: no]')
-if [ "$(grep -Fc 'Keep literal provenance' "$anchor_ws/STATE.md")" -eq 2 ] \
+# Keep these regression checks inside case 26: the Hermes suite pins 41 cases.
+prefix_regressions_ok=1
+# Legacy STATE prefixes must hash like clean lessons without changing suffix rules.
+normalizer_ok=1
+while IFS='~' read -r input expected; do
+  actual=$(bash -c 'source "$1"; normalize_state_candidate "$2"' _ \
+    "$ROOT/scripts/lib-state-fold.sh" "$input")
+  if [ "$actual" != "$expected" ]; then
+    normalizer_ok=0
+    printf 'normalizer input=%s expected=%s actual=%s\n' "$input" "$expected" "$actual"
+  fi
+done <<'CASES'
+- 2026-09-05 2026-09-05 | id-1 | text (source: flush-intake)~text
+- 2026-09-05 | id-1 | text (source: flush-intake)~text
+- 2026-09-05 id-1 | text (source: flush-intake)~text
+- 2026-09-05 text (source: flush-intake)~text
+- 2026-09-05 text (source: distill-audit) [mech_check: no]~text
+- 2026-09-05 text (some note)~text (some note)
+- undated text (source: flush-intake)~- undated text
+- 2026-09-05 two words | text (source: flush-intake)~two words | text
+- 2026-09-05 | /path | text (source: flush-intake)~| /path | text
+- 2026-09-05 a1234567890123456789012345678901234567890123456789012345678901234 | text (source: flush-intake)~a1234567890123456789012345678901234567890123456789012345678901234 | text
+- 2026-09-05 a123456789012345678901234567890123456789012345678901234567890123 | text (source: flush-intake)~text
+CASES
+if [ "$normalizer_ok" -eq 1 ]; then
+  printf '%s\n' '  PASS [26/normalizer] normalizer removes repeated dates and one bounded job id, preserving other text'
+else
+  prefix_regressions_ok=0
+  printf '%s\n' '  FAIL [26/normalizer] normalizer removes repeated dates and one bounded job id, preserving other text' 'normalization mismatch'
+fi
+
+ws=$(new_ws case-42-legacy-prefix-dedup)
+{
+  printf '%s\n' '## Verified facts' '## General rules' '## Open failures' '## Lessons learned' \
+    '- 2026-09-05 2026-09-05 | ev007b-C-r3j1 | Step 1 file distribution (001-023): preserve ownership. (source: flush-intake)' \
+    '## Last session'
+} >"$ws/STATE.md"
+cp "$ws/STATE.md" "$TMP_ROOT/legacy-prefix.before"
+write_block "$ws/loop/pending/flush-$TODAY.md" "$TODAY" \
+  'Step 1 file distribution (001-023): preserve ownership.'
+run_intake "$ws"
+if cmp -s "$TMP_ROOT/legacy-prefix.before" "$ws/STATE.md" \
+  && [ "$(receipt_value "$ws" deduped)" -eq 1 ] \
+  && [ "$(receipt_value "$ws" folded)" -eq 0 ]; then
+  printf '%s\n' '  PASS [26/legacy-dedup] a clean flush lesson dedups against doubled-date STATE with a job id'
+else
+  prefix_regressions_ok=0
+  printf '%s\n' '  FAIL [26/legacy-dedup] a clean flush lesson dedups against doubled-date STATE with a job id' \
+    "receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+ws=$(new_ws case-43-last-session-rejected)
+cp "$ws/STATE.md" "$TMP_ROOT/last-session.before"
+printf '%s\n' \
+  "<!-- flush origin=stop-hook-demand session=test ts=${TODAY}T01:02:03Z outcome=ok unverified=true -->" \
+  '- 2026-09-05 | ev007b-C-r3j1 | next: distribute | blockers: none | artifact: files | handoff: loop/handoffs/x.md' \
+  '- Lesson | next: distribute' \
+  '- Lesson | blockers: none' \
+  '- Lesson | artifact: files' \
+  '- Lesson | handoff: loop/handoffs/x.md' \
+  '- next: distribute' >"$ws/loop/pending/flush-$TODAY.md"
+run_intake "$ws"
+if cmp -s "$TMP_ROOT/last-session.before" "$ws/STATE.md" \
+  && [ "$(receipt_value "$ws" rejected)" -eq 6 ] \
+  && [ "$(receipt_value "$ws" folded)" -eq 0 ]; then
+  printf '%s\n' '  PASS [26/session-fields] Last-session fields are rejected with exact accounting and unchanged STATE'
+else
+  prefix_regressions_ok=0
+  printf '%s\n' '  FAIL [26/session-fields] Last-session fields are rejected with exact accounting and unchanged STATE' \
+    "receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+ws=$(new_ws case-44-next-prose)
+write_block "$ws/loop/pending/flush-$TODAY.md" "$TODAY" \
+  'Explain next: in prose and keep 2026-09-05 as the cutover date.'
+run_intake "$ws"
+if grep -Fqx -- "- $TODAY Explain next: in prose and keep 2026-09-05 as the cutover date. (source: flush-intake)" "$ws/STATE.md" \
+  && [ "$(receipt_value "$ws" folded)" -eq 1 ] \
+  && [ "$(receipt_value "$ws" rejected)" -eq 0 ]; then
+  printf '%s\n' '  PASS [26/prose] next: in prose and an embedded content date remain lessons'
+else
+  prefix_regressions_ok=0
+  printf '%s\n' '  FAIL [26/prose] next: in prose and an embedded content date remain lessons' \
+    "receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+ws=$(new_ws case-45-model-prefix)
+prefix_ok=1
+prefix_case=0
+while IFS='~' read -r input expected; do
+  prefix_case=$((prefix_case + 1))
+  write_block "$ws/loop/pending/flush-$TODAY.md" "$TODAY" "$input"
+  run_intake "$ws"
+  if ! grep -Fqx -- "- $TODAY $expected (source: flush-intake)" "$ws/STATE.md" \
+    || [ "$(receipt_value "$ws" folded)" -ne 1 ]; then
+    prefix_ok=0
+    printf 'prefix case=%s input=%s expected=%s\n' "$prefix_case" "$input" "$expected"
+    cat "$ws/STATE.md"
+  fi
+done <<'CASES'
+2026-09-05 | ev007b-C-r3j1 | Step 1 file distribution (001-023): preserve ownership.~Step 1 file distribution (001-023): preserve ownership.
+2026-09-05 | ev007b-C-r3j1 | 2026-09-05 is the cutover date: keep it~2026-09-05 is the cutover date: keep it
+2026-09-05 ev007b-C-r3j1 | A space-separated id is metadata.~A space-separated id is metadata.
+2026-09-05 A date-only prefix is metadata.~A date-only prefix is metadata.
+id-1 | An id-only prefix is metadata.~An id-only prefix is metadata.
+2026-09-05 | id-1 | id-2 | A second id remains content.~id-2 | A second id remains content.
+2026-09-05 2026-09-06 is another content date.~2026-09-06 is another content date.
+2026-09-05 2026-09-06 | A second date is not a job id.~2026-09-06 | A second date is not a job id.
+2026-09-05 | id-1 |    Leading whitespace is removed.~Leading whitespace is removed.
+2026-09-05 two words | This is not a job id.~two words | This is not a job id.
+2026-09-05 a1234567890123456789012345678901234567890123456789012345678901234 | Too long is content.~a1234567890123456789012345678901234567890123456789012345678901234 | Too long is content.
+2026-09-05 a123456789012345678901234567890123456789012345678901234567890123 | A 64-byte id is metadata.~A 64-byte id is metadata.
+CASES
+if [ "$prefix_ok" -eq 1 ]; then
+  printf '%s\n' '  PASS [26/prefix] fold removes exactly one date and bounded id while preserving content prefixes'
+else
+  prefix_regressions_ok=0
+  printf '%s\n' '  FAIL [26/prefix] fold removes exactly one date and bounded id while preserving content prefixes' 'folded prefix mismatch'
+fi
+
+ws=$(new_ws case-46-empty-prefix)
+cp "$ws/STATE.md" "$TMP_ROOT/empty-prefix.before"
+printf '%s\n' \
+  "<!-- flush origin=stop-hook-demand session=test ts=${TODAY}T01:02:03Z outcome=ok unverified=true -->" \
+  '- 2026-09-05 | id-1 | ' \
+  '- id-1 | ' >"$ws/loop/pending/flush-$TODAY.md"
+run_intake "$ws"
+if cmp -s "$TMP_ROOT/empty-prefix.before" "$ws/STATE.md" \
+  && [ "$(receipt_value "$ws" rejected)" -eq 2 ] \
+  && [ "$(receipt_value "$ws" folded)" -eq 0 ]; then
+  printf '%s\n' '  PASS [26/empty] empty bodies after prefix stripping are rejected without STATE mutation'
+else
+  prefix_regressions_ok=0
+  printf '%s\n' '  FAIL [26/empty] empty bodies after prefix stripping are rejected without STATE mutation' \
+    "receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+if [ "$prefix_regressions_ok" -eq 1 ] \
+  && [ "$(grep -Fc 'Keep literal provenance' "$anchor_ws/STATE.md")" -eq 2 ] \
   && grep -Fqx -- 'Keep a distinct local annotation. (some note)' "$parenthetical_normalized" \
   && [ "$(LC_ALL=C sort -u "$parenthetical_normalized" | wc -l | tr -d '[:space:]')" -eq 2 ] \
   && [ "$(LC_ALL=C sort -u "$mech_normalized" | wc -l | tr -d '[:space:]')" -eq 1 ] \

--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -637,6 +637,10 @@ done <<'CASES'
 - 2026-09-05 | id-1 | text (source: flush-intake)~text
 - 2026-09-05 id-1 | text (source: flush-intake)~text
 - 2026-09-05 text (source: flush-intake)~text
+- 2026-09-07 2026-09-06 outage window (source: flush-intake)~2026-09-06 outage window
+- 2026-09-05 2026-11-30 is the cutover date (source: flush-intake)~2026-11-30 is the cutover date
+- 2026-09-05 2026-09-06 | text (source: flush-intake)~2026-09-06 | text
+- Railway | deploy needs an explicit migrate step. (source: flush-intake)~- Railway | deploy needs an explicit migrate step.
 - 2026-09-05 text (source: distill-audit) [mech_check: no]~text
 - 2026-09-05 text (some note)~text (some note)
 - undated text (source: flush-intake)~- undated text
@@ -646,10 +650,10 @@ done <<'CASES'
 - 2026-09-05 a123456789012345678901234567890123456789012345678901234567890123 | text (source: flush-intake)~text
 CASES
 if [ "$normalizer_ok" -eq 1 ]; then
-  printf '%s\n' '  PASS [26/normalizer] normalizer removes repeated dates and one bounded job id, preserving other text'
+  printf '%s\n' '  PASS [26/normalizer] normalizer removes one fold date and an optional legacy date with a bounded job id, preserving other text'
 else
   prefix_regressions_ok=0
-  printf '%s\n' '  FAIL [26/normalizer] normalizer removes repeated dates and one bounded job id, preserving other text' 'normalization mismatch'
+  printf '%s\n' '  FAIL [26/normalizer] normalizer removes one fold date and an optional legacy date with a bounded job id, preserving other text' 'normalization mismatch'
 fi
 
 ws=$(new_ws case-42-legacy-prefix-dedup)
@@ -672,19 +676,36 @@ else
     "receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
 fi
 
+ws=$(new_ws case-26-content-date-collision)
+{
+  printf '%s\n' '## Verified facts' '## General rules' '## Open failures' '## Lessons learned' \
+    "- $TODAY 2026-09-06 outage window: rotate the key. (source: flush-intake)" \
+    '## Last session'
+} >"$ws/STATE.md"
+write_block "$ws/loop/pending/flush-$TODAY.md" "$TODAY" \
+  '2026-09-05 | job-2 | 2026-09-08 outage window: rotate the key.'
+run_intake "$ws"
+if grep -Fqx -- "- $TODAY 2026-09-08 outage window: rotate the key. (source: flush-intake)" "$ws/STATE.md" \
+  && grep -Fqx -- "- $TODAY 2026-09-06 outage window: rotate the key. (source: flush-intake)" "$ws/STATE.md" \
+  && [ "$(receipt_value "$ws" folded)" -eq 1 ] \
+  && [ "$(receipt_value "$ws" deduped)" -eq 0 ]; then
+  printf '%s\n' '  PASS [26/date-collision] distinct content dates fold as distinct lessons'
+else
+  prefix_regressions_ok=0
+  printf '%s\n' '  FAIL [26/date-collision] distinct content dates fold as distinct lessons' \
+    "receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+fi
+
 ws=$(new_ws case-43-last-session-rejected)
 cp "$ws/STATE.md" "$TMP_ROOT/last-session.before"
 printf '%s\n' \
   "<!-- flush origin=stop-hook-demand session=test ts=${TODAY}T01:02:03Z outcome=ok unverified=true -->" \
   '- 2026-09-05 | ev007b-C-r3j1 | next: distribute | blockers: none | artifact: files | handoff: loop/handoffs/x.md' \
-  '- Lesson | next: distribute' \
-  '- Lesson | blockers: none' \
-  '- Lesson | artifact: files' \
-  '- Lesson | handoff: loop/handoffs/x.md' \
-  '- next: distribute' >"$ws/loop/pending/flush-$TODAY.md"
+  '- 2026-09-05 | ev007b-C-r3j1 | next: distribute | handoff: loop/handoffs/x.md' \
+  '- next: distribute | blockers: none' >"$ws/loop/pending/flush-$TODAY.md"
 run_intake "$ws"
 if cmp -s "$TMP_ROOT/last-session.before" "$ws/STATE.md" \
-  && [ "$(receipt_value "$ws" rejected)" -eq 6 ] \
+  && [ "$(receipt_value "$ws" rejected)" -eq 3 ] \
   && [ "$(receipt_value "$ws" folded)" -eq 0 ]; then
   printf '%s\n' '  PASS [26/session-fields] Last-session fields are rejected with exact accounting and unchanged STATE'
 else
@@ -725,7 +746,13 @@ done <<'CASES'
 2026-09-05 | ev007b-C-r3j1 | 2026-09-05 is the cutover date: keep it~2026-09-05 is the cutover date: keep it
 2026-09-05 ev007b-C-r3j1 | A space-separated id is metadata.~A space-separated id is metadata.
 2026-09-05 A date-only prefix is metadata.~A date-only prefix is metadata.
-id-1 | An id-only prefix is metadata.~An id-only prefix is metadata.
+id-1 | An id-only prefix is metadata.~id-1 | An id-only prefix is metadata.
+2026-09-05 id-1 | An id prefix after a date is metadata.~An id prefix after a date is metadata.
+Railway | deploy needs an explicit migrate step.~Railway | deploy needs an explicit migrate step.
+README | artifact: naming is inconsistent.~README | artifact: naming is inconsistent.
+Explain next: in prose.~Explain next: in prose.
+next: distribute~next: distribute
+id-1 |~id-1 |
 2026-09-05 | id-1 | id-2 | A second id remains content.~id-2 | A second id remains content.
 2026-09-05 2026-09-06 is another content date.~2026-09-06 is another content date.
 2026-09-05 2026-09-06 | A second date is not a job id.~2026-09-06 | A second date is not a job id.
@@ -746,7 +773,7 @@ cp "$ws/STATE.md" "$TMP_ROOT/empty-prefix.before"
 printf '%s\n' \
   "<!-- flush origin=stop-hook-demand session=test ts=${TODAY}T01:02:03Z outcome=ok unverified=true -->" \
   '- 2026-09-05 | id-1 | ' \
-  '- id-1 | ' >"$ws/loop/pending/flush-$TODAY.md"
+  '- 2026-09-05 id-1 | ' >"$ws/loop/pending/flush-$TODAY.md"
 run_intake "$ws"
 if cmp -s "$TMP_ROOT/empty-prefix.before" "$ws/STATE.md" \
   && [ "$(receipt_value "$ws" rejected)" -eq 2 ] \


### PR DESCRIPTION
> **Superseding record (L1-8), 2026-09-07** — candidate SHA 0fd1a58 → 10ea406 after a rebase onto main (adjacent PRs #287 / v0.26.3, #291 and #296 merged; L0-7 obligation). Three rebases only (after PR #287 / v0.26.3, PR #291 / #151, and PR #296 / #261 which raised the test-macos ceiling to 45 min); git diff 0fd1a58 10ea406 on the three declared files is empty. Re-verified after each rebase: flush-intake suite 41/41, hermes-flush-intake 10/10, make test 45/45, make lint 91 OK. The r2 3/3 GO carries over to the content-identical diff.

## Summary

Lessons folded by `scripts/flush-intake.sh` from bullets the model wrote in the Last-session shape came out as `- 2026-09-05 2026-09-05 | ev007b-C-r3j1 | Step 1 …` (fold date + model-written date + job id inside the lesson text), and `normalize_state_candidate` stripped only one leading date, so the dedup hash of such lines differed from the clean form (#150 part (2)). Now: the fold strips exactly one model-written leading date and, only after a date, one bounded `<id> |` segment (a second date is content and stays); bullets in the Last-session entry shape (date-led with two or more of `| next:` / `| blockers:` / `| artifact:` / `| handoff:`, or `next:`-led with pipe fields) are rejected instead of folded; the shared normalizer strips one fold date and a second date only when the legacy job-id prefix follows, so already-doubled STATE lines hash the same as the clean form while distinct lessons that merely start with a date keep distinct keys.

Closes #279. Resolves #150 part (2); #150 part (1) (oversize-drop visibility) stays open in #150.

## Files touched (L0-6)

- `scripts/flush-intake.sh` (consider_candidate: prefix strip once, gated id strip, entry-shape rejection, fail-closed awk assignment)
- `scripts/lib-state-fold.sh` (normalize_state_candidate: one fold date + legacy date/id prefix only)
- `tests/flush-intake.test.sh` (case 26 sub-checks: prefix, content-date protection, date-collision pair, legacy dedup, bare leading token kept, single-field prose folds, full Last-session shape rejected, empty-after-strip, normalizer table)

## 完了記録 (Completion record)

candidate SHA: 10ea406
implementer: Codex gpt-6-astra (medium) via `codex exec` (r1 + review delta), commit by alpha (Claude Code)
reviewer: Opus 5 (Agent code-reviewer) / Kimi K3 (kimi -p) / Gemini 3.8 Flash (agy static) — r1 2 NO-GO / 1 GO → delta → r2 3/3 GO (record below)
identity check: 別モデル（writer = Codex; seats as listed）
CI: test-lint run 34120899031 green on 10ea406 (test, lint, test-macos all SUCCESS — test-macos completed under the 45-min ceiling introduced by #296); gitleaks / history-check / pr-size / repo-state / risk-review-gate SUCCESS
release: N/A② (internal tidy-up: intake fold formatting / dedup key; no public API, distribution or norm change)
previous release: v0.26.3 → https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.26.3（履行済み: Release exists, release-sync run 34080576726）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| Reproduce with a fixture flush block in the shape the v0.25.0 Stop hook writes (`tests/flush-intake.test.sh`) | PASS | case `[26/prefix]`: bullet `- 2026-09-05 \| ev007b-C-r3j1 \| Step 1 …` folds to `- <fold-date> Step 1 … (source: flush-intake)`; negative control (fold-time strip reverted in a temp copy) → `FAIL [26/prefix]` with the doubled line (2026-09-07) |
| `flush-intake.sh` strips the provenance stamp / date-pipe-id prefix exactly once and does not fold Last-session-shaped lines as lessons | PASS | one strip (content-date protection case keeps the inner date; Opus/Kimi constructions); `[26/session-fields]` rejects the full entry shape while single-field prose folds (2026-09-07) |
| Regression test pinned | PASS | `bash tests/flush-intake.test.sh` → `Summary: 41 PASS, 0 FAIL` (bash 5 and /bin/bash 3.2.57); normalizer-sharing suites green: lesson-hash 13, raw-review 64, pending-dedup 13, state-caps-fold 11, apply-promotions 46, deadman-probe 36, last-session-fold 21, distill-audit 53, hermes-flush-intake 10; `make test` → `Suite Summary: 45 PASS, 0 FAIL`; `make lint` → `lint: 91 shell files OK` (2026-09-07) |

Tests added: case 26 sub-checks in `tests/flush-intake.test.sh` (T-2 regression: 5 of 6 r1 sub-checks red on base; the r2 `[26/date-collision]` case red with the greedy normalizer).

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...10ea406: 3 files changed, 210 insertions(+), 2 deletions(-)
宣言ファイル集合との差分: なし（tests/state-caps-fold.test.sh was declared conditionally and not needed）

### Review record

Panel: 3 heterogeneous seats, blind in r1 (identical packet), read-only. Alpha (orchestrator) is not a seat. GLM 5.3 (429 until 2026-09-10) and Grok 4.6 (402) absent; decision `loom-seats --size S --absent glm-5.3 --absent grok-4.6` → Opus 5 / Kimi K3 / Gemini 3.8 Flash.

**r1 — candidate 3dd819a**

| seat | requested → actual | verdict | blocking | F1..F5 | evidence highlights |
|---|---|---|---|---|---|
| Opus 5 (Claude Code Agent code-reviewer) | opus-5 → claude-opus-5[1m] | NO-GO | 1 | PASS FAIL PASS PASS PASS | red-on-base 5/6 sub-checks; 10 sibling suites green under /bin/bash 3.2.57 + BSD awk. **MAJOR (reproduced end-to-end)**: `normalize_state_candidate` strips an unbounded run of leading dates, so two distinct lessons differing only in a leading content date collapse to one dedup key and the second is silently dropped (candidate folded=0 deduped=1 vs base folded=1). MINOR: fold-side `<id> \|` strip fires with no date ("Railway \| …" loses "Railway"); MINOR: Last-session filter rejects single-field prose ("README \| artifact: …"); NIT: awk assignment not fail-closed in-style; NIT: old dedup_key annotations admit one duplicate |
| Kimi K3 (CLI `kimi -p`) | kimi-code/k3 → Kimi K3 | GO | 0 | PASS FAIL PASS PASS PASS | all suites (bash 5 + 3.2) green; own red-on-base; adversarial runs (content-date, bare double date, Railway/Docker word-pipe, next: with/without pipe). MINOR: id grammar cannot distinguish a job id from content; NIT: bare `next:` rejected; NIT: fold/normalizer asymmetry |
| Gemini 3.8 Flash (agy static) | gemini-3.8-flash-high → same | NO-GO | 2 | PASS PASS FAIL N/A(static) PASS | MAJOR: Last-session regex anchors only `next:`; MAJOR: over-broad id stripping; MINOR: greedy normalizer date strip |

Adjudication r1 (alpha): 2 NO-GO / 1 GO — **adopted on evidence** (Opus reproduced the dedup loss end-to-end; Gemini and Kimi independently flagged the id grammar). Delta ordered (Codex astra): normalizer strips one fold date and a second date only when the legacy `<id> |` prefix follows; fold-side id strip gated on a stripped date; Last-session rejection requires the entry shape (date-led + ≥2 field markers, or `next:`-led with pipe fields); fail-closed awk assignment; tests for the collision pair, bare leading token, single-field prose, full Last-session shape, normalizer table.

**r2 — cumulative for 10ea40603da3035b09eaae522035a10091ca53b4**

| seat | verdict | blocking | evidence |
|---|---|---|---|
| Opus 5 | GO | 0 | all r1 findings RESOLVED by re-running its own constructions (collision pair folds both; Railway/postgres/CI kept; README\|artifact: and deploy\|next: prose fold; only the full entry rejected); residual normalizer over-merge (dated bare-token lines: Railway vs Vercel) constructed and judged acceptable MINOR, asks that it be pinned in the normalizer table and narrowed in a follow-up; bash 3.2 + BSD awk green; 9 sibling suites green |
| Kimi K3 | GO | 0 | fold-side word-pipe loss fixed (gated on a stripped date), bare next: prose folds, asymmetry comment resolved; residual asymmetry constructed = acceptable over-merge MINOR; NIT: next:-led regex still slightly wider than the entry shape; suites bash 5 + 3.2 green, lint OK |
| Gemini 3.8 Flash (static) | GO | 0 | all three r1 findings RESOLVED; asymmetry judged acceptable over-merge |

Adjudication r2 (alpha): 3/3 GO, zero blocking. The one convergent residual (normalizer over-merge of dated bare-token lines) is recorded as a follow-up Issue (pin the lossy expectation in the normalizer table; consider narrowing the branch to the pipe-led legacy form) rather than another delta. Seat files: session scratchpad `seats-279/`.
