### PR TITLE
test(#226): pin the eviction-archive fail-closed path and the NUL-archive dedup in flush-intake

### DIFF
--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -1257,5 +1257,77 @@ else
     "seed_ok=$headerless_seed_ok rc=$headerless_retry_rc receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log") archive=$(tr '\n' ' ' <"$eviction_archive_path")"
 fi
 
+ws=$(new_ws case-41-eviction-archive-failure)
+{
+  printf '%s\n' '## Verified facts' '## General rules' '## Open failures' '## Lessons learned'
+  i=1
+  while [ "$i" -le 60 ]; do
+    printf -- '- 2026-06-01 capped lesson %02d (source: distill-audit)\n' "$i"
+    i=$((i + 1))
+  done
+  printf '%s\n' '## Last session'
+} >"$ws/STATE.md"
+cp "$ws/STATE.md" "$TMP_ROOT/state-before-eviction-archive-failure"
+write_block "$ws/loop/pending/flush-2026-07-31.md" 2026-07-31 \
+  'A failed eviction archive must leave the flush untouched.'
+eviction_archive_path="$ws/loop/archive/intake-evictions-$TODAY.md"
+mkdir "$eviction_archive_path"
+set +e
+run_intake "$ws"
+eviction_archive_failure_rc=$?
+set -e
+if [ "$eviction_archive_failure_rc" -eq 1 ] \
+  && [ "$(receipt_value "$ws" error)" = eviction-archive ] \
+  && cmp -s "$TMP_ROOT/state-before-eviction-archive-failure" "$ws/STATE.md" \
+  && [ -f "$ws/loop/pending/flush-2026-07-31.md" ] \
+  && ! find "$ws/loop/pending" -maxdepth 1 -name 'intake-*.md' -print | grep -q . \
+  && [ ! -e "$ws/loop/archive/flush-2026-07-31.md" ] \
+  && [ ! -e "$ws/loop/.deadman/distill.marker" ] \
+  && [ "$(receipt_value "$ws" folded)" -eq 0 ] \
+  && [ "$(receipt_value "$ws" marker)" = untouched ] \
+  && [ -d "$eviction_archive_path" ]; then
+  pass '[41] a failed eviction-archive append refuses the flush and leaves STATE and the pending flush untouched'
+else
+  fail_case '[41] a failed eviction-archive append refuses the flush and leaves STATE and the pending flush untouched' \
+    "rc=$eviction_archive_failure_rc receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+fi
+
+ws=$(new_ws case-42-nul-archive-dedup)
+{
+  printf '%s\n' '## Verified facts' '## General rules' '## Open failures' '## Lessons learned'
+  i=1
+  while [ "$i" -le 60 ]; do
+    printf -- '- 2026-06-01 capped lesson %02d (source: distill-audit)\n' "$i"
+    i=$((i + 1))
+  done
+  printf '%s\n' '## Last session'
+} >"$ws/STATE.md"
+write_block "$ws/loop/pending/flush-2026-08-01.md" 2026-08-01 \
+  'A binary archive must still deduplicate the latest eviction.'
+eviction_archive_path="$ws/loop/archive/intake-evictions-$TODAY.md"
+{
+  printf '<!-- intake eviction adapter=x ts=%sT00:00:00Z -->\n' "$TODAY"
+  printf 'stale \0 record\n'
+  printf '<!-- intake eviction adapter=x ts=%sT00:00:01Z -->\n' "$TODAY"
+  printf '%s\n' '- 2026-06-01 capped lesson 01 (source: distill-audit)'
+} >"$eviction_archive_path"
+printf '%s\n' 'scan=prior error=state-publish' >"$ws/loop/pending/intake-runs.log"
+set +e
+run_intake "$ws"
+nul_archive_retry_rc=$?
+tr -d '\0' <"$eviction_archive_path" | cmp -s - "$eviction_archive_path"
+nul_archive_cmp_rc=$?
+set -e
+if [ "$nul_archive_retry_rc" -eq 0 ] \
+  && [ "$(receipt_value "$ws" error)" = none ] \
+  && [ "$(grep -a -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 2 ] \
+  && [ "$(grep -a -Fc 'capped lesson 01' "$eviction_archive_path")" -eq 1 ] \
+  && [ "$nul_archive_cmp_rc" -eq 1 ]; then
+  pass '[42] a NUL byte in the eviction archive does not disable same-day dedup on a refused-publish retry'
+else
+  fail_case '[42] a NUL byte in the eviction archive does not disable same-day dedup on a refused-publish retry' \
+    "rc=$nul_archive_retry_rc nul_cmp_rc=$nul_archive_cmp_rc headers=$(grep -a -c '^<!-- intake eviction adapter=' "$eviction_archive_path") payloads=$(grep -a -Fc 'capped lesson 01' "$eviction_archive_path") receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+fi
+
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"
 [ "$FAIL_COUNT" -eq 0 ]

--- a/tests/flush-intake.test.sh
+++ b/tests/flush-intake.test.sh
@@ -1311,6 +1311,13 @@ eviction_archive_path="$ws/loop/archive/intake-evictions-$TODAY.md"
   printf '<!-- intake eviction adapter=x ts=%sT00:00:01Z -->\n' "$TODAY"
   printf '%s\n' '- 2026-06-01 capped lesson 01 (source: distill-audit)'
 } >"$eviction_archive_path"
