### PR TITLE
README: regenerate the family footer for family-os v0.20.0 (sibling sweep)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -257,6 +257,8 @@ workspace としてインストールし、ヘルスチェックを実行し、�
 | 横軸・基盤 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 記憶バス — 家族が知っていることを共有する層 | 公開・MIT |
 | 横軸 | [Sitter](https://github.com/caty-ai/sitter) | 委譲したエージェント実行の見張り番 — 監視・証拠の記録・宣言した範囲内でのみ再起動 | 公開・MIT |
 | 横軸 | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | 夜間自律保守ループ — deny-by-default の guard の内側で夜のレーンが走り、朝は人間が cherry-pick するだけ | 公開・MIT |
+| 横軸 | [errmeter](https://github.com/caty-ai/errmeter) | 複数マシンの AI エージェントと定期ジョブの失敗・沈黙を報告する — emit・spool・共有掲示板・復旧フック。消えない叫び | 公開・MIT |
+| 縦軸 | [Caty Gateway](https://github.com/caty-ai/caty-gateway) | CatyPhone の PC 側 gateway — 1 行インストールで、手元の PC で動くエージェント（Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI 互換）とスマホをつなぐ | 公開・MIT |
 
 <!-- family:generated:family-footer:end -->
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ Part of the **Caty AI family** — open tools for running a family of AI agents.
 | Horizontal · foundation | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | The memory bus — how the family shares what it knows | published, MIT |
 | Horizontal | [Sitter](https://github.com/caty-ai/sitter) | Babysits delegated agent runs — watches, keeps evidence, restarts only within declared bounds | published, MIT |
 | Horizontal | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | Nightly autonomous maintenance loop — isolated night lanes behind a deny-by-default guard; humans cherry-pick in the morning | published, MIT |
+| Horizontal | [errmeter](https://github.com/caty-ai/errmeter) | Reports failed or silent AI agents and scheduled jobs across machines — emit, spool, shared board, repair hook; a shout that is never lost | published, MIT |
+| Vertical | [Caty Gateway](https://github.com/caty-ai/caty-gateway) | PC-side gateway for CatyPhone — one-line install; pairs your phone with the agent running on your machine (Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI-compatible) | published, MIT |
 
 <!-- family:generated:family-footer:end -->
 

--- a/README.th.md
+++ b/README.th.md
@@ -257,6 +257,8 @@ flowchart LR
 | แกนนอน · รากฐาน | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | บัสความทรงจำ — ชั้นที่ครอบครัวใช้แบ่งปันสิ่งที่รู้ | เปิดแล้ว・MIT |
 | แกนนอน | [Sitter](https://github.com/caty-ai/sitter) | พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ตเฉพาะในขอบเขตที่ประกาศไว้ | เปิดแล้ว・MIT |
 | แกนนอน | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | ลูปบำรุงรักษาอัตโนมัติยามค่ำคืน — เลนกลางคืนทำงานหลังการ์ดแบบปฏิเสธโดยปริยาย ตอนเช้ามนุษย์เลือก cherry-pick | เปิดแล้ว・MIT |
+| แกนนอน | [errmeter](https://github.com/caty-ai/errmeter) | รายงาน AI agent และงานตั้งเวลาที่ล้มเหลวหรือเงียบหายข้ามเครื่อง — emit, spool, บอร์ดกลาง, repair hook; เสียงตะโกนที่ไม่มีวันหายไป | เปิดแล้ว・MIT |
+| แกนตั้ง | [Caty Gateway](https://github.com/caty-ai/caty-gateway) | เกตเวย์ฝั่ง PC ของ CatyPhone — ติดตั้งด้วยคำสั่งบรรทัดเดียว เชื่อมโทรศัพท์กับเอเจนต์ที่รันบนเครื่องของคุณ (Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI-compatible) | เปิดแล้ว・MIT |
 
 <!-- family:generated:family-footer:end -->
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -256,6 +256,8 @@ flowchart LR
 | 横轴・基座 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 记忆总线 — 家族共享所知的一层 | 已公开・MIT |
 | 横轴 | [Sitter](https://github.com/caty-ai/sitter) | 替你盯着委派出去的智能体 — 监视、留证、仅在声明范围内重启 | 已公开・MIT |
 | 横轴 | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | 夜间自主维护循环 — 在默认拒绝的防护边界内运行夜间通道，早晨由人工挑选合并 | 已公开・MIT |
+| 横轴 | [errmeter](https://github.com/caty-ai/errmeter) | 上报跨机器失败或失联的 AI 代理与定时任务 — emit、spool、共享看板、修复钩子；永不消失的呼喊 | 已公开・MIT |
+| 纵轴 | [Caty Gateway](https://github.com/caty-ai/caty-gateway) | CatyPhone 的电脑端网关 — 一行命令安装，把手机与本机运行的智能体（Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI 兼容）连接起来 | 已公开・MIT |
 
 <!-- family:generated:family-footer:end -->
 


### PR DESCRIPTION
## Why

family-os **v0.20.0** (https://github.com/caty-ai/family-os/releases/tag/v0.20.0) added two published modules to the map: **errmeter** and **caty-gateway**. Every family README carries a generated footer that lists the map, so each sibling repository needs its footer regenerated — otherwise the scheduled `family footer` check reports "the map no longer matches reality". This is the mechanical sibling sweep from the family-footer contract's Publication Runbook (family-os `docs/family-footer-contract.md`).

## What changed

Only the generated region between `<!-- family:generated:family-footer:start -->` and `<!-- family:generated:family-footer:end -->` in the declared `README*.md` files, rendered by `python3 -B tools/family_footer.py render-all` from family-os `main` @ v0.20.0. No hand edits; a second render is a no-op (idempotent).

## Verification

- Rendered from the registry at family-os v0.20.0; byte-exact output is what the scheduled check compares against.
- Repo CI on this PR.

## Completion record (L1-7)

- Done when: footer region equals the v0.20.0 render — PASS (idempotent second render)
- Implementer: alpha (Claude Code) · Review: mechanical generated-content PR per the Publication Runbook (registry PR #174 itself had 3 heterogeneous seats × 3 rounds); CI green required before merge
- release: N/A (generated README footer only; no behaviour, API or distributed artefact change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
