### PR TITLE
ci(#261): pin reusable-test-lint to handbook v0.29.0 and raise test_timeout_minutes to 45

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -8,7 +8,8 @@ permissions: {contents: read}
 concurrency: {group: 'test-lint-${{ github.event.pull_request.number }}', cancel-in-progress: true}
 jobs:
   test-lint:
-    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-test-lint.yml@0e8eceee64b2c5a25e47d15fb4ffbead491e0479 # ci-v1
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-test-lint.yml@2157a80b243bc2f47c5d7203ebd1d6369eaa5abc # ci-v1 (handbook v0.29.0, #160)
     permissions: {contents: read}
     with:
       run_macos: true
+      test_timeout_minutes: 45  # #261: the macOS leg runs 28-30 min on main and hit the 30-min ceiling 5x in one day; handbook#160 input


### PR DESCRIPTION
## Summary

Pins `reusable-test-lint.yml` to caty-ai/family-dev-handbook v0.29.0 (`2157a80`, handbook#160 / PR #162) and passes the new `test_timeout_minutes: 45`, so the macOS leg (28-30 min on main) no longer dies at the reusable's former hardcoded 30-minute ceiling (five cancels on #292 alone on 2026-09-07). This PR's own `test-lint / test-macos` run is the live proof: it executes under the 45-minute ceiling.

The pin also carries the additive `node_version` / `pre_test_setup_*` inputs from handbook#101 (defaults off → no behaviour change for this caller); the reusable's validator rejects anything outside 1..360.

Closes #261

## Declared files

- `.github/workflows/test-lint.yml` (uses: SHA + `with: test_timeout_minutes: 45`)

## 完了記録 (Completion record)

candidate SHA: 310b9da
implementer: alpha (Claude Code, direct edit — workflow YAML pin bump, one line + one `with:` line)
reviewer: Kimi K3 (kimi -p, single heterogeneous delta seat — owner-approved light form for mechanical pin bumps, handbook#127) GO, 0 blocking; upstream reusable change was 3-seat reviewed on handbook PR #162
identity check: 別モデル（writer = Claude; seat = non-Claude）
CI: test-lint run 34115200861 on 310b9da: test SUCCESS (22m38s), test-macos SUCCESS (29m45s — under the new 45-min ceiling; would have been cancelled at 30), lint SUCCESS; gitleaks / history-check / pr-size / repo-state / watch SUCCESS; risk-review-gate red only pending the owner risk-reviewed label
release: N/A③（CI・開発環境の配線のみ — テスト実行の上限時間の設定変更で、挙動・公開 API・配布物は変わらない）
previous release: v0.26.3 → https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.26.3（履行済み: Release exists, release-sync run 34080576726）

| Done when (#261) | 結果 | 証拠 |
|---|---|---|
| Either `timeout-minutes` for test-macos raised (e.g. 45) or the macOS matrix split | PASS | handbook v0.29.0 reusable input `test_timeout_minutes` pinned by SHA 2157a80 and set to 45 in `with:` (this diff); actionlint OK (2026-09-07) |
| One green test-macos duration recorded after adopting it | PASS | this PR's own test-macos job (run 34115200861) ran 2026-09-07 11:10:10Z → 11:39:55Z = 29m45s and completed green under the 45-min ceiling (2026-09-07) |

git diff --stat origin/main...310b9da: 1 file changed, 2 insertions(+), 1 deletion(-)

## Review record

Kimi K3 (kimi-code/k3) GO, 0 blocking. Verified: diff = exactly the uses: SHA + comment + with: test_timeout_minutes: 45; 2157a80 = handbook v0.29.0 tag target and the PR #162 squash commit; pulled-in reusable delta 0e8ecee..2157a80 = node_version / pre_test_setup_* (additive, defaults off) + test_timeout_minutes input and its 1..360 validator; job names / permissions unchanged (required-check keys stable); 45 passes the validator; actionlint OK. Seat file: session scratchpad seat-261-kimi.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