+if tr -d '\0' <"$eviction_archive_path" | cmp -s - "$eviction_archive_path"; then
+  nul_seed_ok=0
+elif [ "$?" -eq 1 ]; then
+  nul_seed_ok=1
+else
+  nul_seed_ok=0
+fi
 printf '%s\n' 'scan=prior error=state-publish' >"$ws/loop/pending/intake-runs.log"
 set +e
 run_intake "$ws"
@@ -1318,15 +1325,17 @@ nul_archive_retry_rc=$?
 tr -d '\0' <"$eviction_archive_path" | cmp -s - "$eviction_archive_path"
 nul_archive_cmp_rc=$?
 set -e
-if [ "$nul_archive_retry_rc" -eq 0 ] \
+if [ "$nul_seed_ok" -eq 1 ] \
+  && [ "$nul_archive_retry_rc" -eq 0 ] \
   && [ "$(receipt_value "$ws" error)" = none ] \
   && [ "$(grep -a -c '^<!-- intake eviction adapter=' "$eviction_archive_path")" -eq 2 ] \
   && [ "$(grep -a -Fc 'capped lesson 01' "$eviction_archive_path")" -eq 1 ] \
+  && [ "$(receipt_value "$ws" evicted_by_cap)" -eq 1 ] \
   && [ "$nul_archive_cmp_rc" -eq 1 ]; then
   pass '[42] a NUL byte in the eviction archive does not disable same-day dedup on a refused-publish retry'
 else
   fail_case '[42] a NUL byte in the eviction archive does not disable same-day dedup on a refused-publish retry' \
-    "rc=$nul_archive_retry_rc nul_cmp_rc=$nul_archive_cmp_rc headers=$(grep -a -c '^<!-- intake eviction adapter=' "$eviction_archive_path") payloads=$(grep -a -Fc 'capped lesson 01' "$eviction_archive_path") receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
+    "seed_ok=$nul_seed_ok rc=$nul_archive_retry_rc evicted=$(receipt_value "$ws" evicted_by_cap) nul_cmp_rc=$nul_archive_cmp_rc headers=$(grep -a -c '^<!-- intake eviction adapter=' "$eviction_archive_path") payloads=$(grep -a -Fc 'capped lesson 01' "$eviction_archive_path") receipt=$(tail -n1 "$ws/loop/pending/intake-runs.log")"
 fi
 
 printf 'Summary: %s PASS, %s FAIL\n' "$PASS_COUNT" "$FAIL_COUNT"

--- a/tests/hermes-flush-intake.test.sh
+++ b/tests/hermes-flush-intake.test.sh
@@ -195,7 +195,7 @@ INTAKE_UNDER_TEST="$HERMES_INTAKE" \
 full_suite_rc=$?
 set -e
 if [ "$full_suite_rc" -eq 0 ] \
-  && grep -Fqx 'Summary: 41 PASS, 0 FAIL' "$full_suite_log"; then
+  && grep -Fqx 'Summary: 43 PASS, 0 FAIL' "$full_suite_log"; then
   pass '[10] the full flush-intake behavioural suite passes through the Hermes entry'
 else
   fail_case '[10] the full flush-intake behavioural suite passes through the Hermes entry' \


### PR DESCRIPTION
## Summary

Two coverage gaps deferred from the #222 panel (PR #224) are now pinned in the flush-intake suite:

- **[41]** the eviction-archive append fails (archive path pre-created as a directory): rc=1, receipt `error=eviction-archive`, STATE.md byte-identical, pending flush retained, no `intake-*.md` / archived flush / distill marker, `folded=0`, `marker=untouched`, placeholder directory intact.
- **[42]** an existing archive whose earlier record carries a NUL byte, with a refused-publish receipt: the retry still locates the last header (`grep -a`) and adopts the record — headers stay 2, payload count 1, NUL still present.

`tests/hermes-flush-intake.test.sh` pins the full-suite count 41 → 43. Test-only; no production code touched.

Closes #226

## Declared files

- `tests/flush-intake.test.sh` (cases [41], [42] appended after [40])
- `tests/hermes-flush-intake.test.sh` (pinned count)

## 完了記録 (Completion record)

candidate SHA: 8764f7a (r1 candidate ad8b9f5 + review micro-delta 8764f7a; Opus r2 verdict is cumulative for 8764f7a)
implementer: Codex gpt-6-astra (medium) via `codex exec`, commit by alpha (Claude Code)
reviewer: Opus 5 (Agent code-reviewer) / Kimi K3 (kimi -p) / Gemini 3.8 Flash (agy static) — r1 3/3 GO + Opus MINOR-1/2 adopted as a micro-delta (8764f7a) + Opus r2 delta confirmation GO (record below)
identity check: 別モデル（writer = Codex; seats as listed）
CI: test-lint run 34134844755 green on 8764f7a (test, test-macos, lint SUCCESS; test-macos under the 45-min ceiling); gitleaks (rerun after a transient 504 on the binary download) / history-check / pr-size / repo-state / risk-review-gate SUCCESS
release: N/A②（テスト追加のみ — 挙動・公開 API・配布物のいずれも変えない内部整理）
previous release: v0.26.3 → https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.26.3（履行済み: Release exists, release-sync run 34080576726）

| Done when | 結果 | 証拠 |
|---|---|---|
| A flush-intake case forces the eviction-archive append to fail and asserts rc=1, `error=eviction-archive`, STATE.md byte-unchanged, pending flush retained, no distill marker | PASS | case [41]: `mkdir "$eviction_archive_path"` makes `state_fold_atomic_archive_append` fail; asserts rc=1, `receipt_value error = eviction-archive`, `cmp -s` against a pre-run STATE snapshot, pending file present, no `intake-*.md`, no archived flush, no `loop/.deadman/distill.marker`, folded=0, marker=untouched, dir intact. Negative control (directory removed): intake rc=0 / error=none → case FAIL, suite `0 PASS, 1 FAIL` (2026-09-07) |
| A flush-intake case seeds a NUL byte into an existing archive with a refused-publish receipt and asserts the retry still dedups (adopts, no duplicate) | PASS | case [42]: archive = header + `stale \0 record` + header + exact payload; receipt `error=state-publish`; asserts pre-run nul_seed_ok=1, rc=0, error=none, receipt evicted_by_cap=1 (delta: the eviction really fired), `grep -a -c` headers = 2, payload count = 1, and NUL still present post-run. Negative control (`grep -a` → `grep` in a temp copy of flush-intake.sh): headers 3 / payload 2 → case FAIL (2026-09-07) |
| hermes pinned count updated accordingly | PASS | `Summary: 41 PASS` → `43 PASS` in tests/hermes-flush-intake.test.sh; `bash tests/hermes-flush-intake.test.sh` → 10 PASS, 0 FAIL (2026-09-07) |
| Suites / lint green | PASS | `bash tests/flush-intake.test.sh` → 43/43 (bash 5 and /bin/bash 3.2.57, writer and alpha independently); `make test` → `Suite Summary: 45 PASS, 0 FAIL`; `make lint` → `lint: 91 shell files OK` (2026-09-07) |

git diff --stat origin/main...8764f7a: 2 files changed, 82 insertions(+), 1 deletion(-)

## Review record

Panel: 3 heterogeneous seats, blind in r1 (identical packet), read-only against candidate ad8b9f5. Writer = Codex gpt-6-astra; Alpha (orchestrator) is not a seat. GLM 5.3 (429 until 2026-09-10) and Grok 4.6 (402) absent → Opus 5 / Kimi K3 / Gemini 3.8 Flash (static).

**r1 — candidate ad8b9f5**

| seat | requested → actual | verdict | blocking | F1..F5 | evidence highlights |
|---|---|---|---|---|---|
| Opus 5 (Claude Code Agent code-reviewer) | opus-5 → claude-opus-5[1m] | GO | 0 | PASS ×5 | suites 43/43 under bash 5.3 and /bin/bash 3.2.57 + BSD grep; hermes 10/10; make lint 91; make test 45/45; negative controls A (grep -a → grep: [42] FAIL headers=3 payloads=2), B (no dir placeholder: [41] FAIL rc=0 marker=touched), C (NUL removed: [42] FAIL nul_cmp_rc=0), D (STATE seeded below cap: [42] still PASS → **MINOR-1 vacuity**); MINOR-2 binary-ness guard post-run vs [40]'s pre-run idiom; NIT: seeding block duplicated ×8; NIT: [41] pins the append arm (:542) not the block-build arm (:514) — same receipt value, matches the Issue's target |
| Kimi K3 (CLI `kimi -p`) | kimi-code/k3 → Kimi K3 | GO | 0 | PASS ×5 | suites + hermes + make lint/test; negative proofs via sed/python reverts in /tmp copies; manual loop-init reproduction; NIT: payload count `-Fc 'capped lesson 01'` cannot collide (02-60 never reach the archive); NIT: [41] exercises the append branch only |
| Gemini 3.8 Flash (agy static) | gemini-3.8-flash-high → Gemini 3.8 Flash | GO | 0 | PASS ×5 | 0 findings |

Adjudication r1 (alpha): 3/3 GO, zero blocking. Opus MINOR-1/MINOR-2 adopted as a micro-delta before merge (writer Codex astra, commit 8764f7a): [42] now requires receipt `evicted_by_cap=1` (negative control D flips to FAIL with `evicted=0`) and the NUL fixture is verified pre-run as `nul_seed_ok` (kept post-run too). NITs recorded, not actioned (seeding-helper refactor and a block-build-arm case are out of scope for a coverage pin).

**r2 — Opus 5 delta confirmation (cumulative for 8764f7a)**: GO, 0 blocking, MINOR-1 RESOLVED (control D: PASS at ad8b9f5 → FAIL `evicted=0` at 8764f7a), MINOR-2 RESOLVED (control E: NUL removed → FAIL `seed_ok=0`); the `if pipe; then … elif [ "$?" -eq 1 ]` construction verified in all three arms on /bin/bash 3.2.57 (cmp rc 2 → seed_ok=0), also under an explicit `set -euo pipefail`; suites 43/43 on both shells. 4 LOW informational notes, none requested. Seat files: session scratchpad `seats-226/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
